### PR TITLE
Add DebugAPI to Node, fix StateDB

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -1,3 +1,6 @@
+[Debug]
+APIAddress = "localhost:12345"
+
 [StateDB]
 Path = "/tmp/iden3-test/hermez/statedb"
 

--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,9 @@ type Node struct {
 		ReceiptTimeout      Duration `validate:"required"`
 		IntervalReceiptLoop Duration `validate:"required"`
 	} `validate:"required"`
+	Debug struct {
+		APIAddress string
+	}
 }
 
 // Load loads a generic config.

--- a/db/statedb/statedb.go
+++ b/db/statedb/statedb.go
@@ -48,8 +48,6 @@ var (
 )
 
 const (
-	// PathStateDB defines the subpath of the StateDB
-	PathStateDB = "/statedb"
 	// PathBatchNum defines the subpath of the Batch Checkpoint in the
 	// subpath of the StateDB
 	PathBatchNum = "/BatchNum"
@@ -88,7 +86,7 @@ type StateDB struct {
 func NewStateDB(path string, typ TypeStateDB, nLevels int) (*StateDB, error) {
 	var sto *pebble.PebbleStorage
 	var err error
-	sto, err = pebble.NewPebbleStorage(path+PathStateDB+PathCurrent, false)
+	sto, err = pebble.NewPebbleStorage(path+PathCurrent, false)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +103,7 @@ func NewStateDB(path string, typ TypeStateDB, nLevels int) (*StateDB, error) {
 	}
 
 	sdb := &StateDB{
-		path: path + PathStateDB,
+		path: path,
 		db:   sto,
 		mt:   mt,
 		typ:  typ,
@@ -163,6 +161,7 @@ func (s *StateDB) setCurrentBatch() error {
 func (s *StateDB) MakeCheckpoint() error {
 	// advance currentBatch
 	s.currentBatch++
+	log.Debugw("Making StateDB checkpoint", "batch", s.currentBatch, "type", s.typ)
 
 	checkpointPath := s.path + PathBatchNum + strconv.Itoa(int(s.currentBatch))
 

--- a/db/statedb/txprocessors.go
+++ b/db/statedb/txprocessors.go
@@ -49,8 +49,13 @@ type ProcessTxOutput struct {
 // the HistoryDB, and adds Nonce & TokenID to the L2Txs.
 // And if TypeSynchronizer returns an array of common.Account with all the
 // created accounts.
-func (s *StateDB) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinatortxs []common.L1Tx, l2txs []common.PoolL2Tx) (*ProcessTxOutput, error) {
-	var err error
+func (s *StateDB) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinatortxs []common.L1Tx, l2txs []common.PoolL2Tx) (ptOut *ProcessTxOutput, err error) {
+	defer func() {
+		if err == nil {
+			err = s.MakeCheckpoint()
+		}
+	}()
+
 	var exitTree *merkletree.MerkleTree
 	var createdAccounts []common.Account
 
@@ -829,7 +834,7 @@ func (s *StateDB) getIdx() (common.Idx, error) {
 	if err != nil {
 		return 0, err
 	}
-	return common.IdxFromBytes(idxBytes[:4])
+	return common.IdxFromBytes(idxBytes[:])
 }
 
 // setIdx stores Idx in the localStateDB

--- a/test/debugapi/debugapi.go
+++ b/test/debugapi/debugapi.go
@@ -92,6 +92,9 @@ func (a *DebugAPI) Run(ctx context.Context) error {
 
 	debugAPI.GET("sdb/batchnum", a.handleCurrentBatch)
 	debugAPI.GET("sdb/mtroot", a.handleMTRoot)
+	// Accounts returned by these endpoints will always have BatchNum = 0,
+	// because the stateDB doesn't store the BatchNum in which an account
+	// is created.
 	debugAPI.GET("sdb/accounts", a.handleAccounts)
 	debugAPI.GET("sdb/accounts/:Idx", a.handleAccount)
 
@@ -104,7 +107,7 @@ func (a *DebugAPI) Run(ctx context.Context) error {
 		MaxHeaderBytes: 1 << 20,          //nolint:gomnd
 	}
 	go func() {
-		log.Infof("Debug API is ready at %v", a.addr)
+		log.Infof("DebugAPI is ready at %v", a.addr)
 		if err := debugAPIServer.ListenAndServe(); err != nil &&
 			err != http.ErrServerClosed {
 			log.Fatalf("Listen: %s\n", err)
@@ -112,10 +115,10 @@ func (a *DebugAPI) Run(ctx context.Context) error {
 	}()
 
 	<-ctx.Done()
-	log.Info("Stopping Debug API...")
+	log.Info("Stopping DebugAPI...")
 	if err := debugAPIServer.Shutdown(context.Background()); err != nil {
 		return err
 	}
-	log.Info("Debug API stopped")
+	log.Info("DebugAPI done")
 	return nil
 }


### PR DESCRIPTION
- Allow starting the DebugAPI from the node via config
- In StateDB:
    - Make checkpoints when ProcessTxs() succeeds
    - Remove extra hardcoded `statedb` path that was redundant
    - Replace hardcoded `[:4]` by `[:]` when parsing idx, which failed because
      idx is 6 bytes length now.
- Extra: In node, use waitgroup instead of `stoppedXXX` channels to wait for
syncrhonizer goroutines to finish.