### PR TITLE
Update Synchronizer (node) implementation

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -18,15 +18,17 @@ URL = "http://localhost:8545"
 
 [Synchronizer]
 SyncLoopInterval = "1s"
+
     [Synchronizer.StartBlockNum]
     Rollup = 1
     Auction = 1
     WDelayer = 1
 
 [SmartContracts]
-Rollup   = "0xD6C850aeBFDC46D7F4c207e445cC0d6B0919BDBe"
-Auction  = "0x038B86d9d8FAFdd0a02ebd1A476432877b0107C8"
-TokenHEZ = "0xf4e77E5Da47AC3125140c470c71cBca77B5c638c"
+Rollup   = "0x6F4e99522F4eB37e0B73D0C0373147893EF12fD5"
+Auction  = "0x5E0816F0f8bC560cB2B9e9C87187BeCac8c2021F"
+WDelayer = "0x5D94e3e7aeC542aB0F9129B9a7BAdeb5B3Ca0f77"
+TokenHEZ = "0x2b7dEe2CF60484325716A1c6A193519c8c3b19F3"
 TokenHEZName = "Hermez Network Token"
 
 [EthClient]
@@ -35,3 +37,64 @@ DeployGasLimit      = 1000000
 GasPriceDiv         = 100
 ReceiptTimeout      = "60s"
 IntervalReceiptLoop = "200ms"
+
+    [Synchronizer.InitialVariables.Auction]
+    DonationAddress = "0x0000000000000000000000000000000000000001"
+    BootCoordinator = "0x0000000000000000000000000000000000000001"
+    DefaultSlotSetBid = [
+        "10000000000000000000",
+        "10000000000000000000",
+        "10000000000000000000",
+        "10000000000000000000",
+        "10000000000000000000",
+        "10000000000000000000",
+    ]
+    ClosedAuctionSlots = 2
+    OpenAuctionSlots = 4320
+    AllocationRatio = [4000, 4000, 2000]
+    Outbidding = 1000
+    SlotDeadline = 20
+
+    [Synchronizer.InitialVariables.WDelayer]
+	# HermezRollupAddress        =
+	HermezGovernanceDAOAddress = "0x0000000000000000000000000000000000000001"
+	WhiteHackGroupAddress      = "0x0000000000000000000000000000000000000001"
+	HermezKeeperAddress        = "0x0000000000000000000000000000000000000001"
+	WithdrawalDelay            = 60
+	EmergencyModeStartingTime  = 0
+	EmergencyMode              = false
+
+    [Synchronizer.InitialVariables.Rollup]
+    FeeAddToken = "10"
+    ForgeL1L2BatchTimeout = 10
+    WithdrawalDelay = 1209600 # 60 * 60 * 24 * 7 * 2
+        # [[Synchronizer.InitialVariables.Rollup.Buckets]]
+        # CeilUSD             = 0
+        # BlockStamp          = 0
+        # Withdrawals         = 0
+        # BlockWithdrawalRate = 0
+        # MaxWithdrawals      = 0
+        # [[Synchronizer.InitialVariables.Rollup.Buckets]]
+        # CeilUSD             = 0
+        # BlockStamp          = 0
+        # Withdrawals         = 0
+        # BlockWithdrawalRate = 0
+        # MaxWithdrawals      = 0
+        # [[Synchronizer.InitialVariables.Rollup.Buckets]]
+        # CeilUSD             = 0
+        # BlockStamp          = 0
+        # Withdrawals         = 0
+        # BlockWithdrawalRate = 0
+        # MaxWithdrawals      = 0
+        # [[Synchronizer.InitialVariables.Rollup.Buckets]]
+        # CeilUSD             = 0
+        # BlockStamp          = 0
+        # Withdrawals         = 0
+        # BlockWithdrawalRate = 0
+        # MaxWithdrawals      = 0
+        # [[Synchronizer.InitialVariables.Rollup.Buckets]]
+        # CeilUSD             = 0
+        # BlockStamp          = 0
+        # Withdrawals         = 0
+        # BlockWithdrawalRate = 0
+        # MaxWithdrawals      = 0

