### PR TITLE
Fix exit table, set delayed_withdrawn in exits

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -222,7 +222,7 @@ func TestMain(m *testing.M) {
 	// Gen exits and add them to DB
 	const totalExits = 40
 	// TODO: UPDATE with til
-	exits := test.GenExitTree(totalExits, batches, accs)
+	exits := test.GenExitTree(totalExits, batches, accs, blocks)
 	err = api.h.AddExitTree(exits)
 	if err != nil {
 		panic(err)

--- a/common/block.go
+++ b/common/block.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"math/big"
 	"time"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -51,15 +52,30 @@ func NewAuctionData() AuctionData {
 	}
 }
 
+// WDelayerTransfer represents a transfer (either deposit or withdrawal) in the
+// WDelayer smart contract
+type WDelayerTransfer struct {
+	Owner  ethCommon.Address
+	Token  ethCommon.Address
+	Amount *big.Int
+	// TxHash ethCommon.Hash // hash of the transaction in which the wdelayer transfer happened
+}
+
 // WDelayerData contains information returned by the WDelayer smart contract
 type WDelayerData struct {
-	Vars *WDelayerVariables
+	Vars             *WDelayerVariables
+	Deposits         []WDelayerTransfer
+	DepositsByTxHash map[ethCommon.Hash]*WDelayerTransfer
+	Withdrawals      []WDelayerTransfer
 }
 
 // NewWDelayerData creates an empty WDelayerData.
 func NewWDelayerData() WDelayerData {
 	return WDelayerData{
-		Vars: nil,
+		Vars:             nil,
+		Deposits:         make([]WDelayerTransfer, 0),
+		DepositsByTxHash: make(map[ethCommon.Hash]*WDelayerTransfer),
+		Withdrawals:      make([]WDelayerTransfer, 0),
 	}
 }
 

--- a/common/exittree.go
+++ b/common/exittree.go
@@ -3,6 +3,7 @@ package common
 import (
 	"math/big"
 
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/iden3/go-merkletree"
 )
 
@@ -30,4 +31,7 @@ type WithdrawInfo struct {
 	Idx             Idx
 	NumExitRoot     BatchNum
 	InstantWithdraw bool
+	TxHash          ethCommon.Hash // hash of the transaction in which the withdraw happened
+	Owner           ethCommon.Address
+	Token           ethCommon.Address
 }

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -235,7 +235,7 @@ func (l2db *L2DB) InvalidateTxs(txIDs []common.TxID, batchNum common.BatchNum) e
 // CheckNonces invalidate txs with nonces that are smaller or equal than their respective accounts nonces.
 // The state of the affected txs will be changed from Pending -> Invalid
 func (l2db *L2DB) CheckNonces(updatedAccounts []common.Account, batchNum common.BatchNum) (err error) {
-	txn, err := l2db.db.Begin()
+	txn, err := l2db.db.Beginx()
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func (l2db *L2DB) Reorg(lastValidBatch common.BatchNum) error {
 // Purge deletes transactions that have been forged or marked as invalid for longer than the safety period
 // it also deletes txs that has been in the L2DB for longer than the ttl if maxTxs has been exceeded
 func (l2db *L2DB) Purge(currentBatchNum common.BatchNum) (err error) {
-	txn, err := l2db.db.Begin()
+	txn, err := l2db.db.Beginx()
 	if err != nil {
 		return err
 	}

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -109,9 +109,11 @@ CREATE TABLE exit_tree (
     account_idx BIGINT REFERENCES account (idx) ON DELETE CASCADE,
     merkle_proof BYTEA NOT NULL,
     balance BYTEA NOT NULL,
-    instant_withdrawn BIGINT REFERENCES batch (batch_num) ON DELETE SET NULL,
-    delayed_withdraw_request BIGINT REFERENCES batch (batch_num) ON DELETE SET NULL,
-    delayed_withdrawn BIGINT REFERENCES batch (batch_num) ON DELETE SET NULL
+    instant_withdrawn BIGINT REFERENCES block (eth_block_num) ON DELETE SET NULL,
+    delayed_withdraw_request BIGINT REFERENCES block (eth_block_num) ON DELETE SET NULL,
+    owner BYTEA,
+    token BYTEA,
+    delayed_withdrawn BIGINT REFERENCES block (eth_block_num) ON DELETE SET NULL
 );
 
 -- +migrate StatementBegin

--- a/db/utils.go
+++ b/db/utils.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"database/sql"
 	"encoding/base64"
 	"fmt"
 	"math/big"
@@ -180,7 +179,7 @@ func SlicePtrsToSlice(slice interface{}) interface{} {
 }
 
 // Rollback an sql transaction, and log the error if it's not nil
-func Rollback(txn *sql.Tx) {
+func Rollback(txn *sqlx.Tx) {
 	err := txn.Rollback()
 	if err != nil {
 		log.Errorw("Rollback", "err", err)

--- a/eth/rollup.go
+++ b/eth/rollup.go
@@ -91,6 +91,7 @@ type RollupEventWithdraw struct {
 	Idx             uint64
 	NumExitRoot     uint64
 	InstantWithdraw bool
+	TxHash          ethCommon.Hash // Hash of the transaction that generated this event
 }
 
 // RollupEvents is the list of events in a block of the Rollup Smart Contract
@@ -577,6 +578,7 @@ func (c *RollupClient) RollupEventsByBlock(blockNum int64) (*RollupEvents, *ethC
 			if instantWithdraw == 1 {
 				withdraw.InstantWithdraw = true
 			}
+			withdraw.TxHash = vLog.TxHash
 			rollupEvents.Withdraw = append(rollupEvents.Withdraw, withdraw)
 		}
 	}

--- a/eth/wdelayer.go
+++ b/eth/wdelayer.go
@@ -30,6 +30,7 @@ type WDelayerEventDeposit struct {
 	Token            ethCommon.Address
 	Amount           *big.Int
 	DepositTimestamp uint64
+	TxHash           ethCommon.Hash // Hash of the transaction that generated this event
 }
 
 // WDelayerEventWithdraw is an event of the WithdrawalDelayer Smart Contract
@@ -411,6 +412,7 @@ func (c *WDelayerClient) WDelayerEventsByBlock(blockNum int64) (*WDelayerEvents,
 			}
 			deposit.Owner = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
 			deposit.Token = ethCommon.BytesToAddress(vLog.Topics[2].Bytes())
+			deposit.TxHash = vLog.TxHash
 			wdelayerEvents.Deposit = append(wdelayerEvents.Deposit, deposit)
 
 		case logWDelayerWithdraw:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/iden3/go-iden3-crypto v0.0.6-0.20201016142444-94e92e88fb4e
 	github.com/iden3/go-merkletree v0.0.0-20201103115630-ad30c8309b44
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
-	github.com/jmoiron/sqlx v1.2.0
+	github.com/jmoiron/sqlx v1.2.1-0.20200615141059-0794cb1f47ee
 	github.com/joho/godotenv v1.3.0
 	github.com/lib/pq v1.8.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
+github.com/jmoiron/sqlx v1.2.1-0.20200615141059-0794cb1f47ee h1:59lyMGvZusByi7Rvctn8cxdVAjhiOnqCv3G5DrYApYQ=
+github.com/jmoiron/sqlx v1.2.1-0.20200615141059-0794cb1f47ee/go.mod h1:ClpsPFzLpSBl7MvJ+BhV0JHz4vmKRBarpvZ9644v9Oo=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/test/historydb.go
+++ b/test/historydb.go
@@ -372,7 +372,7 @@ func GenBids(nBids int, blocks []common.Block, coords []common.Coordinator) []co
 
 // GenExitTree generates an exitTree (as an array of Exits)
 //nolint:gomnd
-func GenExitTree(n int, batches []common.Batch, accounts []common.Account) []common.ExitInfo {
+func GenExitTree(n int, batches []common.Batch, accounts []common.Account, blocks []common.Block) []common.ExitInfo {
 	exitTree := make([]common.ExitInfo, n)
 	for i := 0; i < n; i++ {
 		exitTree[i] = common.ExitInfo{
@@ -397,17 +397,14 @@ func GenExitTree(n int, batches []common.Batch, accounts []common.Account) []com
 			Balance: big.NewInt(int64(i) * 1000),
 		}
 		if i%2 == 0 {
-			instant := new(int64)
-			*instant = int64(batches[(i+1)%len(batches)].BatchNum)
-			exitTree[i].InstantWithdrawn = instant
+			instant := int64(blocks[i%len(blocks)].EthBlockNum)
+			exitTree[i].InstantWithdrawn = &instant
 		} else if i%3 == 0 {
-			delayedReq := new(int64)
-			*delayedReq = int64(batches[(i+1)%len(batches)].BatchNum)
-			exitTree[i].DelayedWithdrawRequest = delayedReq
+			delayedReq := int64(blocks[i%len(blocks)].EthBlockNum)
+			exitTree[i].DelayedWithdrawRequest = &delayedReq
 			if i%9 == 0 {
-				delayed := new(int64)
-				*delayed = int64(batches[(i+2)%len(batches)].BatchNum)
-				exitTree[i].DelayedWithdrawn = delayed
+				delayed := int64(blocks[i%len(blocks)].EthBlockNum)
+				exitTree[i].DelayedWithdrawn = &delayed
 			}
 		}
 	}

--- a/test/til/txs.go
+++ b/test/til/txs.go
@@ -51,7 +51,7 @@ type Context struct {
 	Instructions          []instruction
 	userNames             []string
 	Users                 map[string]*User // Name -> *User
-	usersByIdx            map[int]*User
+	UsersByIdx            map[int]*User
 	accountsByIdx         map[int]*Account
 	LastRegisteredTokenID common.TokenID
 	l1CreatedAccounts     map[string]*Account // (Name, TokenID) -> *Account
@@ -81,7 +81,7 @@ func NewContext(rollupConstMaxL1UserTx int) *Context {
 	return &Context{
 		Users:                 make(map[string]*User),
 		l1CreatedAccounts:     make(map[string]*Account),
-		usersByIdx:            make(map[int]*User),
+		UsersByIdx:            make(map[int]*User),
 		accountsByIdx:         make(map[int]*Account),
 		LastRegisteredTokenID: 0,
 
@@ -393,7 +393,7 @@ func (tc *Context) calculateIdxForL1Txs(isCoordinatorTxs bool, txs []L1Tx) error
 			}
 			tc.l1CreatedAccounts[idxTokenIDToString(tx.fromIdxName, tx.L1Tx.TokenID)] = tc.Users[tx.fromIdxName].Accounts[tx.L1Tx.TokenID]
 			tc.accountsByIdx[tc.idx] = tc.Users[tx.fromIdxName].Accounts[tx.L1Tx.TokenID]
-			tc.usersByIdx[tc.idx] = tc.Users[tx.fromIdxName]
+			tc.UsersByIdx[tc.idx] = tc.Users[tx.fromIdxName]
 			tc.idx++
 		}
 		if isCoordinatorTxs {
@@ -745,7 +745,7 @@ func (tc *Context) FillBlocksExtra(blocks []common.BlockData, cfg *ConfigExtra) 
 				tx := &l1Txs[k]
 				if tx.Type == common.TxTypeCreateAccountDeposit ||
 					tx.Type == common.TxTypeCreateAccountDepositTransfer {
-					user, ok := tc.usersByIdx[tc.extra.idx]
+					user, ok := tc.UsersByIdx[tc.extra.idx]
 					if !ok {
 						return fmt.Errorf("Created account with idx: %v not found", tc.extra.idx)
 					}


### PR DESCRIPTION
- In exit table, `instant_withdrawn`, `delayed_withdraw_request`, and
  `delayed_withdrawn` were referencing batch_num.  But these actions happen
  outside a batch, so they should reference a block_num.
- Process delayed withdrawns:
    - In Synchronizer, first match a Rollup delayed withdrawn request, with the
      WDelayer deposit (via TxHash), and store the owner and token associated
      with the delayed withdrawn.
    - In HistoryDB: store the owner and token of a delayed withdrawal request
      in the exit_tree, and set delayed_withdrawn when the withdraw is done in
      the WDelayer.
- Update dependency of sqlx to master
    - Last release of sqlx is from 2018 October, and it doesn't support
      `NamedQuery` with a slice of structs, which is used in this commit.