### PR TITLE
TxSelector GetL2TxSelection & GetL1L2TxSelection integrated with dbs

### DIFF
--- a/common/account.go
+++ b/common/account.go
@@ -19,7 +19,49 @@ const (
 	maxNonceValue = 0xffffffffff
 	// maxBalanceBytes is the maximum bytes that can use the Account.Balance *big.Int
 	maxBalanceBytes = 24
+
+	idxBytesLen = 4
+	// maxIdxValue is the maximum value that Idx can have (32 bits: maxIdxValue=2**32-1)
+	maxIdxValue = 0xffffffff
+
+	// userThreshold determines the threshold from the User Idxs can be
+	userThreshold = 256
+	// IdxUserThreshold is a Idx type value that determines the threshold
+	// from the User Idxs can be
+	IdxUserThreshold = Idx(userThreshold)
 )
+
+// Idx represents the account Index in the MerkleTree
+type Idx uint32
+
+// Bytes returns a byte array representing the Idx
+func (idx Idx) Bytes() []byte {
+	var b [4]byte
+	binary.LittleEndian.PutUint32(b[:], uint32(idx))
+	return b[:]
+}
+
+// BigInt returns a *big.Int representing the Idx
+func (idx Idx) BigInt() *big.Int {
+	return big.NewInt(int64(idx))
+}
+
+// IdxFromBytes returns Idx from a byte array
+func IdxFromBytes(b []byte) (Idx, error) {
+	if len(b) != idxBytesLen {
+		return 0, fmt.Errorf("can not parse Idx, bytes len %d, expected 4", len(b))
+	}
+	idx := binary.LittleEndian.Uint32(b[:4])
+	return Idx(idx), nil
+}
+
+// IdxFromBigInt converts a *big.Int to Idx type
+func IdxFromBigInt(b *big.Int) (Idx, error) {
+	if b.Int64() > maxIdxValue {
+		return 0, ErrNumOverflow
+	}
+	return Idx(uint32(b.Int64())), nil
+}
 
 // Account is a struct that gives information of the holdings of an address and a specific token. Is the data structure that generates the Value stored in the leaf of the MerkleTree
 type Account struct {

--- a/common/accountcreationauths.go
+++ b/common/accountcreationauths.go
@@ -11,6 +11,6 @@ import (
 type AccountCreationAuth struct {
 	Timestamp time.Time
 	EthAddr   ethCommon.Address
-	BJJ       babyjub.PublicKey
+	BJJ       *babyjub.PublicKey
 	Signature []byte
 }

--- a/common/tx.go
+++ b/common/tx.go
@@ -1,48 +1,8 @@
 package common
 
 import (
-	"encoding/binary"
-	"fmt"
 	"math/big"
 )
-
-const (
-	idxBytesLen = 4
-	// maxIdxValue is the maximum value that Idx can have (32 bits: maxIdxValue=2**32-1)
-	maxIdxValue = 0xffffffff
-)
-
-// Idx represents the account Index in the MerkleTree
-type Idx uint32
-
-// Bytes returns a byte array representing the Idx
-func (idx Idx) Bytes() []byte {
-	var b [4]byte
-	binary.LittleEndian.PutUint32(b[:], uint32(idx))
-	return b[:]
-}
-
-// BigInt returns a *big.Int representing the Idx
-func (idx Idx) BigInt() *big.Int {
-	return big.NewInt(int64(idx))
-}
-
-// IdxFromBytes returns Idx from a byte array
-func IdxFromBytes(b []byte) (Idx, error) {
-	if len(b) != idxBytesLen {
-		return 0, fmt.Errorf("can not parse Idx, bytes len %d, expected 4", len(b))
-	}
-	idx := binary.LittleEndian.Uint32(b[:4])
-	return Idx(idx), nil
-}
-
-// IdxFromBigInt converts a *big.Int to Idx type
-func IdxFromBigInt(b *big.Int) (Idx, error) {
-	if b.Int64() > maxIdxValue {
-		return 0, ErrNumOverflow
-	}
-	return Idx(uint32(b.Int64())), nil
-}
 
 // TxID is the identifier of a Hermez network transaction
 type TxID Hash // Hash is a guess

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -65,6 +65,12 @@ func NewL2DB(
 	}, nil
 }
 
+// DB returns a pointer to the L2DB.db. This method should be used only for
+// internal testing purposes.
+func (l2db *L2DB) DB() *sqlx.DB {
+	return l2db.db
+}
+
 // AddTx inserts a tx into the L2DB
 func (l2db *L2DB) AddTx(tx *common.PoolL2Tx) error {
 	return meddler.Insert(l2db.db, "tx_pool", tx)

--- a/db/statedb/utils.go
+++ b/db/statedb/utils.go
@@ -9,13 +9,27 @@ import (
 	"github.com/iden3/go-merkletree"
 )
 
-// TODO
-func (s *StateDB) getIdxByEthAddr(addr ethCommon.Address) common.Idx {
+// GetIdxByEthAddr returns the smallest Idx in the StateDB for the given
+// Ethereum Address. Will return 0 in case that Idx is not found in the
+// StateDB.
+func (s *StateDB) GetIdxByEthAddr(addr ethCommon.Address) common.Idx {
+	// TODO
 	return common.Idx(0)
 }
 
-// TODO
-func (s *StateDB) getIdxByBJJ(pk *babyjub.PublicKey) common.Idx {
+// GetIdxByBJJ returns the smallest Idx in the StateDB for the given BabyJubJub
+// PublicKey. Will return 0 in case that Idx is not found in the StateDB.
+func (s *StateDB) GetIdxByBJJ(pk *babyjub.PublicKey) common.Idx {
+	// TODO
+	return common.Idx(0)
+}
+
+// GetIdxByEthAddrBJJ returns the smallest Idx in the StateDB for the given
+// Ethereum Address AND the given BabyJubJub PublicKey. If `addr` is the zero
+// address, it's ignored in the query.  If `pk` is nil, it's ignored in the
+// query.  Will return 0 in case that Idx is not found in the StateDB.
+func (s *StateDB) GetIdxByEthAddrBJJ(addr ethCommon.Address, pk *babyjub.PublicKey) common.Idx {
+	// TODO
 	return common.Idx(0)
 }
 

--- a/test/l2db.go
+++ b/test/l2db.go
@@ -1,0 +1,13 @@
+package test
+
+import "github.com/jmoiron/sqlx"
+
+// CleanL2DB deletes 'tx_pool' and 'account_creation_auth' from the given DB
+func CleanL2DB(db *sqlx.DB) {
+	if _, err := db.Exec("DELETE FROM tx_pool"); err != nil {
+		panic(err)
+	}
+	if _, err := db.Exec("DELETE FROM account_creation_auth"); err != nil {
+		panic(err)
+	}
+}

--- a/test/txs.go
+++ b/test/txs.go
@@ -63,7 +63,7 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]*common.L1Tx,
 	var coordinatorL1Txs [][]*common.L1Tx
 	var poolL2Txs [][]*common.PoolL2Tx
 	idx := 1
-	for _, inst := range instructions.Instructions {
+	for i, inst := range instructions.Instructions {
 		switch inst.Type {
 		case common.TxTypeCreateAccountDeposit:
 			tx := common.L1Tx{
@@ -98,7 +98,7 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]*common.L1Tx,
 			}
 
 			tx := common.PoolL2Tx{
-				// TxID: nil,
+				TxID:        common.TxID([]byte{byte(i)}), // TODO this is for the moment, once TxID Hash is implemented use it
 				FromIdx:     accounts[idxTokenIDToString(inst.From, inst.TokenID)].Idx,
 				ToIdx:       accounts[idxTokenIDToString(inst.To, inst.TokenID)].Idx,
 				ToEthAddr:   accounts[idxTokenIDToString(inst.To, inst.TokenID)].Addr,
@@ -109,7 +109,7 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]*common.L1Tx,
 				Nonce:       accounts[idxTokenIDToString(inst.From, inst.TokenID)].Nonce,
 				State:       common.PoolL2TxStatePending,
 				Timestamp:   time.Now(),
-				BatchNum:    0,
+				BatchNum:    common.BatchNum(0),
 				RqToEthAddr: accounts[idxTokenIDToString(inst.To, inst.TokenID)].Addr,
 				RqToBJJ:     accounts[idxTokenIDToString(inst.To, inst.TokenID)].BJJ.Public(),
 				Type:        common.TxTypeTransfer,

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -1,29 +1,58 @@
 package txselector
 
 import (
-	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/db/statedb"
+	"github.com/hermeznetwork/hermez-node/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetL2TxSelection(t *testing.T) {
+func initTest(t *testing.T, testSet string) *TxSelector {
+	pass := os.Getenv("POSTGRES_PASS")
+	l2DB, err := l2db.NewL2DB(5432, "localhost", "hermez", pass, "l2", 10, 512, 24*time.Hour)
+	require.Nil(t, err)
+
 	dir, err := ioutil.TempDir("", "tmpdb")
 	require.Nil(t, err)
 	sdb, err := statedb.NewStateDB(dir, false, 0)
-	assert.Nil(t, err)
-	testL2DB := &l2db.L2DB{}
-	// initTestDB(testL2DB, sdb)
+	require.Nil(t, err)
 
 	txselDir, err := ioutil.TempDir("", "tmpTxSelDB")
 	require.Nil(t, err)
-	txsel, err := NewTxSelector(txselDir, sdb, testL2DB, 3, 3, 3)
+	txsel, err := NewTxSelector(txselDir, sdb, l2DB, 100, 100, 1000)
+	require.Nil(t, err)
+
+	return txsel
+}
+func addL2Txs(t *testing.T, txsel *TxSelector, poolL2Txs []*common.PoolL2Tx) {
+	for i := 0; i < len(poolL2Txs); i++ {
+		err := txsel.l2db.AddTx(poolL2Txs[i])
+		require.Nil(t, err)
+	}
+}
+
+func TestGetL2TxSelection(t *testing.T) {
+	txsel := initTest(t, test.SetTest0)
+	test.CleanL2DB(txsel.l2db.DB())
+
+	// generate test transactions
+	l1Txs, _, poolL2Txs := test.GenerateTestTxsFromSet(t, test.SetTest0)
+
+	// add the first batch of transactions to the TxSelector
+	addL2Txs(t, txsel, poolL2Txs[0])
+
+	_, err := txsel.GetL2TxSelection(0)
 	assert.Nil(t, err)
-	fmt.Println(txsel)
+
+	_, _, _, err = txsel.GetL1L2TxSelection(0, l1Txs[0])
+	assert.Nil(t, err)
 
 	// txs, err := txsel.GetL2TxSelection(0)
 	// assert.Nil(t, err)


### PR DESCRIPTION
- GetL2TxSelection & GetL1L2TxSelection integrated with dbs
- Create L1CoordinatorTx of type `CreateAccountDeposit` when a L2 requires it (and the `AccountCreationAuth` exists)

resolves #51 
resolves #86 