### PR TITLE
Remove goarch 386 and go-version 1.13 from GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.13.x, 1.14.x ]
-        goarch: [ "amd64", "386" ]
+        go-version: [ 1.14.x ]
+        goarch: [ "amd64" ]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go


### PR DESCRIPTION
Resolve #47 