### PR TITLE
Unify StateDB MT{Create/Update}Account

### DIFF
--- a/db/statedb/statedb_test.go
+++ b/db/statedb/statedb_test.go
@@ -55,7 +55,7 @@ func TestStateDBWithoutMT(t *testing.T) {
 
 	// add test accounts
 	for i := 0; i < len(accounts); i++ {
-		err = sdb.CreateAccount(common.Idx(i), accounts[i])
+		_, err = sdb.CreateAccount(common.Idx(i), accounts[i])
 		assert.Nil(t, err)
 	}
 
@@ -68,25 +68,16 @@ func TestStateDBWithoutMT(t *testing.T) {
 	// try already existing idx and get error
 	_, err = sdb.GetAccount(common.Idx(1)) // check that exist
 	assert.Nil(t, err)
-	err = sdb.CreateAccount(common.Idx(1), accounts[1]) // check that can not be created twice
+	_, err = sdb.CreateAccount(common.Idx(1), accounts[1]) // check that can not be created twice
 	assert.NotNil(t, err)
 	assert.Equal(t, ErrAccountAlreadyExists, err)
 
 	// update accounts
 	for i := 0; i < len(accounts); i++ {
 		accounts[i].Nonce = accounts[i].Nonce + 1
-		err = sdb.UpdateAccount(common.Idx(i), accounts[i])
+		_, err = sdb.UpdateAccount(common.Idx(i), accounts[i])
 		assert.Nil(t, err)
 	}
-
-	// check that can not call MerkleTree methods of the StateDB
-	_, err = sdb.MTCreateAccount(common.Idx(1), accounts[1])
-	assert.NotNil(t, err)
-	assert.Equal(t, ErrStateDBWithoutMT, err)
-
-	_, err = sdb.MTUpdateAccount(common.Idx(1), accounts[1])
-	assert.NotNil(t, err)
-	assert.Equal(t, ErrStateDBWithoutMT, err)
 
 	_, err = sdb.MTGetProof(common.Idx(1))
 	assert.NotNil(t, err)
@@ -113,7 +104,7 @@ func TestStateDBWithMT(t *testing.T) {
 
 	// add test accounts
 	for i := 0; i < len(accounts); i++ {
-		_, err = sdb.MTCreateAccount(common.Idx(i), accounts[i])
+		_, err = sdb.CreateAccount(common.Idx(i), accounts[i])
 		assert.Nil(t, err)
 	}
 
@@ -126,7 +117,7 @@ func TestStateDBWithMT(t *testing.T) {
 	// try already existing idx and get error
 	_, err = sdb.GetAccount(common.Idx(1)) // check that exist
 	assert.Nil(t, err)
-	_, err = sdb.MTCreateAccount(common.Idx(1), accounts[1]) // check that can not be created twice
+	_, err = sdb.CreateAccount(common.Idx(1), accounts[1]) // check that can not be created twice
 	assert.NotNil(t, err)
 	assert.Equal(t, ErrAccountAlreadyExists, err)
 
@@ -136,7 +127,7 @@ func TestStateDBWithMT(t *testing.T) {
 	// update accounts
 	for i := 0; i < len(accounts); i++ {
 		accounts[i].Nonce = accounts[i].Nonce + 1
-		_, err = sdb.MTUpdateAccount(common.Idx(i), accounts[i])
+		_, err = sdb.UpdateAccount(common.Idx(i), accounts[i])
 		assert.Nil(t, err)
 	}
 	a, err := sdb.GetAccount(common.Idx(1)) // check that account value has been updated
@@ -159,7 +150,7 @@ func TestCheckpoints(t *testing.T) {
 
 	// add test accounts
 	for i := 0; i < len(accounts); i++ {
-		_, err = sdb.MTCreateAccount(common.Idx(i), accounts[i])
+		_, err = sdb.CreateAccount(common.Idx(i), accounts[i])
 		assert.Nil(t, err)
 	}
 

--- a/db/statedb/txprocessors.go
+++ b/db/statedb/txprocessors.go
@@ -89,7 +89,7 @@ func (s *StateDB) applyCreateAccount(tx *common.L1Tx) error {
 		EthAddr:   tx.FromEthAddr,
 	}
 
-	err := s.CreateAccount(common.Idx(s.idx+1), account)
+	_, err := s.CreateAccount(common.Idx(s.idx+1), account)
 	if err != nil {
 		return err
 	}
@@ -120,13 +120,13 @@ func (s *StateDB) applyDeposit(tx *common.L1Tx, transfer bool) error {
 		// add amount to the receiver
 		accReceiver.Balance = new(big.Int).Add(accReceiver.Balance, tx.Amount)
 		// update receiver account in localStateDB
-		err = s.UpdateAccount(tx.ToIdx, accReceiver)
+		_, err = s.UpdateAccount(tx.ToIdx, accReceiver)
 		if err != nil {
 			return err
 		}
 	}
 	// update sender account in localStateDB
-	err = s.UpdateAccount(tx.FromIdx, accSender)
+	_, err = s.UpdateAccount(tx.FromIdx, accSender)
 	if err != nil {
 		return err
 	}
@@ -146,18 +146,21 @@ func (s *StateDB) applyTransfer(tx *common.Tx) error {
 		return err
 	}
 
+	// increment nonce
+	accSender.Nonce++
+
 	// substract amount to the sender
 	accSender.Balance = new(big.Int).Sub(accSender.Balance, tx.Amount)
 	// add amount to the receiver
 	accReceiver.Balance = new(big.Int).Add(accReceiver.Balance, tx.Amount)
 
 	// update receiver account in localStateDB
-	err = s.UpdateAccount(tx.ToIdx, accReceiver)
+	_, err = s.UpdateAccount(tx.ToIdx, accReceiver)
 	if err != nil {
 		return err
 	}
 	// update sender account in localStateDB
-	err = s.UpdateAccount(tx.FromIdx, accSender)
+	_, err = s.UpdateAccount(tx.FromIdx, accSender)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously as the txprocessor.go methods were specific for the BatchBuilder,
the MTCreateAccount & CreateAccount and MTUpdateAccount & UpdateAccount were
also designed in the spec to be used by BatchBuilder and TxSelector depending on the
MerkleTree usage calling one kind of method or anotherone.

But now that this methods are being called directly by the StateDB (through the
methods in txprocessors.go), to allow also the methods usage from the
Synchronizer, there can not be the MT and no-MT methods separated, so this
commit unifies MTCreateAccount with CreateAccount, and MTUpdateAccount with
UpdateAccount, which internally will update the MerkleTree depending if the
specific StateDB in usage has the MerkleTree defined or not.