### PR TITLE
Add abstraction method of processTxs to StateDB

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
-          $(go env GOPATH)/bin/golangci-lint run
+          $(go env GOPATH)/bin/golangci-lint run --timeout=5m

--- a/batchbuilder/batchbuilder.go
+++ b/batchbuilder/batchbuilder.go
@@ -51,25 +51,7 @@ func (bb *BatchBuilder) Reset(batchNum uint64, fromSynchronizer bool) error {
 }
 
 // BuildBatch takes the transactions and returns the common.ZKInputs of the next batch
-func (bb *BatchBuilder) BuildBatch(configBatch *ConfigBatch, l1usertxs, l1coordinatortxs []*common.L1Tx, l2txs []*common.PoolL2Tx, tokenIDs []common.TokenID) (*common.ZKInputs, error) {
-	for _, tx := range l1usertxs {
-		err := bb.localStateDB.ProcessL1Tx(tx)
-		if err != nil {
-			return nil, err
-		}
-	}
-	for _, tx := range l1coordinatortxs {
-		err := bb.localStateDB.ProcessL1Tx(tx)
-		if err != nil {
-			return nil, err
-		}
-	}
-	for _, tx := range l2txs {
-		err := bb.localStateDB.ProcessPoolL2Tx(tx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return nil, nil
+func (bb *BatchBuilder) BuildBatch(configBatch *ConfigBatch, l1usertxs, l1coordinatortxs []*common.L1Tx, l2txs []*common.L2Tx, tokenIDs []common.TokenID) (*common.ZKInputs, error) {
+	zkInputs, _, err := bb.localStateDB.ProcessTxs(l1usertxs, l1coordinatortxs, l2txs)
+	return zkInputs, err
 }

--- a/common/account_test.go
+++ b/common/account_test.go
@@ -23,7 +23,7 @@ func TestAccount(t *testing.T) {
 
 	account := &Account{
 		TokenID:   TokenID(1),
-		Nonce:     uint64(1234),
+		Nonce:     Nonce(1234),
 		Balance:   big.NewInt(1000),
 		PublicKey: pk,
 		EthAddr:   ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),
@@ -66,7 +66,7 @@ func TestAccountLoop(t *testing.T) {
 
 		account := &Account{
 			TokenID:   TokenID(i),
-			Nonce:     uint64(i),
+			Nonce:     Nonce(i),
 			Balance:   big.NewInt(1000),
 			PublicKey: pk,
 			EthAddr:   address,
@@ -98,7 +98,7 @@ func TestAccountHashValue(t *testing.T) {
 
 	account := &Account{
 		TokenID:   TokenID(1),
-		Nonce:     uint64(1234),
+		Nonce:     Nonce(1234),
 		Balance:   big.NewInt(1000),
 		PublicKey: pk,
 		EthAddr:   ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),
@@ -142,7 +142,7 @@ func TestAccountErrNumOverflowNonce(t *testing.T) {
 	// check limit
 	account := &Account{
 		TokenID:   TokenID(1),
-		Nonce:     uint64(math.Pow(2, 40) - 1),
+		Nonce:     Nonce(math.Pow(2, 40) - 1),
 		Balance:   big.NewInt(1000),
 		PublicKey: pk,
 		EthAddr:   ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),
@@ -151,7 +151,7 @@ func TestAccountErrNumOverflowNonce(t *testing.T) {
 	assert.Nil(t, err)
 
 	// force value overflow
-	account.Nonce = uint64(math.Pow(2, 40))
+	account.Nonce = Nonce(math.Pow(2, 40))
 	b, err := account.Bytes()
 	assert.NotNil(t, err)
 	assert.Equal(t, fmt.Errorf("%s Nonce", ErrNumOverflow), err)
@@ -169,7 +169,7 @@ func TestAccountErrNumOverflowBalance(t *testing.T) {
 	// check limit
 	account := &Account{
 		TokenID:   TokenID(1),
-		Nonce:     uint64(math.Pow(2, 40) - 1),
+		Nonce:     Nonce(math.Pow(2, 40) - 1),
 		Balance:   new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(192), nil), big.NewInt(1)),
 		PublicKey: pk,
 		EthAddr:   ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),

--- a/common/batch.go
+++ b/common/batch.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"encoding/binary"
+	"fmt"
 	"math/big"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -26,3 +28,19 @@ type Batch struct {
 
 // BatchNum identifies a batch
 type BatchNum uint32
+
+// Bytes returns a byte array of length 4 representing the BatchNum
+func (bn BatchNum) Bytes() []byte {
+	var batchNumBytes [4]byte
+	binary.LittleEndian.PutUint32(batchNumBytes[:], uint32(bn))
+	return batchNumBytes[:]
+}
+
+// BatchNumFromBytes returns BatchNum from a []byte
+func BatchNumFromBytes(b []byte) (BatchNum, error) {
+	if len(b) != 4 {
+		return 0, fmt.Errorf("can not parse BatchNumFromBytes, bytes len %d, expected 4", len(b))
+	}
+	batchNum := binary.LittleEndian.Uint32(b[:4])
+	return BatchNum(batchNum), nil
+}

--- a/common/l1tx.go
+++ b/common/l1tx.go
@@ -31,7 +31,6 @@ func (tx *L1Tx) Tx() *Tx {
 		TxID:    tx.TxID,
 		FromIdx: tx.FromIdx,
 		ToIdx:   tx.ToIdx,
-		TokenID: tx.TokenID,
 		Amount:  tx.Amount,
 		Nonce:   0,
 		Fee:     0,

--- a/common/l2tx.go
+++ b/common/l2tx.go
@@ -18,3 +18,15 @@ type L2Tx struct {
 	// Extra metadata, may be uninitialized
 	Type TxType `meddler:"-"` // optional, descrives which kind of tx it's
 }
+
+func (tx *L2Tx) Tx() *Tx {
+	return &Tx{
+		TxID:    tx.TxID,
+		FromIdx: tx.FromIdx,
+		ToIdx:   tx.ToIdx,
+		Amount:  tx.Amount,
+		Nonce:   tx.Nonce,
+		Fee:     tx.Fee,
+		Type:    tx.Type,
+	}
+}

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -27,11 +27,12 @@ func (n Nonce) Bytes() ([5]byte, error) {
 	return b, nil
 }
 
-func NonceFromBytes(b [5]byte) (Nonce, error) {
+// NonceFromBytes returns Nonce from a [5]byte
+func NonceFromBytes(b [5]byte) Nonce {
 	var nonceBytes [8]byte
 	copy(nonceBytes[:], b[:5])
 	nonce := binary.LittleEndian.Uint64(nonceBytes[:])
-	return Nonce(nonce), nil
+	return Nonce(nonce)
 }
 
 // PoolL2Tx is a struct that represents a L2Tx sent by an account to the coordinator hat is waiting to be forged
@@ -171,17 +172,37 @@ func (tx *PoolL2Tx) VerifySignature(pk *babyjub.PublicKey) bool {
 	return pk.VerifyPoseidon(h, tx.Signature)
 }
 
+func (tx *PoolL2Tx) L2Tx() *L2Tx {
+	return &L2Tx{
+		TxID:     tx.TxID,
+		BatchNum: tx.BatchNum,
+		FromIdx:  tx.FromIdx,
+		ToIdx:    tx.ToIdx,
+		Amount:   tx.Amount,
+		Fee:      tx.Fee,
+		Nonce:    tx.Nonce,
+		Type:     tx.Type,
+	}
+}
+
 func (tx *PoolL2Tx) Tx() *Tx {
 	return &Tx{
 		TxID:    tx.TxID,
 		FromIdx: tx.FromIdx,
 		ToIdx:   tx.ToIdx,
-		TokenID: tx.TokenID,
 		Amount:  tx.Amount,
 		Nonce:   tx.Nonce,
 		Fee:     tx.Fee,
 		Type:    tx.Type,
 	}
+}
+
+func PoolL2TxsToL2Txs(txs []*PoolL2Tx) []*L2Tx {
+	var r []*L2Tx
+	for _, tx := range txs {
+		r = append(r, tx.L2Tx())
+	}
+	return r
 }
 
 // PoolL2TxState is a struct that represents the status of a L2 transaction

--- a/common/pooll2tx_test.go
+++ b/common/pooll2tx_test.go
@@ -16,8 +16,7 @@ func TestNonceParser(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(nBytes))
 	assert.Equal(t, "0100000000", hex.EncodeToString(nBytes[:]))
-	n2, err := NonceFromBytes(nBytes)
-	assert.Nil(t, err)
+	n2 := NonceFromBytes(nBytes)
 	assert.Equal(t, n, n2)
 
 	// value before overflow
@@ -26,8 +25,7 @@ func TestNonceParser(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(nBytes))
 	assert.Equal(t, "ffffffffff", hex.EncodeToString(nBytes[:]))
-	n2, err = NonceFromBytes(nBytes)
-	assert.Nil(t, err)
+	n2 = NonceFromBytes(nBytes)
 	assert.Equal(t, n, n2)
 
 	// expect value overflow
@@ -35,8 +33,6 @@ func TestNonceParser(t *testing.T) {
 	nBytes, err = n.Bytes()
 	assert.NotNil(t, err)
 	assert.Equal(t, ErrNonceOverflow, err)
-	_, err = NonceFromBytes(nBytes)
-	assert.Nil(t, err)
 }
 
 func TestTxCompressedData(t *testing.T) {

--- a/common/tx.go
+++ b/common/tx.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/big"
 )
 
@@ -18,6 +19,15 @@ func (idx Idx) Bytes() []byte {
 // BigInt returns a *big.Int representing the Idx
 func (idx Idx) BigInt() *big.Int {
 	return big.NewInt(int64(idx))
+}
+
+// IdxFromBytes returns Idx from a byte array
+func IdxFromBytes(b []byte) (Idx, error) {
+	if len(b) != 4 {
+		return 0, fmt.Errorf("can not parse Idx, bytes len %d, expected 4", len(b))
+	}
+	idx := binary.LittleEndian.Uint32(b[:4])
+	return Idx(idx), nil
 }
 
 // IdxFromBigInt converts a *big.Int to Idx type
@@ -64,7 +74,6 @@ type Tx struct {
 	TxID     TxID
 	FromIdx  Idx // FromIdx is used by L1Tx/Deposit to indicate the Idx receiver of the L1Tx.LoadAmount (deposit)
 	ToIdx    Idx // ToIdx is ignored in L1Tx/Deposit, but used in the L1Tx/DepositTransfer
-	TokenID  TokenID
 	Amount   *big.Int
 	Nonce    Nonce // effective 40 bits used
 	Fee      FeeSelector

--- a/common/zk.go
+++ b/common/zk.go
@@ -58,3 +58,7 @@ type ZKInputs struct {
 type CallDataForge struct {
 	// TBD
 }
+
+type ExitTreeLeaf struct {
+	// TBD
+}

--- a/db/statedb/statedb_test.go
+++ b/db/statedb/statedb_test.go
@@ -27,7 +27,7 @@ func newAccount(t *testing.T, i int) *common.Account {
 
 	return &common.Account{
 		TokenID:   common.TokenID(i),
-		Nonce:     uint64(i),
+		Nonce:     common.Nonce(i),
 		Balance:   big.NewInt(1000),
 		PublicKey: pk,
 		EthAddr:   address,
@@ -159,7 +159,7 @@ func TestCheckpoints(t *testing.T) {
 	assert.Nil(t, err)
 	cb, err := sdb.GetCurrentBatch()
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(1), cb)
+	assert.Equal(t, common.BatchNum(1), cb)
 
 	for i := 1; i < 10; i++ {
 		err = sdb.MakeCheckpoint()
@@ -167,7 +167,7 @@ func TestCheckpoints(t *testing.T) {
 
 		cb, err = sdb.GetCurrentBatch()
 		assert.Nil(t, err)
-		assert.Equal(t, uint64(i+1), cb)
+		assert.Equal(t, common.BatchNum(i+1), cb)
 	}
 
 	// printCheckpoints(t, sdb.path)
@@ -184,14 +184,14 @@ func TestCheckpoints(t *testing.T) {
 	// check that currentBatch is as expected after Reset
 	cb, err = sdb.GetCurrentBatch()
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(3), cb)
+	assert.Equal(t, common.BatchNum(3), cb)
 
 	// advance one checkpoint and check that currentBatch is fine
 	err = sdb.MakeCheckpoint()
 	assert.Nil(t, err)
 	cb, err = sdb.GetCurrentBatch()
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(4), cb)
+	assert.Equal(t, common.BatchNum(4), cb)
 
 	err = sdb.DeleteCheckpoint(uint64(9))
 	assert.Nil(t, err)
@@ -214,13 +214,13 @@ func TestCheckpoints(t *testing.T) {
 	// check that currentBatch is 4 after the Reset
 	cb, err = ldb.GetCurrentBatch()
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(4), cb)
+	assert.Equal(t, common.BatchNum(4), cb)
 	// advance one checkpoint in ldb
 	err = ldb.MakeCheckpoint()
 	assert.Nil(t, err)
 	cb, err = ldb.GetCurrentBatch()
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(5), cb)
+	assert.Equal(t, common.BatchNum(5), cb)
 
 	// Create a 2nd LocalStateDB from the initial StateDB
 	dirLocal2, err := ioutil.TempDir("", "ldb2")
@@ -234,13 +234,13 @@ func TestCheckpoints(t *testing.T) {
 	// check that currentBatch is 4 after the Reset
 	cb, err = ldb2.GetCurrentBatch()
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(4), cb)
+	assert.Equal(t, common.BatchNum(4), cb)
 	// advance one checkpoint in ldb2
 	err = ldb2.MakeCheckpoint()
 	assert.Nil(t, err)
 	cb, err = ldb2.GetCurrentBatch()
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(5), cb)
+	assert.Equal(t, common.BatchNum(5), cb)
 
 	debug := false
 	if debug {


### PR DESCRIPTION
- Update GHA `lint.yml` increasing timeout time to avoid GHA Lint errors
- Update `common.BatchNum` & `common.Idx` & `common.Nonce` usage in `StateDB`
- Add abstraction method of processTxs to `StateDB`
    - Which will be used by `Synchronizer` & `BatchBuilder`

resolves #70 