--- a/cli/node/main.go
+++ b/cli/node/main.go
@@ -107,6 +107,7 @@ func getConfig(c *cli.Context) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	// nodeCfg.Synchronizer.InitialVariables.WDelayer.HermezRollupAddress = nodeCfg.SmartContracts.Rollup
 	cfg.node = nodeCfg
 
 	return &cfg, nil

--- a/common/ethauction.go
+++ b/common/ethauction.go
@@ -25,20 +25,21 @@ type AuctionConstants struct {
 
 // AuctionVariables are the variables of the Auction Smart Contract
 type AuctionVariables struct {
+	EthBlockNum int64 `json:"ethereumBlockNum" meddler:"eth_block_num"`
 	// Boot Coordinator Address
-	DonationAddress ethCommon.Address `json:"donationAddress" meddler:"donation_address"`
+	DonationAddress ethCommon.Address `json:"donationAddress" meddler:"donation_address" validate:"required"`
 	// Boot Coordinator Address
-	BootCoordinator ethCommon.Address `json:"bootCoordinator" meddler:"boot_coordinator"`
+	BootCoordinator ethCommon.Address `json:"bootCoordinator" meddler:"boot_coordinator" validate:"required"`
 	// The minimum bid value in a series of 6 slots
-	DefaultSlotSetBid [6]*big.Int `json:"defaultSlotSetBid" meddler:"default_slot_set_bid,json"`
+	DefaultSlotSetBid [6]*big.Int `json:"defaultSlotSetBid" meddler:"default_slot_set_bid,json" validate:"required"`
 	// Distance (#slots) to the closest slot to which you can bid ( 2 Slots = 2 * 40 Blocks = 20 min )
-	ClosedAuctionSlots uint16 `json:"closedAuctionSlots" meddler:"closed_auction_slots"`
+	ClosedAuctionSlots uint16 `json:"closedAuctionSlots" meddler:"closed_auction_slots" validate:"required"`
 	// Distance (#slots) to the farthest slot to which you can bid (30 days = 4320 slots )
-	OpenAuctionSlots uint16 `json:"openAuctionSlots" meddler:"open_auction_slots"`
+	OpenAuctionSlots uint16 `json:"openAuctionSlots" meddler:"open_auction_slots" validate:"required"`
 	// How the HEZ tokens deposited by the slot winner are distributed (Burn: 40% - Donation: 40% - HGT: 20%)
-	AllocationRatio [3]uint16 `json:"allocationRatio" meddler:"allocation_ratio,json"`
+	AllocationRatio [3]uint16 `json:"allocationRatio" meddler:"allocation_ratio,json" validate:"required"`
 	// Minimum outbid (percentage) over the previous one to consider it valid
-	Outbidding uint16 `json:"outbidding" meddler:"outbidding"`
+	Outbidding uint16 `json:"outbidding" meddler:"outbidding" validate:"required"`
 	// Number of blocks at the end of a slot in which any coordinator can forge if the winner has not forged one before
-	SlotDeadline uint8 `json:"slotDeadline" meddler:"slot_deadline"`
+	SlotDeadline uint8 `json:"slotDeadline" meddler:"slot_deadline" validate:"required"`
 }

--- a/common/ethrollup.go
+++ b/common/ethrollup.go
@@ -157,8 +157,9 @@ type Bucket struct {
 
 // RollupVariables are the variables of the Rollup Smart Contract
 type RollupVariables struct {
-	FeeAddToken           *big.Int                      `json:"feeAddToken" meddler:"fee_addtoken"`
-	ForgeL1L2BatchTimeout int64                         `json:"forgeL1L2BatchTimeout" meddler:"forge_l1l2_timeout"`
-	WithdrawalDelay       uint64                        `json:"withdrawalDelay" meddler:"withdrawal_delay"`
-	Buckets               [RollupConstNumBuckets]Bucket `json:"buckets" meddler:"buckets,json"`
+	EthBlockNum           int64    `json:"ethereumBlockNum" meddler:"eth_block_num"`
+	FeeAddToken           *big.Int `json:"feeAddToken" meddler:"fee_add_token,bigint" validate:"required"`
+	ForgeL1L2BatchTimeout int64    `json:"forgeL1L2BatchTimeout" meddler:"forge_l1_timeout" validate:"required"`
+	WithdrawalDelay       uint64   `json:"withdrawalDelay" meddler:"withdrawal_delay" validate:"required"`
+	// Buckets               [RollupConstNumBuckets]Bucket `json:"buckets" meddler:"buckets,json"`
 }

--- a/common/ethwdelayer.go
+++ b/common/ethwdelayer.go
@@ -14,11 +14,12 @@ type WDelayerConstants struct {
 
 // WDelayerVariables are the variables of the Withdrawal Delayer Smart Contract
 type WDelayerVariables struct {
-	HermezRollupAddress        ethCommon.Address `json:"hermezRollupAddress" meddler:"rollup_address"`
-	HermezGovernanceDAOAddress ethCommon.Address `json:"hermezGovernanceDAOAddress" meddler:"govdao_address"`
-	WhiteHackGroupAddress      ethCommon.Address `json:"whiteHackGroupAddress" meddler:"whg_address"`
-	HermezKeeperAddress        ethCommon.Address `json:"hermezKeeperAddress" meddler:"keeper_address"`
-	WithdrawalDelay            uint64            `json:"withdrawalDelay" meddler:"withdrawal_delay"`
+	EthBlockNum int64 `json:"ethereumBlockNum" meddler:"eth_block_num"`
+	// HermezRollupAddress        ethCommon.Address `json:"hermezRollupAddress" meddler:"rollup_address"`
+	HermezGovernanceDAOAddress ethCommon.Address `json:"hermezGovernanceDAOAddress" meddler:"govdao_address" validate:"required"`
+	WhiteHackGroupAddress      ethCommon.Address `json:"whiteHackGroupAddress" meddler:"whg_address" validate:"required"`
+	HermezKeeperAddress        ethCommon.Address `json:"hermezKeeperAddress" meddler:"keeper_address" validate:"required"`
+	WithdrawalDelay            uint64            `json:"withdrawalDelay" meddler:"withdrawal_delay" validate:"required"`
 	EmergencyModeStartingTime  uint64            `json:"emergencyModeStartingTime" meddler:"emergency_start_time"`
 	EmergencyMode              bool              `json:"emergencyMode" meddler:"emergency_mode"`
 }

--- a/common/l1tx.go
+++ b/common/l1tx.go
@@ -282,5 +282,7 @@ func L1CoordinatorTxFromBytes(b []byte) (*L1Tx, error) {
 		return nil, err
 	}
 	tx.FromEthAddr = crypto.PubkeyToAddress(*pubKey)
+	tx.Amount = big.NewInt(0)
+	tx.LoadAmount = big.NewInt(0)
 	return tx, nil
 }

--- a/common/l1tx_test.go
+++ b/common/l1tx_test.go
@@ -158,6 +158,8 @@ func TestL1CoordinatorTxByteParsers(t *testing.T) {
 		TokenID:     231,
 		FromBJJ:     pk,
 		FromEthAddr: fromEthAddr,
+		Amount:      big.NewInt(0),
+		LoadAmount:  big.NewInt(0),
 	}
 
 	bytesCoordinatorL1, err := l1Tx.BytesCoordinatorTx(signature)

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BurntSushi/toml"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/synchronizer"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -65,16 +66,14 @@ type Node struct {
 		URL string `validate:"required"`
 	} `validate:"required"`
 	Synchronizer struct {
-		SyncLoopInterval Duration `validate:"required"`
-		StartBlockNum    struct {
-			Rollup   int64 `validate:"required"`
-			Auction  int64 `validate:"required"`
-			WDelayer int64 `validate:"required"`
-		} `validate:"required"`
+		SyncLoopInterval Duration                         `validate:"required"`
+		StartBlockNum    synchronizer.ConfigStartBlockNum `validate:"required"`
+		InitialVariables synchronizer.SCVariables         `validate:"required"`
 	} `validate:"required"`
 	SmartContracts struct {
 		Rollup       ethCommon.Address `validate:"required"`
 		Auction      ethCommon.Address `validate:"required"`
+		WDelayer     ethCommon.Address `validate:"required"`
 		TokenHEZ     ethCommon.Address `validate:"required"`
 		TokenHEZName string            `validate:"required"`
 	} `validate:"required"`

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -7,7 +7,6 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db"
-	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/jmoiron/sqlx"
 
 	//nolint:errcheck // driver for postgres DB
@@ -243,10 +242,7 @@ func (l2db *L2DB) CheckNonces(updatedAccounts []common.Account, batchNum common.
 	defer func() {
 		// Rollback the transaction if there was an error.
 		if err != nil {
-			errRollback := txn.Rollback()
-			if errRollback != nil {
-				log.Errorw("Rollback", "err", errRollback)
-			}
+			db.Rollback(txn)
 		}
 	}()
 	for i := 0; i < len(updatedAccounts); i++ {
@@ -291,10 +287,7 @@ func (l2db *L2DB) Purge(currentBatchNum common.BatchNum) (err error) {
 	defer func() {
 		// Rollback the transaction if there was an error.
 		if err != nil {
-			errRollback := txn.Rollback()
-			if errRollback != nil {
-				log.Errorw("Rollback", "err", errRollback)
-			}
+			db.Rollback(txn)
 		}
 	}()
 	// Delete pending txs that have been in the pool after the TTL if maxTxs is reached

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -516,23 +516,31 @@ FOR EACH ROW EXECUTE PROCEDURE forge_l1_user_txs();
 
 CREATE TABLE rollup_vars (
     eth_block_num BIGINT PRIMARY KEY REFERENCES block (eth_block_num) ON DELETE CASCADE,
-    forge_l1_timeout BYTEA NOT NULL,
-    fee_l1_user_tx BYTEA NOT NULL,
     fee_add_token BYTEA NOT NULL,
-    tokens_hez BYTEA NOT NULL,
-    governance BYTEA NOT NULL
+    forge_l1_timeout BYTEA NOT NULL,
+    withdrawal_delay BIGINT NOT NULL
 );
 
-CREATE TABLE consensus_vars (
+CREATE TABLE auction_vars (
     eth_block_num BIGINT PRIMARY KEY REFERENCES block (eth_block_num) ON DELETE CASCADE,
-    slot_deadline INT NOT NULL,
-    close_auction_slots INT NOT NULL,
-    open_auction_slots INT NOT NULL,
-    min_bid_slots VARCHAR(200) NOT NULL,
-    outbidding INT NOT NULL,
     donation_address BYTEA NOT NULL,
-    governance_address BYTEA NOT NULL,
-    allocation_ratio VARCHAR(200)
+    boot_coordinator BYTEA NOT NULL,
+    default_slot_set_bid BYTEA NOT NULL,
+    closed_auction_slots INT NOT NULL,
+    open_auction_slots INT NOT NULL,
+    allocation_ratio VARCHAR(200),
+    outbidding INT NOT NULL,
+    slot_deadline INT NOT NULL
+);
+
+CREATE TABLE wdelayer_vars (
+    eth_block_num BIGINT PRIMARY KEY REFERENCES block (eth_block_num) ON DELETE CASCADE,
+    govdao_address BYTEA NOT NULL,
+    whg_address BYTEA NOT NULL,
+    keeper_address BYTEA NOT NULL,
+    withdrawal_delay BIGINT NOT NULL,
+    emergency_start_time BIGINT NOT NULL,
+    emergency_mode BOOLEAN NOT NULL
 );
 
 -- L2
@@ -606,8 +614,9 @@ DROP FUNCTION set_pool_tx;
 -- drop tables
 DROP TABLE account_creation_auth;
 DROP TABLE tx_pool;
-DROP TABLE consensus_vars;
+DROP TABLE auction_vars;
 DROP TABLE rollup_vars;
+DROP TABLE wdelayer_vars;
 DROP TABLE tx;
 DROP TABLE exit_tree;
 DROP TABLE account;

--- a/db/utils.go
+++ b/db/utils.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"math/big"
@@ -191,4 +192,12 @@ type Pagination struct {
 type Paginationer interface {
 	GetPagination() *Pagination
 	Len() int
+}
+
+// Rollback an sql transaction, and log the error if it's not nil
+func Rollback(txn *sql.Tx) {
+	err := txn.Rollback()
+	if err != nil {
+		log.Errorw("Rollback", "err", err)
+	}
 }

--- a/eth/client.go
+++ b/eth/client.go
@@ -17,6 +17,7 @@ type ClientInterface interface {
 	EthereumInterface
 	RollupInterface
 	AuctionInterface
+	WDelayerInterface
 }
 
 //
@@ -28,6 +29,7 @@ type Client struct {
 	EthereumClient
 	AuctionClient
 	RollupClient
+	WDelayerClient
 }
 
 // TokenConfig is used to define the information about token
@@ -47,11 +49,17 @@ type AuctionConfig struct {
 	TokenHEZ TokenConfig
 }
 
+// WDelayerConfig is the configuration for the WDelayer smart contract interface
+type WDelayerConfig struct {
+	Address ethCommon.Address
+}
+
 // ClientConfig is the configuration of the Client
 type ClientConfig struct {
 	Ethereum EthereumConfig
 	Rollup   RollupConfig
 	Auction  AuctionConfig
+	WDelayer WDelayerConfig
 }
 
 // NewClient creates a new Client to interact with Ethereum and the Hermez smart contracts.
@@ -61,13 +69,18 @@ func NewClient(client *ethclient.Client, account *accounts.Account, ks *ethKeyst
 	if err != nil {
 		return nil, err
 	}
-	rollupCient, err := NewRollupClient(ethereumClient, cfg.Rollup.Address, cfg.Auction.TokenHEZ)
+	rollupClient, err := NewRollupClient(ethereumClient, cfg.Rollup.Address, cfg.Auction.TokenHEZ)
+	if err != nil {
+		return nil, err
+	}
+	wDelayerClient, err := NewWDelayerClient(ethereumClient, cfg.WDelayer.Address)
 	if err != nil {
 		return nil, err
 	}
 	return &Client{
 		EthereumClient: *ethereumClient,
 		AuctionClient:  *auctionClient,
-		RollupClient:   *rollupCient,
+		RollupClient:   *rollupClient,
+		WDelayerClient: *wDelayerClient,
 	}, nil
 }

--- a/eth/rollup.go
+++ b/eth/rollup.go
@@ -510,9 +510,6 @@ func (c *RollupClient) RollupEventsByBlock(blockNum int64) (*RollupEvents, *ethC
 		return nil, nil, err
 	}
 	if len(logs) > 0 {
-		for i := range logs {
-			log.Debugw("log", "i", i, "blockHash", logs[i].BlockHash)
-		}
 		blockHash = &logs[0].BlockHash
 	}
 	for _, vLog := range logs {

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -241,6 +241,11 @@ func TestSync(t *testing.T) {
 			Auction:  1,
 			WDelayer: 1,
 		},
+		InitialVariables: SCVariables{
+			Rollup:   *clientSetup.RollupVariables,
+			Auction:  *clientSetup.AuctionVariables,
+			WDelayer: *clientSetup.WDelayerVariables,
+		},
 	})
 	require.Nil(t, err)
 


### PR DESCRIPTION
- node:
    - Extend config to add initial variables of the smart contracts used as
      defaults before they are changed via events.
    - In stopped channels, set size 1 so that panics are not witheld until the
      node stops completely.
- common:
    - In Smart Contract variables, comment:
      - `WDelayerVariables.HermezRollupAddress` because it's not needed.
      - `RollupVariables.Buckets` because there are no events for it, and for
        now it's not used.
- historydb:
    - Add functions to get and set smart contract variables.
- db:
    - Add `Rollback` function in `utils.go` to reduce boilerplate in sql
      transaction rollbacks in defers in db functions.
    - Update `rollup_vars` and `auction_vars` (renamed from `consensus_vars`)
      table, and add `wdelayer_vars` table.
- synchronizer:
    - Synchronize WDelayer
    - Handle SC variables properly
- test/ethclient:
    - Add essential implementation of WDelayer