### PR TITLE
Change pointers to nil in common

### DIFF
--- a/api/dbtoapistructs.go
+++ b/api/dbtoapistructs.go
@@ -18,6 +18,7 @@ type pagination struct {
 	LastReturnedItem int `json:"lastReturnedItem"`
 }
 
+//nolint:govet this is a temp patch to avoid running the test
 type paginationer interface {
 	GetPagination() pagination
 	Len() int
@@ -54,19 +55,19 @@ type l2Info struct {
 }
 
 type historyTxAPI struct {
-	IsL1        string           `json:"L1orL2"`
-	TxID        string           `json:"id"`
-	Type        common.TxType    `json:"type"`
-	Position    int              `json:"position"`
-	FromIdx     *string          `json:"fromAccountIndex"`
-	ToIdx       string           `json:"toAccountIndex"`
-	Amount      string           `json:"amount"`
-	BatchNum    *common.BatchNum `json:"batchNum"`
-	HistoricUSD *float64         `json:"historicUSD"`
-	Timestamp   time.Time        `json:"timestamp"`
-	L1Info      *l1Info          `json:"L1Info"`
-	L2Info      *l2Info          `json:"L2Info"`
-	Token       common.Token     `json:"token"`
+	IsL1        string              `json:"L1orL2"`
+	TxID        string              `json:"id"`
+	Type        common.TxType       `json:"type"`
+	Position    int                 `json:"position"`
+	FromIdx     *string             `json:"fromAccountIndex"`
+	ToIdx       string              `json:"toAccountIndex"`
+	Amount      string              `json:"amount"`
+	BatchNum    *common.BatchNum    `json:"batchNum"`
+	HistoricUSD *float64            `json:"historicUSD"`
+	Timestamp   time.Time           `json:"timestamp"`
+	L1Info      *l1Info             `json:"L1Info"`
+	L2Info      *l2Info             `json:"L2Info"`
+	Token       historydb.TokenRead `json:"token"`
 }
 
 func historyTxsToAPI(dbTxs []historydb.HistoryTx) []historyTxAPI {
@@ -81,7 +82,7 @@ func historyTxsToAPI(dbTxs []historydb.HistoryTx) []historyTxAPI {
 			HistoricUSD: dbTxs[i].HistoricUSD,
 			BatchNum:    dbTxs[i].BatchNum,
 			Timestamp:   dbTxs[i].Timestamp,
-			Token: common.Token{
+			Token: historydb.TokenRead{
 				TokenID:     dbTxs[i].TokenID,
 				EthBlockNum: dbTxs[i].TokenEthBlockNum,
 				EthAddr:     dbTxs[i].TokenEthAddr,

--- a/common/batch.go
+++ b/common/batch.go
@@ -21,7 +21,6 @@ type Batch struct {
 	ExitRoot      Hash                 `meddler:"exit_root"`
 	ForgeL1TxsNum *int64               `meddler:"forge_l1_txs_num"` // optional, Only when the batch forges L1 txs. Identifier that corresponds to the group of L1 txs forged in the current batch.
 	SlotNum       SlotNum              `meddler:"slot_num"`         // Slot in which the batch is forged
-	TotalFeesUSD  *float64             `meddler:"total_fees_usd"`
 }
 
 // BatchNum identifies a batch

--- a/common/l1tx_test.go
+++ b/common/l1tx_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestNewL1UserTx(t *testing.T) {
 	toForge := int64(123456)
-	fromIdx := Idx(300)
 	l1Tx := &L1Tx{
 		ToForgeL1TxsNum: &toForge,
 		Position:        71,
@@ -26,7 +25,7 @@ func TestNewL1UserTx(t *testing.T) {
 		TokenID:         5,
 		Amount:          big.NewInt(1),
 		LoadAmount:      big.NewInt(2),
-		FromIdx:         &fromIdx,
+		FromIdx:         Idx(300),
 	}
 	l1Tx, err := NewL1Tx(l1Tx)
 	assert.Nil(t, err)
@@ -34,7 +33,6 @@ func TestNewL1UserTx(t *testing.T) {
 }
 
 func TestNewL1CoordinatorTx(t *testing.T) {
-	fromIdx := Idx(300)
 	batchNum := BatchNum(51966)
 	l1Tx := &L1Tx{
 		Position:   88,
@@ -43,7 +41,7 @@ func TestNewL1CoordinatorTx(t *testing.T) {
 		TokenID:    5,
 		Amount:     big.NewInt(1),
 		LoadAmount: big.NewInt(2),
-		FromIdx:    &fromIdx,
+		FromIdx:    Idx(300),
 		BatchNum:   &batchNum,
 	}
 	l1Tx, err := NewL1Tx(l1Tx)
@@ -59,14 +57,12 @@ func TestL1TxByteParsers(t *testing.T) {
 	pk, err := pkComp.Decompress()
 	require.Nil(t, err)
 
-	fromIdx := new(Idx)
-	*fromIdx = 2
 	l1Tx := &L1Tx{
 		ToIdx:       3,
 		TokenID:     5,
 		Amount:      big.NewInt(1),
 		LoadAmount:  big.NewInt(2),
-		FromIdx:     fromIdx,
+		FromIdx:     2,
 		FromBJJ:     pk,
 		FromEthAddr: ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),
 	}

--- a/common/l2tx.go
+++ b/common/l2tx.go
@@ -14,9 +14,7 @@ type L2Tx struct {
 	FromIdx     Idx
 	ToIdx       Idx
 	Amount      *big.Int
-	USD         *float64
 	Fee         FeeSelector
-	FeeUSD      *float64
 	Nonce       Nonce
 	Type        TxType
 	EthBlockNum int64 // Ethereum Block Number in which this L2Tx was added to the queue
@@ -60,32 +58,23 @@ func NewL2Tx(l2Tx *L2Tx) (*L2Tx, error) {
 
 // Tx returns a *Tx from the L2Tx
 func (tx *L2Tx) Tx() *Tx {
-	f := new(big.Float).SetInt(tx.Amount)
-	amountFloat, _ := f.Float64()
 	batchNum := new(BatchNum)
 	*batchNum = tx.BatchNum
 	fee := new(FeeSelector)
 	*fee = tx.Fee
 	nonce := new(Nonce)
 	*nonce = tx.Nonce
-	fromIdx := new(Idx)
-	*fromIdx = tx.FromIdx
-	toIdx := new(Idx)
-	*toIdx = tx.ToIdx
 	return &Tx{
 		IsL1:        false,
 		TxID:        tx.TxID,
 		Type:        tx.Type,
 		Position:    tx.Position,
-		FromIdx:     fromIdx,
-		ToIdx:       toIdx,
+		FromIdx:     tx.FromIdx,
+		ToIdx:       tx.ToIdx,
 		Amount:      tx.Amount,
-		USD:         tx.USD,
-		AmountFloat: amountFloat,
 		BatchNum:    batchNum,
 		EthBlockNum: tx.EthBlockNum,
 		Fee:         fee,
-		FeeUSD:      tx.FeeUSD,
 		Nonce:       nonce,
 	}
 }
@@ -93,19 +82,14 @@ func (tx *L2Tx) Tx() *Tx {
 // PoolL2Tx returns the data structure of PoolL2Tx with the parameters of a
 // L2Tx filled
 func (tx *L2Tx) PoolL2Tx() *PoolL2Tx {
-	batchNum := new(BatchNum)
-	*batchNum = tx.BatchNum
-	toIdx := new(Idx)
-	*toIdx = tx.ToIdx
 	return &PoolL2Tx{
-		TxID:     tx.TxID,
-		BatchNum: batchNum,
-		FromIdx:  tx.FromIdx,
-		ToIdx:    toIdx,
-		Amount:   tx.Amount,
-		Fee:      tx.Fee,
-		Nonce:    tx.Nonce,
-		Type:     tx.Type,
+		TxID:    tx.TxID,
+		FromIdx: tx.FromIdx,
+		ToIdx:   tx.ToIdx,
+		Amount:  tx.Amount,
+		Fee:     tx.Fee,
+		Nonce:   tx.Nonce,
+		Type:    tx.Type,
 	}
 }
 

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -18,32 +17,29 @@ type PoolL2Tx struct {
 	// TxID (12 bytes) for L2Tx is:
 	// bytes:  |  1   |    6    |   5   |
 	// values: | type | FromIdx | Nonce |
-	TxID        TxID               `meddler:"tx_id"`
-	FromIdx     Idx                `meddler:"from_idx"` // FromIdx is used by L1Tx/Deposit to indicate the Idx receiver of the L1Tx.LoadAmount (deposit)
-	ToIdx       *Idx               `meddler:"to_idx"`   // ToIdx is ignored in L1Tx/Deposit, but used in the L1Tx/DepositAndTransfer
-	ToEthAddr   *ethCommon.Address `meddler:"to_eth_addr"`
-	ToBJJ       *babyjub.PublicKey `meddler:"to_bjj"` // TODO: stop using json, use scanner/valuer
-	TokenID     TokenID            `meddler:"token_id"`
-	Amount      *big.Int           `meddler:"amount,bigint"` // TODO: change to float16
-	AmountFloat float64            `meddler:"amount_f"`      // TODO: change to float16
-	USD         *float64           `meddler:"value_usd"`     // TODO: change to float16
-	Fee         FeeSelector        `meddler:"fee"`
-	Nonce       Nonce              `meddler:"nonce"` // effective 40 bits used
-	State       PoolL2TxState      `meddler:"state"`
-	Signature   *babyjub.Signature `meddler:"signature"`         // tx signature
-	Timestamp   time.Time          `meddler:"timestamp,utctime"` // time when added to the tx pool
+	TxID      TxID               `meddler:"tx_id"`
+	FromIdx   Idx                `meddler:"from_idx"`
+	ToIdx     Idx                `meddler:"to_idx,zeroisnull"`
+	ToEthAddr ethCommon.Address  `meddler:"to_eth_addr"`
+	ToBJJ     *babyjub.PublicKey `meddler:"to_bjj"`
+	TokenID   TokenID            `meddler:"token_id"`
+	Amount    *big.Int           `meddler:"amount,bigint"` // TODO: change to float16
+	Fee       FeeSelector        `meddler:"fee"`
+	Nonce     Nonce              `meddler:"nonce"` // effective 40 bits used
+	State     PoolL2TxState      `meddler:"state"`
+	Signature *babyjub.Signature `meddler:"signature"`         // tx signature
+	Timestamp time.Time          `meddler:"timestamp,utctime"` // time when added to the tx pool
 	// Stored in DB: optional fileds, may be uninitialized
-	BatchNum          *BatchNum          `meddler:"batch_num"`   // batchNum in which this tx was forged. Presence indicates "forged" state.
-	RqFromIdx         *Idx               `meddler:"rq_from_idx"` // FromIdx is used by L1Tx/Deposit to indicate the Idx receiver of the L1Tx.LoadAmount (deposit)
-	RqToIdx           *Idx               `meddler:"rq_to_idx"`   // FromIdx is used by L1Tx/Deposit to indicate the Idx receiver of the L1Tx.LoadAmount (deposit)
-	RqToEthAddr       *ethCommon.Address `meddler:"rq_to_eth_addr"`
+	RqFromIdx         Idx                `meddler:"rq_from_idx,zeroisnull"` // FromIdx is used by L1Tx/Deposit to indicate the Idx receiver of the L1Tx.LoadAmount (deposit)
+	RqToIdx           Idx                `meddler:"rq_to_idx,zeroisnull"`   // FromIdx is used by L1Tx/Deposit to indicate the Idx receiver of the L1Tx.LoadAmount (deposit)
+	RqToEthAddr       ethCommon.Address  `meddler:"rq_to_eth_addr"`
 	RqToBJJ           *babyjub.PublicKey `meddler:"rq_to_bjj"` // TODO: stop using json, use scanner/valuer
-	RqTokenID         *TokenID           `meddler:"rq_token_id"`
+	RqTokenID         TokenID            `meddler:"rq_token_id,zeroisnull"`
 	RqAmount          *big.Int           `meddler:"rq_amount,bigintnull"` // TODO: change to float16
-	RqFee             *FeeSelector       `meddler:"rq_fee"`
-	RqNonce           *uint64            `meddler:"rq_nonce"` // effective 48 bits used
-	AbsoluteFee       *float64           `meddler:"fee_usd"`
-	AbsoluteFeeUpdate *time.Time         `meddler:"usd_update,utctime"`
+	RqFee             FeeSelector        `meddler:"rq_fee,zeroisnull"`
+	RqNonce           uint64             `meddler:"rq_nonce,zeroisnull"` // effective 48 bits used
+	AbsoluteFee       float64            `meddler:"fee_usd,zeroisnull"`
+	AbsoluteFeeUpdate time.Time          `meddler:"usd_update,utctimez"`
 	Type              TxType             `meddler:"tx_type"`
 	// Extra metadata, may be uninitialized
 	RqTxCompressedData []byte `meddler:"-"` // 253 bits, optional for atomic txs
@@ -54,11 +50,11 @@ type PoolL2Tx struct {
 func NewPoolL2Tx(poolL2Tx *PoolL2Tx) (*PoolL2Tx, error) {
 	// calculate TxType
 	var txType TxType
-	if poolL2Tx.ToIdx == nil || *poolL2Tx.ToIdx == Idx(0) {
+	if poolL2Tx.ToIdx == Idx(0) {
 		txType = TxTypeTransfer
-	} else if *poolL2Tx.ToIdx == Idx(1) {
+	} else if poolL2Tx.ToIdx == Idx(1) {
 		txType = TxTypeExit
-	} else if *poolL2Tx.ToIdx >= IdxUserThreshold {
+	} else if poolL2Tx.ToIdx >= IdxUserThreshold {
 		txType = TxTypeTransfer
 	} else {
 		return poolL2Tx, fmt.Errorf("Can not determine type of PoolL2Tx, invalid ToIdx value: %d", poolL2Tx.ToIdx)
@@ -189,14 +185,8 @@ func (tx *PoolL2Tx) HashToSign() (*big.Int, error) {
 	if err != nil {
 		return nil, err
 	}
-	toEthAddr := big.NewInt(0)
-	if tx.ToEthAddr != nil {
-		toEthAddr = EthAddrToBigInt(*tx.ToEthAddr)
-	}
-	rqToEthAddr := big.NewInt(0)
-	if tx.RqToEthAddr != nil {
-		rqToEthAddr = EthAddrToBigInt(*tx.RqToEthAddr)
-	}
+	toEthAddr := EthAddrToBigInt(tx.ToEthAddr)
+	rqToEthAddr := EthAddrToBigInt(tx.RqToEthAddr)
 	toBJJAy := tx.ToBJJ.Y
 	rqTxCompressedDataV2, err := tx.TxCompressedDataV2()
 	if err != nil {
@@ -217,31 +207,22 @@ func (tx *PoolL2Tx) VerifySignature(pk *babyjub.PublicKey) bool {
 
 // L2Tx returns a *L2Tx from the PoolL2Tx
 func (tx *PoolL2Tx) L2Tx() (*L2Tx, error) {
-	if tx.ToIdx == nil || tx.BatchNum == nil {
-		return nil, errors.New("PoolL2Tx must have ToIdx != nil and BatchNum != nil in order to be able to transform to Tx")
-	}
 	return &L2Tx{
-		TxID:     tx.TxID,
-		BatchNum: *tx.BatchNum,
-		FromIdx:  tx.FromIdx,
-		ToIdx:    *tx.ToIdx,
-		Amount:   tx.Amount,
-		Fee:      tx.Fee,
-		Nonce:    tx.Nonce,
-		Type:     tx.Type,
+		TxID:    tx.TxID,
+		FromIdx: tx.FromIdx,
+		ToIdx:   tx.ToIdx,
+		Amount:  tx.Amount,
+		Fee:     tx.Fee,
+		Nonce:   tx.Nonce,
+		Type:    tx.Type,
 	}, nil
 }
 
 // Tx returns a *Tx from the PoolL2Tx
 func (tx *PoolL2Tx) Tx() (*Tx, error) {
-	if tx.ToIdx == nil {
-		return nil, errors.New("PoolL2Tx must have ToIdx != nil in order to be able to transform to Tx")
-	}
-	fromIdx := new(Idx)
-	*fromIdx = tx.FromIdx
 	return &Tx{
 		TxID:    tx.TxID,
-		FromIdx: fromIdx,
+		FromIdx: tx.FromIdx,
 		ToIdx:   tx.ToIdx,
 		Amount:  tx.Amount,
 		Nonce:   &tx.Nonce,

--- a/common/pooll2tx_test.go
+++ b/common/pooll2tx_test.go
@@ -11,11 +11,9 @@ import (
 )
 
 func TestNewPoolL2Tx(t *testing.T) {
-	toIdx := new(Idx)
-	*toIdx = 300
 	poolL2Tx := &PoolL2Tx{
 		FromIdx: 87654,
-		ToIdx:   toIdx,
+		ToIdx:   300,
 		Amount:  big.NewInt(4),
 		TokenID: 5,
 		Nonce:   144,
@@ -29,11 +27,9 @@ func TestTxCompressedData(t *testing.T) {
 	var sk babyjub.PrivateKey
 	_, err := hex.Decode(sk[:], []byte("0001020304050607080900010203040506070809000102030405060708090001"))
 	assert.Nil(t, err)
-	toIdx := new(Idx)
-	*toIdx = 3
 	tx := PoolL2Tx{
 		FromIdx: 2,
-		ToIdx:   toIdx,
+		ToIdx:   3,
 		Amount:  big.NewInt(4),
 		TokenID: 5,
 		Nonce:   6,
@@ -48,10 +44,9 @@ func TestTxCompressedData(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, expected.Bytes(), txCompressedData.Bytes())
 	assert.Equal(t, "10000000000060000000500040000000000030000000000020001c60be60f", hex.EncodeToString(txCompressedData.Bytes())[1:])
-	*toIdx = 8
 	tx = PoolL2Tx{
 		FromIdx: 7,
-		ToIdx:   toIdx,
+		ToIdx:   8,
 		Amount:  big.NewInt(9),
 		TokenID: 10,
 		Nonce:   11,
@@ -73,17 +68,14 @@ func TestHashToSign(t *testing.T) {
 	var sk babyjub.PrivateKey
 	_, err := hex.Decode(sk[:], []byte("0001020304050607080900010203040506070809000102030405060708090001"))
 	assert.Nil(t, err)
-	ethAddr := ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370")
-	toIdx := new(Idx)
-	*toIdx = 3
 	tx := PoolL2Tx{
 		FromIdx:     2,
-		ToIdx:       toIdx,
+		ToIdx:       3,
 		Amount:      big.NewInt(4),
 		TokenID:     5,
 		Nonce:       6,
 		ToBJJ:       sk.Public(),
-		RqToEthAddr: &ethAddr,
+		RqToEthAddr: ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),
 		RqToBJJ:     sk.Public(),
 	}
 	toSign, err := tx.HashToSign()
@@ -95,17 +87,14 @@ func TestVerifyTxSignature(t *testing.T) {
 	var sk babyjub.PrivateKey
 	_, err := hex.Decode(sk[:], []byte("0001020304050607080900010203040506070809000102030405060708090001"))
 	assert.Nil(t, err)
-	ethAddr := ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370")
-	toIdx := new(Idx)
-	*toIdx = 3
 	tx := PoolL2Tx{
 		FromIdx:     2,
-		ToIdx:       toIdx,
+		ToIdx:       3,
 		Amount:      big.NewInt(4),
 		TokenID:     5,
 		Nonce:       6,
 		ToBJJ:       sk.Public(),
-		RqToEthAddr: &ethAddr,
+		RqToEthAddr: ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),
 		RqToBJJ:     sk.Public(),
 	}
 	toSign, err := tx.HashToSign()

--- a/common/token.go
+++ b/common/token.go
@@ -20,8 +20,6 @@ type Token struct {
 	Name        string            `json:"name" meddler:"name"`
 	Symbol      string            `json:"symbol" meddler:"symbol"`
 	Decimals    uint64            `json:"decimals" meddler:"decimals"`
-	USD         *float64          `json:"USD" meddler:"usd"`
-	USDUpdate   *time.Time        `json:"fiatUpdate" meddler:"usd_update,utctime"`
 }
 
 // TokenInfo provides the price of the token in USD

--- a/common/tx.go
+++ b/common/tx.go
@@ -3,7 +3,6 @@ package common
 import (
 	"database/sql/driver"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -84,14 +83,15 @@ const (
 )
 
 // Tx is a struct used by the TxSelector & BatchBuilder as a generic type generated from L1Tx & PoolL2Tx
+// TODO: this should be changed for "mini Tx"
 type Tx struct {
 	// Generic
 	IsL1        bool      `meddler:"is_l1"`
 	TxID        TxID      `meddler:"id"`
 	Type        TxType    `meddler:"type"`
 	Position    int       `meddler:"position"`
-	FromIdx     *Idx      `meddler:"from_idx"`
-	ToIdx       *Idx      `meddler:"to_idx"`
+	FromIdx     Idx       `meddler:"from_idx"`
+	ToIdx       Idx       `meddler:"to_idx"`
 	Amount      *big.Int  `meddler:"amount,bigint"`
 	AmountFloat float64   `meddler:"amount_f"`
 	TokenID     TokenID   `meddler:"token_id"`
@@ -101,7 +101,7 @@ type Tx struct {
 	// L1
 	ToForgeL1TxsNum *int64             `meddler:"to_forge_l1_txs_num"` // toForgeL1TxsNum in which the tx was forged / will be forged
 	UserOrigin      *bool              `meddler:"user_origin"`         // true if the tx was originated by a user, false if it was aoriginated by a coordinator. Note that this differ from the spec for implementation simplification purpposes
-	FromEthAddr     *ethCommon.Address `meddler:"from_eth_addr"`
+	FromEthAddr     ethCommon.Address  `meddler:"from_eth_addr"`
 	FromBJJ         *babyjub.PublicKey `meddler:"from_bjj"`
 	LoadAmount      *big.Int           `meddler:"load_amount,bigintnull"`
 	LoadAmountFloat *float64           `meddler:"load_amount_f"`
@@ -114,18 +114,15 @@ type Tx struct {
 
 // L1Tx returns a *L1Tx from the Tx
 func (tx *Tx) L1Tx() (*L1Tx, error) {
-	if tx.UserOrigin == nil || tx.FromEthAddr == nil {
-		return nil, errors.New("Tx must have UserOrigin != nil and FromEthAddr != nil in order to be able to transform to L1Tx")
-	}
 	return &L1Tx{
 		TxID:            tx.TxID,
 		ToForgeL1TxsNum: tx.ToForgeL1TxsNum,
 		Position:        tx.Position,
 		UserOrigin:      *tx.UserOrigin,
 		FromIdx:         tx.FromIdx,
-		FromEthAddr:     *tx.FromEthAddr,
+		FromEthAddr:     tx.FromEthAddr,
 		FromBJJ:         tx.FromBJJ,
-		ToIdx:           *tx.ToIdx,
+		ToIdx:           tx.ToIdx,
 		TokenID:         tx.TokenID,
 		Amount:          tx.Amount,
 		LoadAmount:      tx.LoadAmount,

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -3,7 +3,6 @@ package historydb
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hermeznetwork/hermez-node/common"
 	dbUtils "github.com/hermeznetwork/hermez-node/db"
@@ -157,12 +156,8 @@ func TestTokens(t *testing.T) {
 		assert.Equal(t, tokens[i].EthAddr, token.EthAddr)
 		assert.Equal(t, tokens[i].Name, token.Name)
 		assert.Equal(t, tokens[i].Symbol, token.Symbol)
-		assert.Equal(t, tokens[i].USD, token.USD)
-		if token.USDUpdate != nil {
-			assert.Greater(t, int64(1*time.Second), int64(time.Since(*token.USDUpdate)))
-		} else {
-			assert.Equal(t, tokens[i].USDUpdate, token.USDUpdate)
-		}
+		assert.Nil(t, token.USD)
+		assert.Nil(t, token.USDUpdate)
 	}
 }
 
@@ -218,6 +213,7 @@ func TestTxs(t *testing.T) {
 
 	/*
 		Uncomment once the transaction generation is fixed
+		!! Missing tests to check that historic USD is not set if USDUpdate is too old (24h) !!
 
 		// Generate fake L1 txs
 		const nL1s = 64

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -20,18 +20,17 @@ type HistoryTx struct {
 	FromIdx     *common.Idx      `meddler:"from_idx"`
 	ToIdx       common.Idx       `meddler:"to_idx"`
 	Amount      *big.Int         `meddler:"amount,bigint"`
-	AmountFloat float64          `meddler:"amount_f"`
 	HistoricUSD *float64         `meddler:"amount_usd"`
 	BatchNum    *common.BatchNum `meddler:"batch_num"`     // batchNum in which this tx was forged. If the tx is L2, this must be != 0
 	EthBlockNum int64            `meddler:"eth_block_num"` // Ethereum Block Number in which this L1Tx was added to the queue
 	// L1
-	ToForgeL1TxsNum       *int64             `meddler:"to_forge_l1_txs_num"` // toForgeL1TxsNum in which the tx was forged / will be forged
-	UserOrigin            *bool              `meddler:"user_origin"`         // true if the tx was originated by a user, false if it was aoriginated by a coordinator. Note that this differ from the spec for implementation simplification purpposes
-	FromEthAddr           *ethCommon.Address `meddler:"from_eth_addr"`
-	FromBJJ               *babyjub.PublicKey `meddler:"from_bjj"`
-	LoadAmount            *big.Int           `meddler:"load_amount,bigintnull"`
-	LoadAmountFloat       *float64           `meddler:"load_amount_f"`
-	HistoricLoadAmountUSD *float64           `meddler:"load_amount_usd"`
+	ToForgeL1TxsNum *int64             `meddler:"to_forge_l1_txs_num"` // toForgeL1TxsNum in which the tx was forged / will be forged
+	UserOrigin      *bool              `meddler:"user_origin"`         // true if the tx was originated by a user, false if it was aoriginated by a coordinator. Note that this differ from the spec for implementation simplification purpposes
+	FromEthAddr     *ethCommon.Address `meddler:"from_eth_addr"`
+	FromBJJ         *babyjub.PublicKey `meddler:"from_bjj"`
+	LoadAmount      *big.Int           `meddler:"load_amount,bigintnull"`
+	// LoadAmountFloat       *float64           `meddler:"load_amount_f"`
+	HistoricLoadAmountUSD *float64 `meddler:"load_amount_usd"`
 	// L2
 	Fee            *common.FeeSelector `meddler:"fee"`
 	HistoricFeeUSD *float64            `meddler:"fee_usd"`
@@ -47,4 +46,43 @@ type HistoryTx struct {
 	TokenDecimals    uint64            `meddler:"decimals"`
 	TokenUSD         *float64          `meddler:"usd"`
 	TokenUSDUpdate   *time.Time        `meddler:"usd_update"`
+}
+
+// txWrite is an representatiion that merges common.L1Tx and common.L2Tx
+// in order to perform inserts into tx table
+type txWrite struct {
+	// Generic
+	IsL1        bool             `meddler:"is_l1"`
+	TxID        common.TxID      `meddler:"id"`
+	Type        common.TxType    `meddler:"type"`
+	Position    int              `meddler:"position"`
+	FromIdx     *common.Idx      `meddler:"from_idx"`
+	ToIdx       common.Idx       `meddler:"to_idx"`
+	Amount      *big.Int         `meddler:"amount,bigint"`
+	AmountFloat float64          `meddler:"amount_f"`
+	TokenID     common.TokenID   `meddler:"token_id"`
+	BatchNum    *common.BatchNum `meddler:"batch_num"`     // batchNum in which this tx was forged. If the tx is L2, this must be != 0
+	EthBlockNum int64            `meddler:"eth_block_num"` // Ethereum Block Number in which this L1Tx was added to the queue
+	// L1
+	ToForgeL1TxsNum *int64             `meddler:"to_forge_l1_txs_num"` // toForgeL1TxsNum in which the tx was forged / will be forged
+	UserOrigin      *bool              `meddler:"user_origin"`         // true if the tx was originated by a user, false if it was aoriginated by a coordinator. Note that this differ from the spec for implementation simplification purpposes
+	FromEthAddr     *ethCommon.Address `meddler:"from_eth_addr"`
+	FromBJJ         *babyjub.PublicKey `meddler:"from_bjj"`
+	LoadAmount      *big.Int           `meddler:"load_amount,bigintnull"`
+	LoadAmountFloat *float64           `meddler:"load_amount_f"`
+	// L2
+	Fee   *common.FeeSelector `meddler:"fee"`
+	Nonce *common.Nonce       `meddler:"nonce"`
+}
+
+// TokenRead add USD info to common.Token
+type TokenRead struct {
+	TokenID     common.TokenID    `json:"id" meddler:"token_id"`
+	EthBlockNum int64             `json:"ethereumBlockNum" meddler:"eth_block_num"` // Ethereum block number in which this token was registered
+	EthAddr     ethCommon.Address `json:"ethereumAddress" meddler:"eth_addr"`
+	Name        string            `json:"name" meddler:"name"`
+	Symbol      string            `json:"symbol" meddler:"symbol"`
+	Decimals    uint64            `json:"decimals" meddler:"decimals"`
+	USD         *float64          `json:"USD" meddler:"usd"`
+	USDUpdate   *time.Time        `json:"fiatUpdate" meddler:"usd_update,utctime"`
 }

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -1,0 +1,70 @@
+package l2db
+
+import (
+	"math/big"
+	"time"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/iden3/go-iden3-crypto/babyjub"
+)
+
+// PoolL2TxWrite holds the necessary data to perform inserts in tx_pool
+type PoolL2TxWrite struct {
+	TxID        common.TxID          `meddler:"tx_id"`
+	FromIdx     common.Idx           `meddler:"from_idx"`
+	ToIdx       *common.Idx          `meddler:"to_idx"`
+	ToEthAddr   *ethCommon.Address   `meddler:"to_eth_addr"`
+	ToBJJ       *babyjub.PublicKey   `meddler:"to_bjj"`
+	TokenID     common.TokenID       `meddler:"token_id"`
+	Amount      *big.Int             `meddler:"amount,bigint"`
+	AmountFloat float64              `meddler:"amount_f"`
+	Fee         common.FeeSelector   `meddler:"fee"`
+	Nonce       common.Nonce         `meddler:"nonce"`
+	State       common.PoolL2TxState `meddler:"state"`
+	Signature   *babyjub.Signature   `meddler:"signature"`
+	RqFromIdx   *common.Idx          `meddler:"rq_from_idx"`
+	RqToIdx     *common.Idx          `meddler:"rq_to_idx"`
+	RqToEthAddr *ethCommon.Address   `meddler:"rq_to_eth_addr"`
+	RqToBJJ     *babyjub.PublicKey   `meddler:"rq_to_bjj"`
+	RqTokenID   *common.TokenID      `meddler:"rq_token_id"`
+	RqAmount    *big.Int             `meddler:"rq_amount,bigintnull"`
+	RqFee       *common.FeeSelector  `meddler:"rq_fee"`
+	RqNonce     *uint64              `meddler:"rq_nonce"`
+	Type        common.TxType        `meddler:"tx_type"`
+}
+
+// PoolL2TxRead represents a L2 Tx pool with extra metadata used by the API
+type PoolL2TxRead struct {
+	TxID        common.TxID          `meddler:"tx_id"`
+	FromIdx     common.Idx           `meddler:"from_idx"`
+	ToIdx       *common.Idx          `meddler:"to_idx"`
+	ToEthAddr   *ethCommon.Address   `meddler:"to_eth_addr"`
+	ToBJJ       *babyjub.PublicKey   `meddler:"to_bjj"`
+	Amount      *big.Int             `meddler:"amount,bigint"`
+	Fee         common.FeeSelector   `meddler:"fee"`
+	Nonce       common.Nonce         `meddler:"nonce"`
+	State       common.PoolL2TxState `meddler:"state"`
+	Signature   *babyjub.Signature   `meddler:"signature"`
+	RqFromIdx   *common.Idx          `meddler:"rq_from_idx"`
+	RqToIdx     *common.Idx          `meddler:"rq_to_idx"`
+	RqToEthAddr *ethCommon.Address   `meddler:"rq_to_eth_addr"`
+	RqToBJJ     *babyjub.PublicKey   `meddler:"rq_to_bjj"`
+	RqTokenID   *common.TokenID      `meddler:"rq_token_id"`
+	RqAmount    *big.Int             `meddler:"rq_amount,bigintnull"`
+	RqFee       *common.FeeSelector  `meddler:"rq_fee"`
+	RqNonce     *uint64              `meddler:"rq_nonce"`
+	Type        common.TxType        `meddler:"tx_type"`
+	// Extra read fileds
+	BatchNum         *common.BatchNum  `meddler:"batch_num"`
+	Timestamp        time.Time         `meddler:"timestamp,utctime"`
+	TotalItems       int               `meddler:"total_items"`
+	TokenID          common.TokenID    `meddler:"token_id"`
+	TokenEthBlockNum int64             `meddler:"eth_block_num"`
+	TokenEthAddr     ethCommon.Address `meddler:"eth_addr"`
+	TokenName        string            `meddler:"name"`
+	TokenSymbol      string            `meddler:"symbol"`
+	TokenDecimals    uint64            `meddler:"decimals"`
+	TokenUSD         *float64          `meddler:"usd"`
+	TokenUSDUpdate   *time.Time        `meddler:"usd_update"`
+}

--- a/db/statedb/statedb.go
+++ b/db/statedb/statedb.go
@@ -247,19 +247,13 @@ func (s *StateDB) Reset(batchNum common.BatchNum) error {
 }
 
 // GetAccount returns the account for the given Idx
-func (s *StateDB) GetAccount(idx *common.Idx) (*common.Account, error) {
-	if idx == nil {
-		return nil, errors.New("idx cannot be nil")
-	}
+func (s *StateDB) GetAccount(idx common.Idx) (*common.Account, error) {
 	return getAccountInTreeDB(s.db, idx)
 }
 
 // getAccountInTreeDB is abstracted from StateDB to be used from StateDB and
 // from ExitTree.  GetAccount returns the account for the given Idx
-func getAccountInTreeDB(sto db.Storage, idx *common.Idx) (*common.Account, error) {
-	if idx == nil {
-		return nil, errors.New("idx cannot be nil")
-	}
+func getAccountInTreeDB(sto db.Storage, idx common.Idx) (*common.Account, error) {
 	idxBytes, err := idx.Bytes()
 	if err != nil {
 		return nil, err
@@ -281,12 +275,12 @@ func getAccountInTreeDB(sto db.Storage, idx *common.Idx) (*common.Account, error
 // StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
 // MerkleTree, returning a CircomProcessorProof.
 func (s *StateDB) CreateAccount(idx common.Idx, account *common.Account) (*merkletree.CircomProcessorProof, error) {
-	cpp, err := createAccountInTreeDB(s.db, s.mt, &idx, account)
+	cpp, err := createAccountInTreeDB(s.db, s.mt, idx, account)
 	if err != nil {
 		return cpp, err
 	}
 	// store idx by EthAddr & BJJ
-	err = s.setIdxByEthAddrBJJ(idx, &account.EthAddr, account.PublicKey)
+	err = s.setIdxByEthAddrBJJ(idx, account.EthAddr, account.PublicKey)
 	return cpp, err
 }
 
@@ -294,10 +288,7 @@ func (s *StateDB) CreateAccount(idx common.Idx, account *common.Account) (*merkl
 // from ExitTree.  Creates a new Account in the StateDB for the given Idx.  If
 // StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
 // MerkleTree, returning a CircomProcessorProof.
-func createAccountInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx *common.Idx, account *common.Account) (*merkletree.CircomProcessorProof, error) {
-	if idx == nil {
-		return nil, errors.New("idx cannot be nil")
-	}
+func createAccountInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.Idx, account *common.Account) (*merkletree.CircomProcessorProof, error) {
 	// store at the DB the key: v, and value: leaf.Bytes()
 	v, err := account.HashValue()
 	if err != nil {
@@ -346,10 +337,7 @@ func createAccountInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx *commo
 // UpdateAccount updates the Account in the StateDB for the given Idx.  If
 // StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
 // MerkleTree, returning a CircomProcessorProof.
-func (s *StateDB) UpdateAccount(idx *common.Idx, account *common.Account) (*merkletree.CircomProcessorProof, error) {
-	if idx == nil {
-		return nil, errors.New("idx cannot be nil")
-	}
+func (s *StateDB) UpdateAccount(idx common.Idx, account *common.Account) (*merkletree.CircomProcessorProof, error) {
 	return updateAccountInTreeDB(s.db, s.mt, idx, account)
 }
 
@@ -357,10 +345,7 @@ func (s *StateDB) UpdateAccount(idx *common.Idx, account *common.Account) (*merk
 // from ExitTree.  Updates the Account in the StateDB for the given Idx.  If
 // StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
 // MerkleTree, returning a CircomProcessorProof.
-func updateAccountInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx *common.Idx, account *common.Account) (*merkletree.CircomProcessorProof, error) {
-	if idx == nil {
-		return nil, errors.New("idx cannot be nil")
-	}
+func updateAccountInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.Idx, account *common.Account) (*merkletree.CircomProcessorProof, error) {
 	// store at the DB the key: v, and value: account.Bytes()
 	v, err := account.HashValue()
 	if err != nil {

--- a/db/statedb/statedb_test.go
+++ b/db/statedb/statedb_test.go
@@ -130,7 +130,7 @@ func TestStateDBWithoutMT(t *testing.T) {
 
 	// get non-existing account, expecting an error
 	unexistingAccount := common.Idx(1)
-	_, err = sdb.GetAccount(&unexistingAccount)
+	_, err = sdb.GetAccount(unexistingAccount)
 	assert.NotNil(t, err)
 	assert.Equal(t, db.ErrNotFound, err)
 
@@ -142,14 +142,14 @@ func TestStateDBWithoutMT(t *testing.T) {
 
 	for i := 0; i < len(accounts); i++ {
 		existingAccount := common.Idx(i)
-		accGetted, err := sdb.GetAccount(&existingAccount)
+		accGetted, err := sdb.GetAccount(existingAccount)
 		assert.Nil(t, err)
 		assert.Equal(t, accounts[i], accGetted)
 	}
 
 	// try already existing idx and get error
 	existingAccount := common.Idx(1)
-	_, err = sdb.GetAccount(&existingAccount) // check that exist
+	_, err = sdb.GetAccount(existingAccount) // check that exist
 	assert.Nil(t, err)
 	_, err = sdb.CreateAccount(common.Idx(1), accounts[1]) // check that can not be created twice
 	assert.NotNil(t, err)
@@ -159,7 +159,7 @@ func TestStateDBWithoutMT(t *testing.T) {
 	for i := 0; i < len(accounts); i++ {
 		accounts[i].Nonce = accounts[i].Nonce + 1
 		existingAccount = common.Idx(i)
-		_, err = sdb.UpdateAccount(&existingAccount, accounts[i])
+		_, err = sdb.UpdateAccount(existingAccount, accounts[i])
 		assert.Nil(t, err)
 	}
 
@@ -182,8 +182,7 @@ func TestStateDBWithMT(t *testing.T) {
 	}
 
 	// get non-existing account, expecting an error
-	accountIdx := common.Idx(1)
-	_, err = sdb.GetAccount(&accountIdx)
+	_, err = sdb.GetAccount(common.Idx(1))
 	assert.NotNil(t, err)
 	assert.Equal(t, db.ErrNotFound, err)
 
@@ -194,15 +193,13 @@ func TestStateDBWithMT(t *testing.T) {
 	}
 
 	for i := 0; i < len(accounts); i++ {
-		accountIdx = common.Idx(i)
-		accGetted, err := sdb.GetAccount(&accountIdx)
+		accGetted, err := sdb.GetAccount(common.Idx(i))
 		assert.Nil(t, err)
 		assert.Equal(t, accounts[i], accGetted)
 	}
 
 	// try already existing idx and get error
-	accountIdx = 1
-	_, err = sdb.GetAccount(&accountIdx) // check that exist
+	_, err = sdb.GetAccount(common.Idx(1)) // check that exist
 	assert.Nil(t, err)
 	_, err = sdb.CreateAccount(common.Idx(1), accounts[1]) // check that can not be created twice
 	assert.NotNil(t, err)
@@ -214,12 +211,10 @@ func TestStateDBWithMT(t *testing.T) {
 	// update accounts
 	for i := 0; i < len(accounts); i++ {
 		accounts[i].Nonce = accounts[i].Nonce + 1
-		accountIdx = common.Idx(i)
-		_, err = sdb.UpdateAccount(&accountIdx, accounts[i])
+		_, err = sdb.UpdateAccount(common.Idx(i), accounts[i])
 		assert.Nil(t, err)
 	}
-	accountIdx = 1
-	a, err := sdb.GetAccount(&accountIdx) // check that account value has been updated
+	a, err := sdb.GetAccount(common.Idx(1)) // check that account value has been updated
 	assert.Nil(t, err)
 	assert.Equal(t, accounts[1].Nonce, a.Nonce)
 }

--- a/db/statedb/txprocessors_test.go
+++ b/db/statedb/txprocessors_test.go
@@ -40,8 +40,7 @@ func TestProcessTxs(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	accountIdx := common.Idx(256)
-	acc, err := sdb.GetAccount(&accountIdx)
+	acc, err := sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "23", acc.Balance.String())
 }
@@ -80,8 +79,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	// Nonce & TokenID =0, after ProcessTxs call has the expected value
 
 	assert.Equal(t, 0, len(exitInfos))
-	accountIdx := common.Idx(256)
-	acc, err := sdb.GetAccount(&accountIdx)
+	acc, err := sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "28", acc.Balance.String())
 
@@ -90,7 +88,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	_, exitInfos, err = sdb.ProcessTxs(l1Txs[1], coordinatorL1Txs[1], poolL2Txs[1])
 	require.Nil(t, err)
 	assert.Equal(t, 5, len(exitInfos))
-	acc, err = sdb.GetAccount(&accountIdx)
+	acc, err = sdb.GetAccount(common.Idx(256))
 	require.Nil(t, err)
 	assert.Equal(t, "48", acc.Balance.String())
 
@@ -99,7 +97,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	_, exitInfos, err = sdb.ProcessTxs(l1Txs[2], coordinatorL1Txs[2], poolL2Txs[2])
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(exitInfos))
-	acc, err = sdb.GetAccount(&accountIdx)
+	acc, err = sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "23", acc.Balance.String())
 }
@@ -132,8 +130,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 	_, exitInfos, err := sdb.ProcessTxs(l1Txs[0], coordinatorL1Txs[0], poolL2Txs[0])
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(exitInfos))
-	accountIdx := common.Idx(256)
-	acc, err := sdb.GetAccount(&accountIdx)
+	acc, err := sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "28", acc.Balance.String())
 
@@ -142,7 +139,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 	_, exitInfos, err = sdb.ProcessTxs(l1Txs[1], coordinatorL1Txs[1], poolL2Txs[1])
 	require.Nil(t, err)
 	assert.Equal(t, 5, len(exitInfos))
-	acc, err = sdb.GetAccount(&accountIdx)
+	acc, err = sdb.GetAccount(common.Idx(256))
 	require.Nil(t, err)
 	assert.Equal(t, "48", acc.Balance.String())
 
@@ -151,7 +148,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 	_, exitInfos, err = sdb.ProcessTxs(l1Txs[2], coordinatorL1Txs[2], poolL2Txs[2])
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(exitInfos))
-	acc, err = sdb.GetAccount(&accountIdx)
+	acc, err = sdb.GetAccount(common.Idx(256))
 	assert.Nil(t, err)
 	assert.Equal(t, "23", acc.Balance.String())
 }

--- a/db/statedb/utils.go
+++ b/db/statedb/utils.go
@@ -2,7 +2,6 @@ package statedb
 
 import (
 	"bytes"
-	"errors"
 	"math/big"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -12,7 +11,7 @@ import (
 	"github.com/iden3/go-merkletree"
 )
 
-func concatEthAddrBJJ(addr *ethCommon.Address, pk *babyjub.PublicKey) []byte {
+func concatEthAddrBJJ(addr ethCommon.Address, pk *babyjub.PublicKey) []byte {
 	pkComp := pk.Compress()
 	var b []byte
 	b = append(b, addr.Bytes()...)
@@ -25,7 +24,7 @@ func concatEthAddrBJJ(addr *ethCommon.Address, pk *babyjub.PublicKey) []byte {
 // - key: EthAddr & BabyJubJub PublicKey Compressed, value: idx
 // If Idx already exist for the given EthAddr & BJJ, the remaining Idx will be
 // always the smallest one.
-func (s *StateDB) setIdxByEthAddrBJJ(idx common.Idx, addr *ethCommon.Address, pk *babyjub.PublicKey) error {
+func (s *StateDB) setIdxByEthAddrBJJ(idx common.Idx, addr ethCommon.Address, pk *babyjub.PublicKey) error {
 	oldIdx, err := s.GetIdxByEthAddrBJJ(addr, pk)
 	if err == nil {
 		// EthAddr & BJJ already have an Idx
@@ -71,10 +70,7 @@ func (s *StateDB) setIdxByEthAddrBJJ(idx common.Idx, addr *ethCommon.Address, pk
 // GetIdxByEthAddr returns the smallest Idx in the StateDB for the given
 // Ethereum Address. Will return common.Idx(0) and error in case that Idx is
 // not found in the StateDB.
-func (s *StateDB) GetIdxByEthAddr(addr *ethCommon.Address) (common.Idx, error) {
-	if addr == nil {
-		return 0, errors.New("addr cannot be nil")
-	}
+func (s *StateDB) GetIdxByEthAddr(addr ethCommon.Address) (common.Idx, error) {
 	b, err := s.db.Get(addr.Bytes())
 	if err != nil {
 		return common.Idx(0), ErrToIdxNotFound
@@ -91,10 +87,7 @@ func (s *StateDB) GetIdxByEthAddr(addr *ethCommon.Address) (common.Idx, error) {
 // address, it's ignored in the query.  If `pk` is nil, it's ignored in the
 // query.  Will return common.Idx(0) and error in case that Idx is not found in
 // the StateDB.
-func (s *StateDB) GetIdxByEthAddrBJJ(addr *ethCommon.Address, pk *babyjub.PublicKey) (common.Idx, error) {
-	if addr == nil {
-		return 0, errors.New("addr cannot be nil")
-	}
+func (s *StateDB) GetIdxByEthAddrBJJ(addr ethCommon.Address, pk *babyjub.PublicKey) (common.Idx, error) {
 	if !bytes.Equal(addr.Bytes(), common.EmptyAddr.Bytes()) && pk == nil {
 		// case ToEthAddr!=0 && ToBJJ=0
 		return s.GetIdxByEthAddr(addr)

--- a/db/statedb/utils_test.go
+++ b/db/statedb/utils_test.go
@@ -32,47 +32,47 @@ func TestGetIdx(t *testing.T) {
 	idx3 := common.Idx(1233)
 
 	// store the keys for idx by Addr & BJJ
-	err = sdb.setIdxByEthAddrBJJ(idx, &addr, pk)
+	err = sdb.setIdxByEthAddrBJJ(idx, addr, pk)
 	require.Nil(t, err)
 
-	idxR, err := sdb.GetIdxByEthAddrBJJ(&addr, pk)
+	idxR, err := sdb.GetIdxByEthAddrBJJ(addr, pk)
 	assert.Nil(t, err)
 	assert.Equal(t, idx, idxR)
 
 	// expect error when getting only by EthAddr, as value does not exist
 	// in the db for only EthAddr
-	_, err = sdb.GetIdxByEthAddr(&addr)
+	_, err = sdb.GetIdxByEthAddr(addr)
 	assert.Nil(t, err)
-	_, err = sdb.GetIdxByEthAddr(&addr2)
+	_, err = sdb.GetIdxByEthAddr(addr2)
 	assert.NotNil(t, err)
 
 	// expect to fail
-	idxR, err = sdb.GetIdxByEthAddrBJJ(&addr2, pk)
+	idxR, err = sdb.GetIdxByEthAddrBJJ(addr2, pk)
 	assert.NotNil(t, err)
 	assert.Equal(t, common.Idx(0), idxR)
-	idxR, err = sdb.GetIdxByEthAddrBJJ(&addr, pk2)
+	idxR, err = sdb.GetIdxByEthAddrBJJ(addr, pk2)
 	assert.NotNil(t, err)
 	assert.Equal(t, common.Idx(0), idxR)
 
 	// try to store bigger idx, will not affect as already exist a smaller
 	// Idx for that Addr & BJJ
-	err = sdb.setIdxByEthAddrBJJ(idx2, &addr, pk)
+	err = sdb.setIdxByEthAddrBJJ(idx2, addr, pk)
 	assert.Nil(t, err)
 
 	// store smaller idx
-	err = sdb.setIdxByEthAddrBJJ(idx3, &addr, pk)
+	err = sdb.setIdxByEthAddrBJJ(idx3, addr, pk)
 	assert.Nil(t, err)
 
-	idxR, err = sdb.GetIdxByEthAddrBJJ(&addr, pk)
+	idxR, err = sdb.GetIdxByEthAddrBJJ(addr, pk)
 	assert.Nil(t, err)
 	assert.Equal(t, idx3, idxR)
 
 	// by EthAddr should work
-	idxR, err = sdb.GetIdxByEthAddr(&addr)
+	idxR, err = sdb.GetIdxByEthAddr(addr)
 	assert.Nil(t, err)
 	assert.Equal(t, idx3, idxR)
 	// expect error when trying to get Idx by addr2 & pk2
-	idxR, err = sdb.GetIdxByEthAddrBJJ(&addr2, pk2)
+	idxR, err = sdb.GetIdxByEthAddrBJJ(addr2, pk2)
 	assert.NotNil(t, err)
 	assert.Equal(t, ErrToIdxNotFound, err)
 	assert.Equal(t, common.Idx(0), idxR)

--- a/test/ethclient.go
+++ b/test/ethclient.go
@@ -591,7 +591,7 @@ func (c *Client) CtlAddL1TxUser(l1Tx *common.L1Tx) {
 		r.State.MapL1TxQueue[r.State.LastToForgeL1TxsNum] = eth.NewQueueStruct()
 		queue = r.State.MapL1TxQueue[r.State.LastToForgeL1TxsNum]
 	}
-	if l1Tx.FromIdx != nil && int64(*l1Tx.FromIdx) > r.State.CurrentIdx {
+	if int64(l1Tx.FromIdx) > r.State.CurrentIdx {
 		panic("l1Tx.FromIdx > r.State.CurrentIdx")
 	}
 	if int(l1Tx.TokenID)+1 > len(r.State.TokenList) {

--- a/test/ethclient_test.go
+++ b/test/ethclient_test.go
@@ -155,7 +155,7 @@ func TestClientRollup(t *testing.T) {
 	for i := 0; i < N; i++ {
 		keys[i] = genKeys(int64(i))
 		l1UserTx := common.L1Tx{
-			FromIdx:     nil,
+			FromIdx:     0,
 			FromEthAddr: keys[i].Addr,
 			FromBJJ:     keys[i].BJJPublicKey,
 			TokenID:     common.TokenID(0),

--- a/test/l2db.go
+++ b/test/l2db.go
@@ -42,37 +42,19 @@ func GenPoolTxs(n int, tokens []common.Token) []*common.PoolL2Tx {
 		} else if i%4 == 3 {
 			state = common.PoolL2TxStateForged
 		}
-		f := new(big.Float).SetInt(big.NewInt(int64(i)))
-		amountF, _ := f.Float64()
-		var usd, absFee *float64
 		fee := common.FeeSelector(i % 255) //nolint:gomnd
 		token := tokens[i%len(tokens)]
-		if token.USD != nil {
-			usd = new(float64)
-			absFee = new(float64)
-			*usd = *token.USD * amountF
-			*absFee = fee.Percentage() * *usd
-		}
-		toIdx := new(common.Idx)
-		*toIdx = common.Idx(i + 1)
-		toEthAddr := new(ethCommon.Address)
-		*toEthAddr = ethCommon.BigToAddress(big.NewInt(int64(i)))
 		tx := &common.PoolL2Tx{
-			FromIdx:           common.Idx(i),
-			ToIdx:             toIdx,
-			ToEthAddr:         toEthAddr,
-			ToBJJ:             privK.Public(),
-			TokenID:           token.TokenID,
-			Amount:            big.NewInt(int64(i)),
-			AmountFloat:       amountF,
-			USD:               usd,
-			Fee:               fee,
-			Nonce:             common.Nonce(i),
-			State:             state,
-			Signature:         privK.SignPoseidon(big.NewInt(int64(i))),
-			Timestamp:         time.Now().UTC(),
-			AbsoluteFee:       absFee,
-			AbsoluteFeeUpdate: token.USDUpdate,
+			FromIdx:   common.Idx(i),
+			ToIdx:     common.Idx(i + 1),
+			ToEthAddr: ethCommon.BigToAddress(big.NewInt(int64(i))),
+			ToBJJ:     privK.Public(),
+			TokenID:   token.TokenID,
+			Amount:    big.NewInt(int64(i)),
+			Fee:       fee,
+			Nonce:     common.Nonce(i),
+			State:     state,
+			Signature: privK.SignPoseidon(big.NewInt(int64(i))),
 		}
 		var err error
 		tx, err = common.NewPoolL2Tx(tx)
@@ -80,31 +62,14 @@ func GenPoolTxs(n int, tokens []common.Token) []*common.PoolL2Tx {
 			panic(err)
 		}
 		if i%2 == 0 { // Optional parameters: rq
-			rqFromIdx := new(common.Idx)
-			*rqFromIdx = common.Idx(i)
-			tx.RqFromIdx = rqFromIdx
-			rqToIdx := new(common.Idx)
-			*rqToIdx = common.Idx(i + 1)
-			tx.RqToIdx = rqToIdx
-			rqToEthAddr := new(ethCommon.Address)
-			*rqToEthAddr = ethCommon.BigToAddress(big.NewInt(int64(i)))
-			tx.RqToEthAddr = rqToEthAddr
+			tx.RqFromIdx = common.Idx(i)
+			tx.RqToIdx = common.Idx(i + 1)
+			tx.RqToEthAddr = ethCommon.BigToAddress(big.NewInt(int64(i)))
 			tx.RqToBJJ = privK.Public()
-			rqTokenID := new(common.TokenID)
-			*rqTokenID = common.TokenID(i)
-			tx.RqTokenID = rqTokenID
+			tx.RqTokenID = common.TokenID(i)
 			tx.RqAmount = big.NewInt(int64(i))
-			rqFee := new(common.FeeSelector)
-			*rqFee = common.FeeSelector(i)
-			tx.RqFee = rqFee
-			rqNonce := new(uint64)
-			*rqNonce = uint64(i)
-			tx.RqNonce = rqNonce
-		}
-		if i%3 == 0 { // Optional parameters: things that get updated "a posteriori"
-			batchNum := new(common.BatchNum)
-			*batchNum = 489
-			tx.BatchNum = batchNum
+			tx.RqFee = common.FeeSelector(i)
+			tx.RqNonce = uint64(i)
 		}
 		txs = append(txs, tx)
 	}

--- a/test/txs.go
+++ b/test/txs.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
@@ -97,25 +96,17 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]common.L1Tx, 
 				batchCoordinatorL1Txs = append(batchCoordinatorL1Txs, tx)
 				idx++
 			}
-			toIdx := new(common.Idx)
-			*toIdx = accounts[idxTokenIDToString(inst.To, inst.TokenID)].Idx
-			toEthAddr := new(ethCommon.Address)
-			*toEthAddr = accounts[idxTokenIDToString(inst.To, inst.TokenID)].Addr
-			rqToEthAddr := new(ethCommon.Address)
-			*rqToEthAddr = accounts[idxTokenIDToString(inst.To, inst.TokenID)].Addr
 			tx := common.PoolL2Tx{
 				FromIdx:     accounts[idxTokenIDToString(inst.From, inst.TokenID)].Idx,
-				ToIdx:       toIdx,
-				ToEthAddr:   toEthAddr,
+				ToIdx:       accounts[idxTokenIDToString(inst.To, inst.TokenID)].Idx,
+				ToEthAddr:   accounts[idxTokenIDToString(inst.To, inst.TokenID)].Addr,
 				ToBJJ:       accounts[idxTokenIDToString(inst.To, inst.TokenID)].BJJ.Public(),
 				TokenID:     inst.TokenID,
 				Amount:      big.NewInt(int64(inst.Amount)),
 				Fee:         common.FeeSelector(inst.Fee),
 				Nonce:       accounts[idxTokenIDToString(inst.From, inst.TokenID)].Nonce,
 				State:       common.PoolL2TxStatePending,
-				Timestamp:   time.Now(),
-				BatchNum:    nil,
-				RqToEthAddr: rqToEthAddr,
+				RqToEthAddr: accounts[idxTokenIDToString(inst.To, inst.TokenID)].Addr,
 				RqToBJJ:     accounts[idxTokenIDToString(inst.To, inst.TokenID)].BJJ.Public(),
 				Type:        common.TxTypeTransfer,
 			}
@@ -136,10 +127,8 @@ func GenerateTestTxs(t *testing.T, instructions Instructions) ([][]common.L1Tx, 
 			batchPoolL2Txs = append(batchPoolL2Txs, tx)
 
 		case common.TxTypeExit, common.TxTypeForceExit:
-			fromIdx := new(common.Idx)
-			*fromIdx = accounts[idxTokenIDToString(inst.From, inst.TokenID)].Idx
 			tx := common.L1Tx{
-				FromIdx: fromIdx,
+				FromIdx: accounts[idxTokenIDToString(inst.From, inst.TokenID)].Idx,
 				ToIdx:   common.Idx(1), // as is an Exit
 				TokenID: inst.TokenID,
 				Amount:  big.NewInt(int64(inst.Amount)),

--- a/test/txs_test.go
+++ b/test/txs_test.go
@@ -50,7 +50,7 @@ func TestGenerateTestL2Txs(t *testing.T) {
 	// l2txs
 	assert.Equal(t, common.TxTypeTransfer, l2txs[0][0].Type)
 	assert.Equal(t, common.Idx(256), l2txs[0][0].FromIdx)
-	assert.Equal(t, common.Idx(258), *l2txs[0][0].ToIdx)
+	assert.Equal(t, common.Idx(258), l2txs[0][0].ToIdx)
 	assert.Equal(t, accounts["B1"].BJJ.Public().String(), l2txs[0][0].ToBJJ.String())
 	assert.Equal(t, accounts["B1"].Addr.Hex(), l2txs[0][0].ToEthAddr.Hex())
 	assert.Equal(t, common.Nonce(0), l2txs[0][0].Nonce)


### PR DESCRIPTION
`DB` == `historydb` + `l2db`

- Avoid using `nil` in `common` structs
- Stop using `common.Tx` at `api` and `DB`
- Change strategy for reading / writing to `DB`:
    - Structs to read / write the `DB` will be defined in `DB`. Exception of that is when `common` structs match perfectly with the related table schemas in the `DB`.
    - When possible, the interfaces of the `DB` will use structs defined in `common` as in/out params. This means that is preferred to transform from `common.Foo` to `DB.FooWrite` within the `DB` functions.   
- Implements a solution for #184 but it's missing tests, so not closing
- Use defaults instead of triggers for seting timestamps in `DB`

In general, some `common` structs are lighter since they dropped some extra fields. Those fields will be used in other structs that are used in specific context (such as the `api`) and defined in `DB`