### PR TITLE
Have BigInt be a proper big value that has 18 decimals

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1467,7 +1467,7 @@ components:
     BigInt:
       type: string
       description: BigInt is an integer encoded as a string for numbers that are very large.
-      example: "870885693"
+      example: "8708856933496328593"
     FeeSelector:
       type: integer
       description: Index of the fee type to select, more info [here](https://idocs.hermez.io/#/spec/zkrollup/fee-table?id=transaction-fee-table).


### PR DESCRIPTION
As the value is so small right now, we are showing 0s in the Wallet UI.