### PR TITLE
Add TxID calculation & New{Layer}Tx Type

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const apiPort = ":4010"
@@ -165,7 +166,7 @@ func TestMain(m *testing.M) {
 	// Gen L1Txs and add them to DB
 	const totalL1Txs = 40
 	const userL1Txs = 4
-	usrL1Txs, othrL1Txs := test.GenL1Txs(0, totalL1Txs, userL1Txs, &usrAddr, accs, tokens, blocks, batches)
+	usrL1Txs, othrL1Txs := test.GenL1Txs(256, totalL1Txs, userL1Txs, &usrAddr, accs, tokens, blocks, batches)
 	var l1Txs []common.L1Tx
 	l1Txs = append(l1Txs, usrL1Txs...)
 	l1Txs = append(l1Txs, othrL1Txs...)
@@ -176,7 +177,7 @@ func TestMain(m *testing.M) {
 	// Gen L2Txs and add them to DB
 	const totalL2Txs = 20
 	const userL2Txs = 4
-	usrL2Txs, othrL2Txs := test.GenL2Txs(totalL1Txs, totalL2Txs, userL2Txs, &usrAddr, accs, tokens, blocks, batches)
+	usrL2Txs, othrL2Txs := test.GenL2Txs(256+totalL1Txs, totalL2Txs, userL2Txs, &usrAddr, accs, tokens, blocks, batches)
 	var l2Txs []common.L2Tx
 	l2Txs = append(l2Txs, usrL2Txs...)
 	l2Txs = append(l2Txs, othrL2Txs...)
@@ -369,7 +370,7 @@ func TestGetHistoryTxs(t *testing.T) {
 	assert.NoError(t, err)
 	idxTxs := historyTxAPIs{}
 	for i := 0; i < len(tc.allTxs); i++ {
-		if tc.allTxs[i].FromIdx == idx {
+		if tc.allTxs[i].FromIdx[6:] == idx[6:] {
 			idxTxs = append(idxTxs, tc.allTxs[i])
 		}
 	}
@@ -479,7 +480,7 @@ func TestGetHistoryTxs(t *testing.T) {
 }
 
 func assertHistoryTxAPIs(t *testing.T, expected, actual historyTxAPIs) {
-	assert.Equal(t, len(expected), len(actual))
+	require.Equal(t, len(expected), len(actual))
 	for i := 0; i < len(actual); i++ { //nolint len(actual) won't change within the loop
 		assert.Equal(t, expected[i].Timestamp.Unix(), actual[i].Timestamp.Unix())
 		expected[i].Timestamp = actual[i].Timestamp

--- a/api/dbtoapistructs.go
+++ b/api/dbtoapistructs.go
@@ -55,7 +55,7 @@ type l2Info struct {
 
 type historyTxAPI struct {
 	IsL1        string           `json:"L1orL2"`
-	TxID        common.TxID      `json:"id"`
+	TxID        string           `json:"id"`
 	Type        common.TxType    `json:"type"`
 	Position    int              `json:"position"`
 	FromIdx     string           `json:"fromAccountIndex"`
@@ -73,7 +73,7 @@ func historyTxsToAPI(dbTxs []*historydb.HistoryTx) []historyTxAPI {
 	apiTxs := []historyTxAPI{}
 	for i := 0; i < len(dbTxs); i++ {
 		apiTx := historyTxAPI{
-			TxID:        dbTxs[i].TxID,
+			TxID:        dbTxs[i].TxID.String(),
 			Type:        dbTxs[i].Type,
 			Position:    dbTxs[i].Position,
 			FromIdx:     idxToHez(dbTxs[i].FromIdx, dbTxs[i].TokenSymbol),

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1421,7 +1421,7 @@ components:
     TransactionId:
       type: string
       description: Identifier for transactions. Used for any kind of transaction (both L1 and L2). More info on how the identifiers are built [here](https://idocs.hermez.io/#/spec/architecture/db/README?id=txid)
-      example: "0x0040e2010000000000470000" 
+      example: "0x00000000000001e240004700" 
     EthereumAddress:
       type: string
       description: "Address of an Etherum account."

--- a/common/l1tx.go
+++ b/common/l1tx.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/big"
 
@@ -16,6 +17,13 @@ const (
 // L1Tx is a struct that represents a L1 tx
 type L1Tx struct {
 	// Stored in DB: mandatory fileds
+
+	// TxID (12 bytes) for L1Tx is:
+	// bytes:  |  1   |        8        |    2     |      1      |
+	// values: | type | ToForgeL1TxsNum | Position | 0 (padding) |
+	// where type:
+	// 	- L1UserTx: 0
+	// 	- L1CoordinatorTx: 1
 	TxID            TxID
 	ToForgeL1TxsNum int64 // toForgeL1TxsNum in which the tx was forged / will be forged
 	Position        int
@@ -32,6 +40,58 @@ type L1Tx struct {
 	BatchNum        *BatchNum
 	USD             *float64
 	LoadAmountUSD   *float64
+}
+
+// NewL1Tx returns the given L1Tx with the TxId & Type parameters calculated
+// from the L1Tx values
+func NewL1Tx(l1Tx *L1Tx) (*L1Tx, error) {
+	// calculate TxType
+	var txType TxType
+	if l1Tx.FromIdx == Idx(0) {
+		if l1Tx.ToIdx == Idx(0) {
+			txType = TxTypeCreateAccountDeposit
+		} else if l1Tx.ToIdx >= IdxUserThreshold {
+			txType = TxTypeCreateAccountDepositTransfer
+		} else {
+			return l1Tx, fmt.Errorf("Can not determine type of L1Tx, invalid ToIdx value: %d", l1Tx.ToIdx)
+		}
+	} else if l1Tx.FromIdx >= IdxUserThreshold {
+		if l1Tx.ToIdx == Idx(0) {
+			txType = TxTypeDeposit
+		} else if l1Tx.ToIdx == Idx(1) {
+			txType = TxTypeExit
+		} else if l1Tx.ToIdx >= IdxUserThreshold {
+			if l1Tx.LoadAmount.Int64() == int64(0) {
+				txType = TxTypeForceTransfer
+			} else {
+				txType = TxTypeDepositTransfer
+			}
+		} else {
+			return l1Tx, fmt.Errorf("Can not determine type of L1Tx, invalid ToIdx value: %d", l1Tx.ToIdx)
+		}
+	} else {
+		return l1Tx, fmt.Errorf("Can not determine type of L1Tx, invalid FromIdx value: %d", l1Tx.FromIdx)
+	}
+
+	if l1Tx.Type != "" && l1Tx.Type != txType {
+		return l1Tx, fmt.Errorf("L1Tx.Type: %s, should be: %s", l1Tx.Type, txType)
+	}
+	l1Tx.Type = txType
+
+	var txid [TxIDLen]byte
+	if !l1Tx.UserOrigin {
+		txid[0] = TxIDPrefixL1CoordTx
+	}
+	var toForgeL1TxsNumBytes [8]byte
+	binary.BigEndian.PutUint64(toForgeL1TxsNumBytes[:], uint64(l1Tx.ToForgeL1TxsNum))
+	copy(txid[1:9], toForgeL1TxsNumBytes[:])
+
+	var positionBytes [2]byte
+	binary.BigEndian.PutUint16(positionBytes[:], uint16(l1Tx.Position))
+	copy(txid[9:11], positionBytes[:])
+	l1Tx.TxID = TxID(txid)
+
+	return l1Tx, nil
 }
 
 // Tx returns a *Tx from the L1Tx

--- a/common/l1tx_test.go
+++ b/common/l1tx_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewL1Tx(t *testing.T) {
+	l1Tx := &L1Tx{
+		ToForgeL1TxsNum: int64(123456),
+		Position:        71,
+		ToIdx:           301,
+		TokenID:         5,
+		Amount:          big.NewInt(1),
+		LoadAmount:      big.NewInt(2),
+		FromIdx:         300,
+	}
+	l1Tx, err := NewL1Tx(l1Tx)
+	assert.Nil(t, err)
+	assert.Equal(t, "0x01000000000001e240004700", l1Tx.TxID.String())
+}
+
 func TestL1TxByteParsers(t *testing.T) {
 	var pkComp babyjub.PublicKeyComp
 	err := pkComp.UnmarshalText([]byte("0x56ca90f80d7c374ae7485e9bcc47d4ac399460948da6aeeb899311097925a72c"))

--- a/common/l2tx.go
+++ b/common/l2tx.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"math/big"
 )
 
@@ -19,6 +20,42 @@ type L2Tx struct {
 	Nonce       Nonce
 	Type        TxType
 	EthBlockNum int64 // Ethereum Block Number in which this L2Tx was added to the queue
+}
+
+// NewL2Tx returns the given L2Tx with the TxId & Type parameters calculated
+// from the L2Tx values
+func NewL2Tx(l2Tx *L2Tx) (*L2Tx, error) {
+	// calculate TxType
+	var txType TxType
+	if l2Tx.ToIdx == Idx(1) {
+		txType = TxTypeExit
+	} else if l2Tx.ToIdx >= IdxUserThreshold {
+		txType = TxTypeTransfer
+	} else {
+		return l2Tx, fmt.Errorf("Can not determine type of L2Tx, invalid ToIdx value: %d", l2Tx.ToIdx)
+	}
+
+	// if TxType!=l2Tx.TxType return error
+	if l2Tx.Type != "" && l2Tx.Type != txType {
+		return l2Tx, fmt.Errorf("L2Tx.Type: %s, should be: %s", l2Tx.Type, txType)
+	}
+	l2Tx.Type = txType
+
+	var txid [TxIDLen]byte
+	txid[0] = TxIDPrefixL2Tx
+	fromIdxBytes, err := l2Tx.FromIdx.Bytes()
+	if err != nil {
+		return l2Tx, err
+	}
+	copy(txid[1:7], fromIdxBytes[:])
+	nonceBytes, err := l2Tx.Nonce.Bytes()
+	if err != nil {
+		return l2Tx, err
+	}
+	copy(txid[7:12], nonceBytes[:])
+	l2Tx.TxID = TxID(txid)
+
+	return l2Tx, nil
 }
 
 // Tx returns a *Tx from the L2Tx

--- a/common/l2tx_test.go
+++ b/common/l2tx_test.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewL2Tx(t *testing.T) {
+	l2Tx := &L2Tx{
+		FromIdx: 87654,
+		ToIdx:   300,
+		Amount:  big.NewInt(4),
+		Nonce:   144,
+	}
+	l2Tx, err := NewL2Tx(l2Tx)
+	assert.Nil(t, err)
+	assert.Equal(t, "0x020000000156660000000090", l2Tx.TxID.String())
+}

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -13,6 +13,10 @@ import (
 // PoolL2Tx is a struct that represents a L2Tx sent by an account to the coordinator hat is waiting to be forged
 type PoolL2Tx struct {
 	// Stored in DB: mandatory fileds
+
+	// TxID (12 bytes) for L2Tx is:
+	// bytes:  |  1   |    6    |   5   |
+	// values: | type | FromIdx | Nonce |
 	TxID        TxID               `meddler:"tx_id"`
 	FromIdx     Idx                `meddler:"from_idx"` // FromIdx is used by L1Tx/Deposit to indicate the Idx receiver of the L1Tx.LoadAmount (deposit)
 	ToIdx       Idx                `meddler:"to_idx"`   // ToIdx is ignored in L1Tx/Deposit, but used in the L1Tx/DepositAndTransfer
@@ -43,6 +47,44 @@ type PoolL2Tx struct {
 	// Extra metadata, may be uninitialized
 	RqTxCompressedData []byte `meddler:"-"` // 253 bits, optional for atomic txs
 	TokenSymbol        string `meddler:"token_symbol"`
+}
+
+// NewPoolL2Tx returns the given L2Tx with the TxId & Type parameters calculated
+// from the L2Tx values
+func NewPoolL2Tx(poolL2Tx *PoolL2Tx) (*PoolL2Tx, error) {
+	// calculate TxType
+	var txType TxType
+	if poolL2Tx.ToIdx == Idx(0) {
+		txType = TxTypeTransfer
+	} else if poolL2Tx.ToIdx == Idx(1) {
+		txType = TxTypeExit
+	} else if poolL2Tx.ToIdx >= IdxUserThreshold {
+		txType = TxTypeTransfer
+	} else {
+		return poolL2Tx, fmt.Errorf("Can not determine type of PoolL2Tx, invalid ToIdx value: %d", poolL2Tx.ToIdx)
+	}
+
+	// if TxType!=poolL2Tx.TxType return error
+	if poolL2Tx.Type != "" && poolL2Tx.Type != txType {
+		return poolL2Tx, fmt.Errorf("PoolL2Tx.Type: %s, should be: %s", poolL2Tx.Type, txType)
+	}
+	poolL2Tx.Type = txType
+
+	var txid [TxIDLen]byte
+	txid[0] = TxIDPrefixL2Tx
+	fromIdxBytes, err := poolL2Tx.FromIdx.Bytes()
+	if err != nil {
+		return poolL2Tx, err
+	}
+	copy(txid[1:7], fromIdxBytes[:])
+	nonceBytes, err := poolL2Tx.Nonce.Bytes()
+	if err != nil {
+		return poolL2Tx, err
+	}
+	copy(txid[7:12], nonceBytes[:])
+	poolL2Tx.TxID = TxID(txid)
+
+	return poolL2Tx, nil
 }
 
 // TxCompressedData spec:

--- a/common/pooll2tx_test.go
+++ b/common/pooll2tx_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewPoolL2Tx(t *testing.T) {
+	poolL2Tx := &PoolL2Tx{
+		FromIdx: 87654,
+		ToIdx:   300,
+		Amount:  big.NewInt(4),
+		TokenID: 5,
+		Nonce:   144,
+	}
+	poolL2Tx, err := NewPoolL2Tx(poolL2Tx)
+	assert.Nil(t, err)
+	assert.Equal(t, "0x020000000156660000000090", poolL2Tx.TxID.String())
+}
+
 func TestTxCompressedData(t *testing.T) {
 	var sk babyjub.PrivateKey
 	_, err := hex.Decode(sk[:], []byte("0001020304050607080900010203040506070809000102030405060708090001"))

--- a/common/tx_test.go
+++ b/common/tx_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxIDScannerValue(t *testing.T) {
+	txid0 := &TxID{}
+	txid1 := &TxID{}
+	txid0B := [12]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	txid1B := [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	copy(txid0[:], txid0B[:])
+	copy(txid1[:], txid1B[:])
+
+	var value driver.Valuer
+	var scan sql.Scanner
+	value = txid0
+	scan = txid1
+	fromDB, err := value.Value()
+	assert.NoError(t, err)
+	assert.NoError(t, scan.Scan(fromDB))
+	assert.Equal(t, value, scan)
+}

--- a/db/statedb/statedb.go
+++ b/db/statedb/statedb.go
@@ -185,7 +185,7 @@ func (s *StateDB) Reset(batchNum common.BatchNum) error {
 			return err
 		}
 		s.db = sto
-		s.idx = 0
+		s.idx = 255
 		s.currentBatch = batchNum
 		return nil
 	}

--- a/db/statedb/txprocessors.go
+++ b/db/statedb/txprocessors.go
@@ -319,16 +319,19 @@ func (s *StateDB) processL2Tx(exitTree *merkletree.MerkleTree, tx *common.PoolL2
 				// case ToEthAddr!=0 && ToBJJ=0
 				idx, err = s.GetIdxByEthAddr(tx.ToEthAddr)
 				if err != nil {
+					log.Error(err)
 					return nil, nil, false, ErrToIdxNotFound
 				}
 			} else if !bytes.Equal(tx.ToEthAddr.Bytes(), common.EmptyAddr.Bytes()) && tx.ToBJJ != nil {
 				// case ToEthAddr!=0 && ToBJJ!=0
 				idx, err = s.GetIdxByEthAddrBJJ(tx.ToEthAddr, tx.ToBJJ)
 				if err != nil {
+					log.Error(err)
 					return nil, nil, false, ErrToIdxNotFound
 				}
 			} else {
 				// rest of cases (included case ToEthAddr==0) are not possible
+				log.Error(err)
 				return nil, nil, false, ErrToIdxNotFound
 			}
 			s.zki.AuxToIdx[s.i] = idx.BigInt()

--- a/db/statedb/txprocessors_test.go
+++ b/db/statedb/txprocessors_test.go
@@ -40,7 +40,7 @@ func TestProcessTxs(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	acc, err := sdb.GetAccount(common.Idx(1))
+	acc, err := sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "23", acc.Balance.String())
 }
@@ -73,7 +73,7 @@ func TestProcessTxsBatchByBatch(t *testing.T) {
 	_, exitInfos, err := sdb.ProcessTxs(true, true, l1Txs[0], coordinatorL1Txs[0], poolL2Txs[0])
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(exitInfos))
-	acc, err := sdb.GetAccount(common.Idx(1))
+	acc, err := sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "28", acc.Balance.String())
 
@@ -82,8 +82,8 @@ func TestProcessTxsBatchByBatch(t *testing.T) {
 	_, exitInfos, err = sdb.ProcessTxs(true, true, l1Txs[1], coordinatorL1Txs[1], poolL2Txs[1])
 	require.Nil(t, err)
 	assert.Equal(t, 5, len(exitInfos))
-	acc, err = sdb.GetAccount(common.Idx(1))
-	assert.Nil(t, err)
+	acc, err = sdb.GetAccount(common.Idx(256))
+	require.Nil(t, err)
 	assert.Equal(t, "48", acc.Balance.String())
 
 	// use third batch
@@ -91,7 +91,7 @@ func TestProcessTxsBatchByBatch(t *testing.T) {
 	_, exitInfos, err = sdb.ProcessTxs(true, true, l1Txs[2], coordinatorL1Txs[2], poolL2Txs[2])
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(exitInfos))
-	acc, err = sdb.GetAccount(common.Idx(1))
+	acc, err = sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "23", acc.Balance.String())
 }

--- a/test/historydb.go
+++ b/test/historydb.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"strconv"
 	"time"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -88,10 +87,10 @@ func GenAccounts(totalAccounts, userAccounts int, tokens []common.Token, userAdd
 		panic("totalAccounts must be greater than userAccounts")
 	}
 	accs := []common.Account{}
-	for i := 0; i < totalAccounts; i++ {
+	for i := 256; i < 256+totalAccounts; i++ {
 		var addr ethCommon.Address
 		var pubK *babyjub.PublicKey
-		if i < userAccounts {
+		if i < 256+userAccounts {
 			addr = *userAddr
 			pubK = userBjj
 		} else {
@@ -126,7 +125,7 @@ func GenL1Txs(
 	userTxs := []common.L1Tx{}
 	othersTxs := []common.L1Tx{}
 	_, nextTxsNum := GetNextToForgeNumAndBatch(batches)
-	for i := 0; i < totalTxs; i++ {
+	for i := fromIdx; i < fromIdx+totalTxs; i++ {
 		token := tokens[i%len(tokens)]
 		var usd *float64
 		var lUSD *float64
@@ -142,8 +141,7 @@ func GenL1Txs(
 			*lUSD = noDecimalsUSD * af
 		}
 		tx := common.L1Tx{
-			TxID:          common.TxID(common.Hash([]byte("L1_" + strconv.Itoa(fromIdx+i)))),
-			Position:      i,
+			Position:      i - fromIdx,
 			UserOrigin:    i%2 == 0,
 			TokenID:       token.TokenID,
 			Amount:        amount,
@@ -151,17 +149,21 @@ func GenL1Txs(
 			LoadAmount:    amount,
 			LoadAmountUSD: lUSD,
 			EthBlockNum:   blocks[i%len(blocks)].EthBlockNum,
-			Type:          randomTxType(i),
 		}
+		nTx, err := common.NewL1Tx(&tx)
+		if err != nil {
+			panic(err)
+		}
+		tx = *nTx
 		if batches[i%len(batches)].ForgeL1TxsNum != 0 {
 			// Add already forged txs
 			tx.BatchNum = &batches[i%len(batches)].BatchNum
-			setFromToAndAppend(tx, i, nUserTxs, userAddr, accounts, &userTxs, &othersTxs)
+			setFromToAndAppend(fromIdx, tx, i, nUserTxs, userAddr, accounts, &userTxs, &othersTxs)
 		} else {
 			// Add unforged txs
 			tx.ToForgeL1TxsNum = nextTxsNum
 			tx.UserOrigin = true
-			setFromToAndAppend(tx, i, nUserTxs, userAddr, accounts, &userTxs, &othersTxs)
+			setFromToAndAppend(fromIdx, tx, i, nUserTxs, userAddr, accounts, &userTxs, &othersTxs)
 		}
 	}
 	return userTxs, othersTxs
@@ -186,6 +188,7 @@ func GetNextToForgeNumAndBatch(batches []common.Batch) (common.BatchNum, int64) 
 }
 
 func setFromToAndAppend(
+	fromIdx int,
 	tx common.L1Tx,
 	i, nUserTxs int,
 	userAddr *ethCommon.Address,
@@ -193,7 +196,7 @@ func setFromToAndAppend(
 	userTxs *[]common.L1Tx,
 	othersTxs *[]common.L1Tx,
 ) {
-	if i < nUserTxs {
+	if i < fromIdx+nUserTxs {
 		var from, to *common.Account
 		var err error
 		if i%2 == 0 {
@@ -252,13 +255,13 @@ func GenL2Txs(
 	}
 	userTxs := []common.L2Tx{}
 	othersTxs := []common.L2Tx{}
-	for i := 0; i < totalTxs; i++ {
+	for i := fromIdx; i < fromIdx+totalTxs; i++ {
 		amount := big.NewInt(int64(i + 1))
 		fee := common.FeeSelector(i % 256) //nolint:gomnd
 		tx := common.L2Tx{
-			TxID:        common.TxID(common.Hash([]byte("L2_" + strconv.Itoa(fromIdx+i)))),
+			TxID:        common.TxID([12]byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, byte(i)}), // only for testing purposes
 			BatchNum:    batches[i%len(batches)].BatchNum,
-			Position:    i,
+			Position:    i - fromIdx,
 			Amount:      amount,
 			Fee:         fee,
 			Nonce:       common.Nonce(i + 1),

--- a/test/l2db.go
+++ b/test/l2db.go
@@ -27,7 +27,7 @@ func CleanL2DB(db *sqlx.DB) {
 func GenPoolTxs(n int, tokens []common.Token) []*common.PoolL2Tx {
 	txs := make([]*common.PoolL2Tx, 0, n)
 	privK := babyjub.NewRandPrivKey()
-	for i := 0; i < n; i++ {
+	for i := 256; i < 256+n; i++ {
 		var state common.PoolL2TxState
 		//nolint:gomnd
 		if i%4 == 0 {
@@ -54,7 +54,6 @@ func GenPoolTxs(n int, tokens []common.Token) []*common.PoolL2Tx {
 			*absFee = fee.Percentage() * *usd
 		}
 		tx := &common.PoolL2Tx{
-			TxID:              common.TxID(common.Hash([]byte(strconv.Itoa(i)))),
 			FromIdx:           common.Idx(i),
 			ToIdx:             common.Idx(i + 1),
 			ToEthAddr:         ethCommon.BigToAddress(big.NewInt(int64(i))),
@@ -71,6 +70,11 @@ func GenPoolTxs(n int, tokens []common.Token) []*common.PoolL2Tx {
 			TokenSymbol:       token.Symbol,
 			AbsoluteFee:       absFee,
 			AbsoluteFeeUpdate: token.USDUpdate,
+		}
+		var err error
+		tx, err = common.NewPoolL2Tx(tx)
+		if err != nil {
+			panic(err)
 		}
 		if i%2 == 0 { // Optional parameters: rq
 			tx.RqFromIdx = common.Idx(i)

--- a/test/txs.go
+++ b/test/txs.go
@@ -62,8 +62,8 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]*common.L1Tx,
 	var l1Txs [][]*common.L1Tx
 	var coordinatorL1Txs [][]*common.L1Tx
 	var poolL2Txs [][]*common.PoolL2Tx
-	idx := 1
-	for i, inst := range instructions.Instructions {
+	idx := 256
+	for _, inst := range instructions.Instructions {
 		switch inst.Type {
 		case common.TxTypeCreateAccountDeposit:
 			tx := common.L1Tx{
@@ -98,7 +98,6 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]*common.L1Tx,
 			}
 
 			tx := common.PoolL2Tx{
-				TxID:        common.TxID([]byte{byte(i)}), // TODO this is for the moment, once TxID Hash is implemented use it
 				FromIdx:     accounts[idxTokenIDToString(inst.From, inst.TokenID)].Idx,
 				ToIdx:       accounts[idxTokenIDToString(inst.To, inst.TokenID)].Idx,
 				ToEthAddr:   accounts[idxTokenIDToString(inst.To, inst.TokenID)].Addr,
@@ -114,6 +113,11 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]*common.L1Tx,
 				RqToBJJ:     accounts[idxTokenIDToString(inst.To, inst.TokenID)].BJJ.Public(),
 				Type:        common.TxTypeTransfer,
 			}
+			nTx, err := common.NewPoolL2Tx(&tx)
+			if err != nil {
+				panic(err)
+			}
+			tx = *nTx
 			// perform signature and set it to tx.Signature
 			toSign, err := tx.HashToSign()
 			if err != nil {

--- a/test/txs_test.go
+++ b/test/txs_test.go
@@ -38,19 +38,21 @@ func TestGenerateTestL2Txs(t *testing.T) {
 	assert.Equal(t, 4, len(coordinatorL1txs[1]))
 	assert.Equal(t, 6, len(l2txs[1]))
 
+	accounts := GenerateKeys(t, instructions.Accounts)
+
 	// l1txs
 	assert.Equal(t, common.TxTypeCreateAccountDeposit, l1txs[0][0].Type)
-	assert.Equal(t, "5bac784d938067d980a9d39bdd79bf84a0cbb296977c47cc30de2d5ce9229d2f", l1txs[0][0].FromBJJ.String())
-	assert.Equal(t, "323ff10c28df37ecb787fe216e111db64aa7cfa2c517509fe0057ff08a10b30c", l1txs[0][1].FromBJJ.String())
-	assert.Equal(t, "f3587ad5cc7414a47545770b6c75bc71930f63c491eb2294dde8b8a6670b8e96", l1txs[0][2].FromBJJ.String())
-	assert.Equal(t, "750a24a874a81c6c6f8aaa168ff2ee88c58263fee9ddd96d9717bcffc809b027", l1txs[1][1].FromBJJ.String())
+	assert.Equal(t, accounts["A1"].BJJ.Public().String(), l1txs[0][0].FromBJJ.String())
+	assert.Equal(t, accounts["A2"].BJJ.Public().String(), l1txs[0][1].FromBJJ.String())
+	assert.Equal(t, accounts["B1"].BJJ.Public().String(), l1txs[0][2].FromBJJ.String())
+	assert.Equal(t, accounts["User13"].BJJ.Public().String(), l1txs[1][1].FromBJJ.String())
 
 	// l2txs
 	assert.Equal(t, common.TxTypeTransfer, l2txs[0][0].Type)
-	assert.Equal(t, common.Idx(1), l2txs[0][0].FromIdx)
-	assert.Equal(t, common.Idx(3), l2txs[0][0].ToIdx)
-	assert.Equal(t, "f3587ad5cc7414a47545770b6c75bc71930f63c491eb2294dde8b8a6670b8e96", l2txs[0][0].ToBJJ.String())
-	assert.Equal(t, "0x6813Eb9362372EEF6200f3b1dbC3f819671cBA69", l2txs[0][0].ToEthAddr.Hex())
+	assert.Equal(t, common.Idx(256), l2txs[0][0].FromIdx)
+	assert.Equal(t, common.Idx(258), l2txs[0][0].ToIdx)
+	assert.Equal(t, accounts["B1"].BJJ.Public().String(), l2txs[0][0].ToBJJ.String())
+	assert.Equal(t, accounts["B1"].Addr.Hex(), l2txs[0][0].ToEthAddr.Hex())
 	assert.Equal(t, common.Nonce(0), l2txs[0][0].Nonce)
 	assert.Equal(t, common.Nonce(1), l2txs[1][1].Nonce)
 	assert.Equal(t, common.FeeSelector(1), l2txs[0][0].Fee)

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -112,6 +112,7 @@ func (txsel *TxSelector) GetL1L2TxSelection(batchNum common.BatchNum, l1Txs []*c
 
 	var validTxs txs
 	var l1CoordinatorTxs []*common.L1Tx
+	positionL1 := len(l1Txs)
 
 	// if tx.ToIdx>=256, tx.ToIdx should exist to localAccountsDB, if so,
 	// tx is used.  if tx.ToIdx==0, check if tx.ToEthAddr/tx.ToBJJ exist in
@@ -190,6 +191,7 @@ func (txsel *TxSelector) GetL1L2TxSelection(batchNum common.BatchNum, l1Txs []*c
 				}
 				// create L1CoordinatorTx for the accountCreation
 				l1CoordinatorTx := &common.L1Tx{
+					Position:    positionL1,
 					UserOrigin:  false,
 					FromEthAddr: accAuth.EthAddr,
 					FromBJJ:     accAuth.BJJ,
@@ -197,6 +199,7 @@ func (txsel *TxSelector) GetL1L2TxSelection(batchNum common.BatchNum, l1Txs []*c
 					LoadAmount:  big.NewInt(0),
 					Type:        common.TxTypeCreateAccountDeposit,
 				}
+				positionL1++
 				l1CoordinatorTxs = append(l1CoordinatorTxs, l1CoordinatorTx)
 			} else if bytes.Equal(l2TxsRaw[i].ToEthAddr.Bytes(), common.FFAddr.Bytes()) && l2TxsRaw[i].ToBJJ != nil {
 				// if idx exist for EthAddr&BJJ use it
@@ -213,6 +216,7 @@ func (txsel *TxSelector) GetL1L2TxSelection(batchNum common.BatchNum, l1Txs []*c
 				// L1Authorization, as ToEthAddr==0xff
 				// create L1CoordinatorTx for the accountCreation
 				l1CoordinatorTx := &common.L1Tx{
+					Position:    positionL1,
 					UserOrigin:  false,
 					FromEthAddr: l2TxsRaw[i].ToEthAddr,
 					FromBJJ:     l2TxsRaw[i].ToBJJ,
@@ -220,6 +224,7 @@ func (txsel *TxSelector) GetL1L2TxSelection(batchNum common.BatchNum, l1Txs []*c
 					LoadAmount:  big.NewInt(0),
 					Type:        common.TxTypeCreateAccountDeposit,
 				}
+				positionL1++
 				l1CoordinatorTxs = append(l1CoordinatorTxs, l1CoordinatorTx)
 			}
 		} else if l2TxsRaw[i].ToIdx == common.Idx(1) {


### PR DESCRIPTION
Add TxID calculation & New{Layer}Tx Type

New{Layer}Tx methods that compute the `TxID` & `TxType` values from the
transaction values:
- NewL1Tx
- NewL2Tx
- NewPoolL2Tx

Add TxID Scanner & Valuer for database/sql

HistoryDB & L2DB & API packages tests will need to be addapted to the
TestTransaction generation once is done (#160).

resolves #134 