### PR TITLE
Add PoolL2Tx verify signature needed methods

### DIFF
--- a/common/pooll2tx_test.go
+++ b/common/pooll2tx_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/stretchr/testify/assert"
 )
@@ -72,4 +73,50 @@ func TestTxCompressedData(t *testing.T) {
 	assert.Equal(t, "6571340879233176732837827812956721483162819083004853354503", txCompressedData.String())
 	assert.Equal(t, "10c000000000b0000000a0009000000000008000000000007", hex.EncodeToString(txCompressedData.Bytes())[1:])
 
+}
+
+func TestHashToSign(t *testing.T) {
+	var sk babyjub.PrivateKey
+	_, err := hex.Decode(sk[:], []byte("0001020304050607080900010203040506070809000102030405060708090001"))
+	assert.Nil(t, err)
+	ethAddr := ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370")
+
+	tx := PoolL2Tx{
+		FromIdx:     2,
+		ToIdx:       3,
+		Amount:      big.NewInt(4),
+		TokenID:     5,
+		Nonce:       6,
+		ToBJJ:       sk.Public(),
+		RqToEthAddr: ethAddr,
+		RqToBJJ:     sk.Public(),
+	}
+	toSign, err := tx.HashToSign()
+	assert.Nil(t, err)
+	assert.Equal(t, "14526446928649310956370997581245770629723313742905751117262272426489782809503", toSign.String())
+}
+
+func TestVerifyTxSignature(t *testing.T) {
+	var sk babyjub.PrivateKey
+	_, err := hex.Decode(sk[:], []byte("0001020304050607080900010203040506070809000102030405060708090001"))
+	assert.Nil(t, err)
+	ethAddr := ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370")
+
+	tx := PoolL2Tx{
+		FromIdx:     2,
+		ToIdx:       3,
+		Amount:      big.NewInt(4),
+		TokenID:     5,
+		Nonce:       6,
+		ToBJJ:       sk.Public(),
+		RqToEthAddr: ethAddr,
+		RqToBJJ:     sk.Public(),
+	}
+	toSign, err := tx.HashToSign()
+	assert.Nil(t, err)
+	assert.Equal(t, "14526446928649310956370997581245770629723313742905751117262272426489782809503", toSign.String())
+
+	sig := sk.SignPoseidon(toSign)
+	tx.Signature = sig
+	assert.True(t, tx.VerifySignature(sk.Public()))
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,5 +1,11 @@
 package common
 
+import (
+	"math/big"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+)
+
 // SwapEndianness swaps the order of the bytes in the slice.
 func SwapEndianness(b []byte) []byte {
 	o := make([]byte, len(b))
@@ -7,4 +13,9 @@ func SwapEndianness(b []byte) []byte {
 		o[len(b)-1-i] = b[i]
 	}
 	return o
+}
+
+// EthAddrToBigInt returns a *big.Int from a given ethereum common.Address.
+func EthAddrToBigInt(a ethCommon.Address) *big.Int {
+	return new(big.Int).SetBytes(a.Bytes())
 }

--- a/db/l2db/l2db_test.go
+++ b/db/l2db/l2db_test.go
@@ -149,7 +149,7 @@ func genTxs(n int) []*common.PoolL2Tx {
 			Fee:       99,
 			Nonce:     28,
 			State:     state,
-			Signature: *privK.SignPoseidon(big.NewInt(674238462)),
+			Signature: privK.SignPoseidon(big.NewInt(674238462)),
 			Timestamp: time.Now().UTC(),
 		}
 		if i%2 == 0 { // Optional parameters: rq


### PR DESCRIPTION
Implements the hash to be signed from PoolL2Tx, compatible with javascript version.
Implements the signature verification for a given PoolL2Tx.

resolves #65 