### PR TITLE
Integrate purger to node

### DIFF
--- a/common/account.go
+++ b/common/account.go
@@ -257,3 +257,9 @@ func AccountFromBytes(b [32 * NLeafElems]byte) (*Account, error) {
 	}
 	return &a, nil
 }
+
+// IdxNonce is a pair of Idx and Nonce representing an account
+type IdxNonce struct {
+	Idx   Idx   `db:"idx"`
+	Nonce Nonce `db:"nonce"`
+}

--- a/config/config.go
+++ b/config/config.go
@@ -35,13 +35,27 @@ type ServerProof struct {
 
 // Coordinator is the coordinator specific configuration.
 type Coordinator struct {
+	// ForgerAddress is the address under which this coordinator is forging
 	ForgerAddress     ethCommon.Address `validate:"required"`
 	ForgeLoopInterval Duration          `validate:"required"`
-	ConfirmBlocks     int64             `validate:"required"`
-	L2DB              struct {
+	// ConfirmBlocks is the number of confirmation blocks to wait for sent
+	// ethereum transactions before forgetting about them
+	ConfirmBlocks int64 `validate:"required"`
+	// L1BatchTimeoutPerc is the portion of the range before the L1Batch
+	// timeout that will trigger a schedule to forge an L1Batch
+	L1BatchTimeoutPerc float64 `validate:"required"`
+	L2DB               struct {
 		SafetyPeriod common.BatchNum `validate:"required"`
 		MaxTxs       uint32          `validate:"required"`
 		TTL          Duration        `validate:"required"`
+		// PurgeBatchDelay is the delay between batches to purge outdated transactions
+		PurgeBatchDelay int64 `validate:"required"`
+		// InvalidateBatchDelay is the delay between batches to mark invalid transactions
+		InvalidateBatchDelay int64 `validate:"required"`
+		// PurgeBlockDelay is the delay between blocks to purge outdated transactions
+		PurgeBlockDelay int64 `validate:"required"`
+		// InvalidateBlockDelay is the delay between blocks to mark invalid transactions
+		InvalidateBlockDelay int64 `validate:"required"`
 	} `validate:"required"`
 	TxSelector struct {
 		Path string `validate:"required"`
@@ -56,10 +70,24 @@ type Coordinator struct {
 		GasPriceDiv         uint64   `validate:"required"`
 		ReceiptTimeout      Duration `validate:"required"`
 		IntervalReceiptLoop Duration `validate:"required"`
+		// IntervalCheckLoop is the waiting interval between receipt
+		// checks of ethereum transactions in the TxManager
+		IntervalCheckLoop Duration `validate:"required"`
+		// Attempts is the number of attempts to do an eth client RPC
+		// call before giving up
+		Attempts int `validate:"required"`
+		// AttemptsDelay is delay between attempts do do an eth client
+		// RPC call
+		AttemptsDelay Duration `validate:"required"`
 	} `validate:"required"`
 	API struct {
 		Coordinator bool
 	} `validate:"required"`
+	Debug struct {
+		// BatchPath if set, specifies the path where batchInfo is stored
+		// in JSON in every step/update of the pipeline
+		BatchPath string
+	}
 }
 
 // Node is the hermez node configuration.

--- a/coordinator/purger.go
+++ b/coordinator/purger.go
@@ -1,0 +1,152 @@
+package coordinator
+
+import (
+	"fmt"
+
+	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/db/l2db"
+	"github.com/hermeznetwork/hermez-node/db/statedb"
+	"github.com/hermeznetwork/hermez-node/log"
+	"github.com/hermeznetwork/tracerr"
+	"github.com/iden3/go-merkletree/db"
+)
+
+// PurgerCfg is the purger configuration
+type PurgerCfg struct {
+	// PurgeBatchDelay is the delay between batches to purge outdated transactions
+	PurgeBatchDelay int64
+	// InvalidateBatchDelay is the delay between batches to mark invalid transactions
+	InvalidateBatchDelay int64
+	// PurgeBlockDelay is the delay between blocks to purge outdated transactions
+	PurgeBlockDelay int64
+	// InvalidateBlockDelay is the delay between blocks to mark invalid transactions
+	InvalidateBlockDelay int64
+}
+
+// Purger manages cleanup of transactions in the pool
+type Purger struct {
+	cfg                 PurgerCfg
+	lastPurgeBlock      int64
+	lastPurgeBatch      int64
+	lastInvalidateBlock int64
+	lastInvalidateBatch int64
+}
+
+// CanPurge returns true if it's a good time to purge according to the
+// configuration
+func (p *Purger) CanPurge(blockNum, batchNum int64) bool {
+	if blockNum > p.lastPurgeBlock+p.cfg.PurgeBlockDelay {
+		return true
+	}
+	if batchNum > p.lastPurgeBatch+p.cfg.PurgeBatchDelay {
+		return true
+	}
+	return false
+}
+
+// CanInvalidate returns true if it's a good time to invalidate according to
+// the configuration
+func (p *Purger) CanInvalidate(blockNum, batchNum int64) bool {
+	if blockNum > p.lastInvalidateBlock+p.cfg.InvalidateBlockDelay {
+		return true
+	}
+	if batchNum > p.lastInvalidateBatch+p.cfg.InvalidateBatchDelay {
+		return true
+	}
+	return false
+}
+
+// PurgeMaybe purges txs if it's a good time to do so
+func (p *Purger) PurgeMaybe(l2DB *l2db.L2DB, blockNum, batchNum int64) (bool, error) {
+	if !p.CanPurge(blockNum, batchNum) {
+		return false, nil
+	}
+	p.lastPurgeBlock = blockNum
+	p.lastPurgeBatch = batchNum
+	log.Debugw("Purger: purging l2txs in pool", "block", blockNum, "batch", batchNum)
+	err := l2DB.Purge(common.BatchNum(batchNum))
+	return true, tracerr.Wrap(err)
+}
+
+// InvalidateMaybe invalidates txs if it's a good time to do so
+func (p *Purger) InvalidateMaybe(l2DB *l2db.L2DB, stateDB *statedb.LocalStateDB,
+	blockNum, batchNum int64) (bool, error) {
+	if !p.CanInvalidate(blockNum, batchNum) {
+		return false, nil
+	}
+	p.lastInvalidateBlock = blockNum
+	p.lastInvalidateBatch = batchNum
+	log.Debugw("Purger: invalidating l2txs in pool", "block", blockNum, "batch", batchNum)
+	err := poolMarkInvalidOldNonces(l2DB, stateDB, common.BatchNum(batchNum))
+	return true, err
+}
+
+//nolint:unused,deadcode
+func idxsNonceFromL2Txs(txs []common.L2Tx) []common.IdxNonce {
+	idxNonceMap := map[common.Idx]common.Nonce{}
+	for _, tx := range txs {
+		if nonce, ok := idxNonceMap[tx.FromIdx]; !ok {
+			idxNonceMap[tx.FromIdx] = tx.Nonce
+		} else if tx.Nonce > nonce {
+			idxNonceMap[tx.FromIdx] = tx.Nonce
+		}
+	}
+	idxsNonce := make([]common.IdxNonce, 0, len(idxNonceMap))
+	for idx, nonce := range idxNonceMap {
+		idxsNonce = append(idxsNonce, common.IdxNonce{Idx: idx, Nonce: nonce})
+	}
+	return idxsNonce
+}
+
+func idxsNonceFromPoolL2Txs(txs []common.PoolL2Tx) []common.IdxNonce {
+	idxNonceMap := map[common.Idx]common.Nonce{}
+	for _, tx := range txs {
+		if nonce, ok := idxNonceMap[tx.FromIdx]; !ok {
+			idxNonceMap[tx.FromIdx] = tx.Nonce
+		} else if tx.Nonce > nonce {
+			idxNonceMap[tx.FromIdx] = tx.Nonce
+		}
+	}
+	idxsNonce := make([]common.IdxNonce, 0, len(idxNonceMap))
+	for idx, nonce := range idxNonceMap {
+		idxsNonce = append(idxsNonce, common.IdxNonce{Idx: idx, Nonce: nonce})
+	}
+	return idxsNonce
+}
+
+// poolMarkInvalidOldNoncesFromL2Txs marks as invalid the txs in the pool that
+// contain nonces equal or older to the highest nonce used in a forged l2Tx for
+// the
+// corresponding sender account
+func poolMarkInvalidOldNoncesFromL2Txs(l2DB *l2db.L2DB,
+	idxsNonce []common.IdxNonce, batchNum common.BatchNum) error {
+	return l2DB.CheckNonces(idxsNonce, batchNum)
+}
+
+// poolMarkInvalidOldNonces marks as invalid txs in the pool that contain
+// nonces equal or older to the nonce of the corresponding sender account
+func poolMarkInvalidOldNonces(l2DB *l2db.L2DB, stateDB *statedb.LocalStateDB,
+	batchNum common.BatchNum) error {
+	idxs, err := l2DB.GetPendingUniqueFromIdxs()
+	if err != nil {
+		return err
+	}
+	idxsNonce := make([]common.IdxNonce, len(idxs))
+	lastIdx, err := stateDB.GetIdx()
+	if err != nil {
+		return err
+	}
+	for i, idx := range idxs {
+		acc, err := stateDB.GetAccount(idx)
+		if err != nil {
+			if tracerr.Unwrap(err) != db.ErrNotFound {
+				return err
+			} else if idx <= lastIdx {
+				return fmt.Errorf("account with idx %v not found: %w", idx, err)
+			}
+		}
+		idxsNonce[i].Idx = idx
+		idxsNonce[i].Nonce = acc.Nonce
+	}
+	return l2DB.CheckNonces(idxsNonce, batchNum)
+}

--- a/coordinator/purger_test.go
+++ b/coordinator/purger_test.go
@@ -1,0 +1,3 @@
+package coordinator
+
+// TODO: Test purger functions

--- a/db/l2db/l2db_test.go
+++ b/db/l2db/l2db_test.go
@@ -334,12 +334,13 @@ func TestCheckNonces(t *testing.T) {
 	poolL2Txs, err := generatePoolL2Txs()
 	assert.NoError(t, err)
 	// Update Accounts currentNonce
-	var updateAccounts []common.Account
+	var updateAccounts []common.IdxNonce
 	const currentNonce = common.Nonce(1)
 	for i := range accs {
-		account := accs[i]
-		account.Nonce = common.Nonce(currentNonce)
-		updateAccounts = append(updateAccounts, account)
+		updateAccounts = append(updateAccounts, common.IdxNonce{
+			Idx:   accs[i].Idx,
+			Nonce: common.Nonce(currentNonce),
+		})
 	}
 	// Add txs to DB
 	var invalidTxIDs []common.TxID

--- a/db/statedb/statedb.go
+++ b/db/statedb/statedb.go
@@ -303,7 +303,7 @@ func (s *StateDB) reset(batchNum common.BatchNum, closeCurrent bool) error {
 		return tracerr.Wrap(err)
 	}
 	// idx is obtained from the statedb reset
-	s.idx, err = s.getIdx()
+	s.idx, err = s.GetIdx()
 	if err != nil {
 		return tracerr.Wrap(err)
 	}

--- a/db/statedb/txprocessors.go
+++ b/db/statedb/txprocessors.go
@@ -1118,9 +1118,9 @@ func (s *StateDB) computeEffectiveAmounts(tx *common.L1Tx) {
 	}
 }
 
-// getIdx returns the stored Idx from the localStateDB, which is the last Idx
+// GetIdx returns the stored Idx from the localStateDB, which is the last Idx
 // used for an Account in the localStateDB.
-func (s *StateDB) getIdx() (common.Idx, error) {
+func (s *StateDB) GetIdx() (common.Idx, error) {
 	idxBytes, err := s.DB().Get(keyidx)
 	if tracerr.Unwrap(err) == db.ErrNotFound {
 		return 0, nil

--- a/eth/ethereum.go
+++ b/eth/ethereum.go
@@ -65,8 +65,8 @@ type EthereumConfig struct {
 	CallGasLimit        uint64
 	DeployGasLimit      uint64
 	GasPriceDiv         uint64
-	ReceiptTimeout      time.Duration // in seconds
-	IntervalReceiptLoop time.Duration // in milliseconds
+	ReceiptTimeout      time.Duration
+	IntervalReceiptLoop time.Duration
 }
 
 // EthereumClient is an ethereum client to call Smart Contract methods and check blockchain information.

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -801,11 +801,16 @@ func (s *Synchronizer) rollupSync(ethBlock *common.Block) (*common.RollupData, e
 			MaxTx:    512,
 			MaxL1Tx:  64,
 		}
-		processTxsOut, err := s.stateDB.ProcessTxs(ptc, forgeBatchArgs.FeeIdxCoordinator, l1UserTxs,
-			batchData.L1CoordinatorTxs, poolL2Txs)
+		processTxsOut, err := s.stateDB.ProcessTxs(ptc, forgeBatchArgs.FeeIdxCoordinator,
+			l1UserTxs, batchData.L1CoordinatorTxs, poolL2Txs)
 		if err != nil {
 			return nil, tracerr.Wrap(err)
 		}
+		// Set the BatchNum in the forged L1UserTxs
+		for i := range l1UserTxs {
+			l1UserTxs[i].BatchNum = &batchNum
+		}
+		batchData.L1UserTxs = l1UserTxs
 
 		// Set batchNum in exits
 		for i := range processTxsOut.ExitInfos {

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -58,6 +58,11 @@ func NewTxSelector(dbpath string, synchronizerStateDB *statedb.StateDB, l2 *l2db
 	}, nil
 }
 
+// LocalAccountsDB returns the LocalStateDB of the TxSelector
+func (txsel *TxSelector) LocalAccountsDB() *statedb.LocalStateDB {
+	return txsel.localAccountsDB
+}
+
 // Reset tells the TxSelector to get it's internal AccountsDB
 // from the required `batchNum`
 func (txsel *TxSelector) Reset(batchNum common.BatchNum) error {


### PR DESCRIPTION
- Common
	- Add `IdxNonce` type used to track nonces in accounts to invalidate
	  l2txs in the pool
- Config
	- Update coordinator config will all the new configuration parameters
	  used in the coordinator
- Coordinator
	- Introduce the `Purger` to track how often to purge and do the job when
	  needed according to a configuration.
	- Implement the methods to invalidate l2txs transactions due to l2txs
	  selection in batches.  For now these functions are not used in favour
	  of the `Purger` methods, which check ALL the l2txs in the pool.
	- Call Invalidation and Purging methods of the purger both when the
	  node is forging (in the pipeline when starting a new batch) and when
	  the node is not forging (in coordinator when being notified about a
	  new synced block)
- L2DB:
	- Implement `GetPendingUniqueFromIdxs` to get all the unique idxs from
	  pending transactions (used to get their nonces and then invalidate
	  txs)
	- Redo `CheckNonces` with a single SQL query and using `common.IdxNonce`
	  instead of `common.Account`
- StateDB:
	- Expose GetIdx to check errors when invalidating pool txs
- Synchronizer:
	- Test forged L1UserTxs processed by TxProcessor
	- Improve checks of Effective values
- TxSelector:
	- Expose the internal LocalStateDB in order to check account nonces in
	  the coordinator when not forging.