### PR TITLE
Helper methods for Synchronizer and TX refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,4 @@ jobs:
         POSTGRES_PASS: ${{ secrets.POSTGRES_PASS }}
         ETHCLIENT_DIAL_URL: ${{ secrets.ETHCLIENT_DIAL_URL }}
         GOARCH: ${{ matrix.goarch }}
-      run: go test ./... -v
+      run: go test -p 1 ./...

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ POSTGRES_PASS=yourpasswordhere; sudo docker run --rm --name hermez-db-test -p 54
 - Then, run the tests with the password as env var
 
 ```
-POSTGRES_PASS=yourpasswordhere ETHCLIENT_DIAL_URL=yourethereumurlhere go test ./...
+POSTGRES_PASS=yourpasswordhere ETHCLIENT_DIAL_URL=yourethereumurlhere go test -p 1 ./...
 ```
+
+NOTE: `-p 1` forces execution of package test in serial.  Otherwise they may be
+executed in paralel and the test may find unexpected entries in the SQL
+databse because it's shared among all tests.
 
 ## Lint
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -82,6 +82,11 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
+	// Reset DB
+	err = hdb.Reorg(-1)
+	if err != nil {
+		panic(err)
+	}
 	dir, err := ioutil.TempDir("", "tmpdb")
 	if err != nil {
 		panic(err)
@@ -94,6 +99,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
+	test.CleanL2DB(l2db.DB())
 	// Init API
 	api := gin.Default()
 	if err := SetAPIEndpoints(

--- a/common/batch.go
+++ b/common/batch.go
@@ -8,7 +8,7 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
-const batchNumBytesLen = 4
+const batchNumBytesLen = 8
 
 // Batch is a struct that represents Hermez network batch
 type Batch struct {
@@ -24,20 +24,20 @@ type Batch struct {
 }
 
 // BatchNum identifies a batch
-type BatchNum uint32
+type BatchNum int64
 
 // Bytes returns a byte array of length 4 representing the BatchNum
 func (bn BatchNum) Bytes() []byte {
-	var batchNumBytes [4]byte
-	binary.LittleEndian.PutUint32(batchNumBytes[:], uint32(bn))
+	var batchNumBytes [batchNumBytesLen]byte
+	binary.BigEndian.PutUint64(batchNumBytes[:], uint64(bn))
 	return batchNumBytes[:]
 }
 
 // BatchNumFromBytes returns BatchNum from a []byte
 func BatchNumFromBytes(b []byte) (BatchNum, error) {
 	if len(b) != batchNumBytesLen {
-		return 0, fmt.Errorf("can not parse BatchNumFromBytes, bytes len %d, expected 4", len(b))
+		return 0, fmt.Errorf("can not parse BatchNumFromBytes, bytes len %d, expected %d", len(b), batchNumBytesLen)
 	}
-	batchNum := binary.LittleEndian.Uint32(b[:4])
+	batchNum := binary.BigEndian.Uint64(b[:batchNumBytesLen])
 	return BatchNum(batchNum), nil
 }

--- a/common/coordinator.go
+++ b/common/coordinator.go
@@ -7,8 +7,8 @@ import (
 // Coordinator represents a Hermez network coordinator who wins an auction for an specific slot
 // WARNING: this is strongly based on the previous implementation, once the new spec is done, this may change a lot.
 type Coordinator struct {
-	EthBlockNum int64             // block in which the coordinator was registered
-	Forger      ethCommon.Address // address of the forger
-	Withdraw    ethCommon.Address // address of the withdraw
-	URL         string            // URL of the coordinators API
+	Forger       ethCommon.Address `meddler:"forger_addr"`   // address of the forger
+	EthBlockNum  int64             `meddler:"eth_block_num"` // block in which the coordinator was registered
+	WithdrawAddr ethCommon.Address `meddler:"withdraw_addr"` // address of the withdraw
+	URL          string            `meddler:"url"`           // URL of the coordinators API
 }

--- a/common/exittree.go
+++ b/common/exittree.go
@@ -8,8 +8,19 @@ import (
 
 // ExitInfo represents the ExitTree Leaf data
 type ExitInfo struct {
-	AccountIdx  Idx
-	MerkleProof *merkletree.CircomVerifierProof
-	Balance     *big.Int
-	Nullifier   *big.Int
+	BatchNum    BatchNum                        `meddler:"batch_num"`
+	AccountIdx  Idx                             `meddler:"account_idx"`
+	MerkleProof *merkletree.CircomVerifierProof `meddler:"merkle_proof,json"`
+	Balance     *big.Int                        `meddler:"balance,bigint"`
+	// InstantWithdrawn is the ethBlockNum in which the exit is withdrawn
+	// instantly.  nil means this hasn't happened.
+	InstantWithdrawn *int64 `meddler:"instant_withdrawn"`
+	// DelayedWithdrawRequest is the ethBlockNum in which the exit is
+	// requested to be withdrawn from the delayedWithdrawn smart contract.
+	// nil means this hasn't happened.
+	DelayedWithdrawRequest *int64 `meddler:"delayed_withdraw_request"`
+	// DelayedWithdrawn is the ethBlockNum in which the exit is withdrawn
+	// from the delayedWithdrawn smart contract.  nil means this hasn't
+	// happened.
+	DelayedWithdrawn *int64 `meddler:"delayed_withdrawn"`
 }

--- a/common/tx.go
+++ b/common/tx.go
@@ -66,3 +66,24 @@ type Tx struct {
 	FeeUSD float64     `meddler:"fee_usd,zeroisnull"`
 	Nonce  Nonce       `meddler:"nonce,zeroisnull"`
 }
+
+// L1Tx returns a *L1Tx from the Tx
+func (tx *Tx) L1Tx() *L1Tx {
+	l1Tx := &L1Tx{
+		TxID:            tx.TxID,
+		ToForgeL1TxsNum: tx.ToForgeL1TxsNum,
+		Position:        tx.Position,
+		UserOrigin:      tx.UserOrigin,
+		FromIdx:         tx.FromIdx,
+		FromEthAddr:     tx.FromEthAddr,
+		FromBJJ:         tx.FromBJJ,
+		ToIdx:           tx.ToIdx,
+		TokenID:         tx.TokenID,
+		Amount:          tx.Amount,
+		LoadAmount:      tx.LoadAmount,
+		EthBlockNum:     tx.EthBlockNum,
+		Type:            tx.Type,
+		BatchNum:        tx.BatchNum,
+	}
+	return l1Tx
+}

--- a/db/historydb/migrations/001_init.sql
+++ b/db/historydb/migrations/001_init.sql
@@ -27,11 +27,12 @@ CREATE TABLE batch (
 
 CREATE TABLE exit_tree (
     batch_num BIGINT REFERENCES batch (batch_num) ON DELETE CASCADE,
-    withdrawn BIGINT REFERENCES batch (batch_num) ON DELETE SET NULL,
     account_idx BIGINT,
     merkle_proof BYTEA NOT NULL,
-    balance NUMERIC NOT NULL,
-    nullifier BYTEA NOT NULL,
+    balance BYTEA NOT NULL,
+    instant_withdrawn BIGINT REFERENCES batch (batch_num) ON DELETE SET NULL,
+    delayed_withdraw_request BIGINT REFERENCES batch (batch_num) ON DELETE SET NULL,
+    delayed_withdrawn BIGINT REFERENCES batch (batch_num) ON DELETE SET NULL,
     PRIMARY KEY (batch_num, account_idx)
 );
 

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -173,7 +173,7 @@ func (l2db *L2DB) InvalidateTxs(txIDs []common.TxID, batchNum common.BatchNum) e
 
 // CheckNonces invalidate txs with nonces that are smaller or equal than their respective accounts nonces.
 // The state of the affected txs will be changed from Pending -> Invalid
-func (l2db *L2DB) CheckNonces(updatedAccounts []common.Account, batchNum common.BatchNum) error {
+func (l2db *L2DB) CheckNonces(updatedAccounts []common.Account, batchNum common.BatchNum) (err error) {
 	txn, err := l2db.db.Begin()
 	if err != nil {
 		return err
@@ -203,7 +203,7 @@ func (l2db *L2DB) CheckNonces(updatedAccounts []common.Account, batchNum common.
 }
 
 // UpdateTxValue updates the absolute fee and value of txs given a token list that include their price in USD
-func (l2db *L2DB) UpdateTxValue(tokens []common.Token) error {
+func (l2db *L2DB) UpdateTxValue(tokens []common.Token) (err error) {
 	// WARNING: this is very slow and should be optimized
 	txn, err := l2db.db.Begin()
 	if err != nil {
@@ -252,7 +252,7 @@ func (l2db *L2DB) Reorg(lastValidBatch common.BatchNum) error {
 
 // Purge deletes transactions that have been forged or marked as invalid for longer than the safety period
 // it also deletes txs that has been in the L2DB for longer than the ttl if maxTxs has been exceeded
-func (l2db *L2DB) Purge(currentBatchNum common.BatchNum) error {
+func (l2db *L2DB) Purge(currentBatchNum common.BatchNum) (err error) {
 	txn, err := l2db.db.Begin()
 	if err != nil {
 		return err

--- a/db/statedb/txprocessors.go
+++ b/db/statedb/txprocessors.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/iden3/go-iden3-crypto/babyjub"
-	"github.com/iden3/go-iden3-crypto/poseidon"
 	"github.com/iden3/go-merkletree"
 	"github.com/iden3/go-merkletree/db"
 	"github.com/iden3/go-merkletree/db/memory"
@@ -142,24 +141,10 @@ func (s *StateDB) ProcessTxs(cmpExitTree, cmpZKInputs bool, l1usertxs, l1coordin
 		if err != nil {
 			return nil, nil, err
 		}
-		// 1. compute nullifier
-		exitAccStateValue, err := exitAccount.HashValue()
-		if err != nil {
-			return nil, nil, err
-		}
-		nullifier, err := poseidon.Hash([]*big.Int{
-			exitAccStateValue,
-			big.NewInt(int64(s.currentBatch)),
-			exitTree.Root().BigInt(),
-		})
-		if err != nil {
-			return nil, nil, err
-		}
-		// 2. generate common.ExitInfo
+		// 1. generate common.ExitInfo
 		ei := &common.ExitInfo{
 			AccountIdx:  exitIdx,
 			MerkleProof: p,
-			Nullifier:   nullifier,
 			Balance:     exitAccount.Balance,
 		}
 		exitInfos = append(exitInfos, ei)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -501,9 +501,9 @@ func (s *Synchronizer) auctionSync(blockNum int64) (*auctionData, error) {
 	// Get Coordinators
 	for _, eNewCoordinator := range auctionEvents.NewCoordinator {
 		coordinator := &common.Coordinator{
-			Forger:   eNewCoordinator.ForgerAddress,
-			Withdraw: eNewCoordinator.WithdrawalAddress,
-			URL:      eNewCoordinator.URL,
+			Forger:       eNewCoordinator.ForgerAddress,
+			WithdrawAddr: eNewCoordinator.WithdrawalAddress,
+			URL:          eNewCoordinator.URL,
 		}
 		auctionData.coordinators = append(auctionData.coordinators, coordinator)
 	}
@@ -525,9 +525,9 @@ func (s *Synchronizer) auctionSync(blockNum int64) (*auctionData, error) {
 	// Get Coordinators from updates
 	for _, eCoordinatorUpdated := range auctionEvents.CoordinatorUpdated {
 		coordinator := &common.Coordinator{
-			Forger:   eCoordinatorUpdated.ForgerAddress,
-			Withdraw: eCoordinatorUpdated.WithdrawalAddress,
-			URL:      eCoordinatorUpdated.URL,
+			Forger:       eCoordinatorUpdated.ForgerAddress,
+			WithdrawAddr: eCoordinatorUpdated.WithdrawalAddress,
+			URL:          eCoordinatorUpdated.URL,
 		}
 		auctionData.coordinators = append(auctionData.coordinators, coordinator)
 	}

--- a/test/l2db.go
+++ b/test/l2db.go
@@ -13,10 +13,10 @@ import (
 
 // CleanL2DB deletes 'tx_pool' and 'account_creation_auth' from the given DB
 func CleanL2DB(db *sqlx.DB) {
-	if _, err := db.Exec("DELETE FROM tx_pool"); err != nil {
+	if _, err := db.Exec("DELETE FROM tx_pool;"); err != nil {
 		panic(err)
 	}
-	if _, err := db.Exec("DELETE FROM account_creation_auth"); err != nil {
+	if _, err := db.Exec("DELETE FROM account_creation_auth;"); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
This PR is based on the `feature/historydb-sync` branch from https://github.com/hermeznetwork/hermez-node/pull/139 but rebased to master and updated to avoid changing the already existing API of the historyDB. 

Notes about changes outside of the Synchronizer scope:
- Added `-p 1` to go test (in GHA and README) so tests are not run in parallel.  This was probably not affecting GHA because the VM is probably a single core, so test were run in serial.  But in local developers may have encountered errors in test due to SQL DB inserts coming from different tests. More info: https://coderwall.com/p/rwgo_a/go-test-package-in-parallel
- HistoryDB.Reorg() can now take negative numbers to delete all blocks.  Before this, block 0 couldn't be deleted (but the test eth client uses block 0 as the ethereum genesis block, so it's worth allowing deleting block 0)
- Added many ';' at the end of SQL statements
- In `exit_tree` TABLE, set `balance` to  `BYTEA` because it's a `*big.Int`