### PR TITLE
Make coordinator more responsive

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2837,9 +2837,9 @@ components:
             - $ref: '#/components/schemas/EthBlockNum'
             - description: The time that everyone needs to wait until a withdrawal of the funds is allowed, in seconds.
             - example: 539573849
-        emergencyModeStartingTime:
+        emergencyModeStartingBlock:
           type: integer
-          description: Second (since unix epoch) in which the emergency mode has been activated.
+          description: Block number in which the emergency mode has been activated.
           example: 10
         emergencyMode:
           type: boolean
@@ -2851,7 +2851,7 @@ components:
         - hermezGovernanceAddress
         - emergencyCouncilAddress
         - withdrawalDelay
-        - emergencyModeStartingTime
+        - emergencyModeStartingBlock
         - emergencyMode
     StateMetrics:
       type: object

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -25,9 +25,9 @@ SyncLoopInterval = "1s"
 StatsRefreshPeriod = "1s"
 
     [Synchronizer.StartBlockNum]
-    Rollup = 6
-    Auction = 3
-    WDelayer = 7
+    Rollup = 19
+    Auction = 17
+    WDelayer = 15
 
 [SmartContracts]
 Rollup   = "0x8EEaea23686c319133a7cC110b840d1591d9AeE0"
@@ -56,12 +56,12 @@ TokenHEZName = "Hermez Network Token"
     SlotDeadline = 20
 
     [Synchronizer.InitialVariables.WDelayer]
-	# HermezRollupAddress        =
-	HermezGovernanceAddress    = "0x0000000000000000000000000000000000000001"
-	EmergencyCouncilAddress    = "0x0000000000000000000000000000000000000001"
-	WithdrawalDelay            = 60
-	EmergencyModeStartingTime  = 0
-	EmergencyMode              = false
+    # HermezRollupAddress        =
+    HermezGovernanceAddress    = "0x0000000000000000000000000000000000000001"
+    EmergencyCouncilAddress    = "0x0000000000000000000000000000000000000001"
+    WithdrawalDelay            = 60
+    EmergencyModeStartingTime  = 0
+    EmergencyMode              = false
 
     [Synchronizer.InitialVariables.Rollup]
     FeeAddToken = "10"

--- a/cli/node/coordcfg.buidler.toml
+++ b/cli/node/coordcfg.buidler.toml
@@ -1,0 +1,40 @@
+ForgerAddress = "0x6BB84Cc84D4A34467aD12a2039A312f7029e2071"
+ConfirmBlocks = 10
+L1BatchTimeoutPerc = 0.6
+ProofServerPollInterval = "1s"
+SyncRetryInterval = "1s"
+
+[L2DB]
+SafetyPeriod = 10
+MaxTxs       = 512
+TTL          = "24h"
+PurgeBatchDelay = 10
+InvalidateBatchDelay = 20
+PurgeBlockDelay = 10
+InvalidateBlockDelay = 20
+
+[TxSelector]
+Path = "/tmp/iden3-test/hermez/txselector"
+
+[BatchBuilder]
+Path = "/tmp/iden3-test/hermez/batchbuilder"
+
+[[ServerProofs]]
+URL = "http://localhost:3000"
+
+[EthClient]
+CallGasLimit        = 300000
+DeployGasLimit      = 1000000
+GasPriceDiv         = 100
+ReceiptTimeout      = "60s"
+ReceiptLoopInterval = "500ms"
+
+CheckLoopInterval = "500ms"
+Attempts = 8
+AttemptsDelay = "200ms"
+
+[API]
+Coordinator = true
+
+[Debug]
+BatchPath = "/tmp/iden3-test/hermez/batchesdebug"

--- a/common/ethwdelayer.go
+++ b/common/ethwdelayer.go
@@ -30,11 +30,11 @@ type WDelayerEscapeHatchWithdrawal struct {
 type WDelayerVariables struct {
 	EthBlockNum int64 `json:"ethereumBlockNum" meddler:"eth_block_num"`
 	// HermezRollupAddress        ethCommon.Address `json:"hermezRollupAddress" meddler:"rollup_address"`
-	HermezGovernanceAddress   ethCommon.Address `json:"hermezGovernanceAddress" meddler:"gov_address" validate:"required"`
-	EmergencyCouncilAddress   ethCommon.Address `json:"emergencyCouncilAddress" meddler:"emg_address" validate:"required"`
-	WithdrawalDelay           uint64            `json:"withdrawalDelay" meddler:"withdrawal_delay" validate:"required"`
-	EmergencyModeStartingTime uint64            `json:"emergencyModeStartingTime" meddler:"emergency_start_time"`
-	EmergencyMode             bool              `json:"emergencyMode" meddler:"emergency_mode"`
+	HermezGovernanceAddress    ethCommon.Address `json:"hermezGovernanceAddress" meddler:"gov_address" validate:"required"`
+	EmergencyCouncilAddress    ethCommon.Address `json:"emergencyCouncilAddress" meddler:"emg_address" validate:"required"`
+	WithdrawalDelay            uint64            `json:"withdrawalDelay" meddler:"withdrawal_delay" validate:"required"`
+	EmergencyModeStartingBlock int64             `json:"emergencyModeStartingBlock" meddler:"emergency_start_block"`
+	EmergencyMode              bool              `json:"emergencyMode" meddler:"emergency_mode"`
 }
 
 // Copy returns a deep copy of the Variables

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 
 // Duration is a wrapper type that parses time duration from text.
 type Duration struct {
-	time.Duration
+	time.Duration `validate:"required"`
 }
 
 // UnmarshalText unmarshalls time duration from text.
@@ -46,7 +46,10 @@ type Coordinator struct {
 	// ProofServerPollInterval is the waiting interval between polling the
 	// ProofServer while waiting for a particular status
 	ProofServerPollInterval Duration `validate:"required"`
-	L2DB                    struct {
+	// SyncRetryInterval is the waiting interval between calls to the main
+	// handler of a synced block after an error
+	SyncRetryInterval Duration `validate:"required"`
+	L2DB              struct {
 		SafetyPeriod common.BatchNum `validate:"required"`
 		MaxTxs       uint32          `validate:"required"`
 		TTL          Duration        `validate:"required"`

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -583,7 +583,7 @@ CREATE TABLE wdelayer_vars (
     gov_address BYTEA NOT NULL,
     emg_address BYTEA NOT NULL,
     withdrawal_delay BIGINT NOT NULL,
-    emergency_start_time BIGINT NOT NULL,
+    emergency_start_block BIGINT NOT NULL,
     emergency_mode BOOLEAN NOT NULL
 );
 

--- a/eth/auction.go
+++ b/eth/auction.go
@@ -651,7 +651,10 @@ func (c *AuctionClient) AuctionConstants() (auctionConstants *common.AuctionCons
 			return tracerr.Wrap(err)
 		}
 		auctionConstants.TokenHEZ, err = c.auction.TokenHEZ(c.opts)
-		return tracerr.Wrap(err)
+		if err != nil {
+			return tracerr.Wrap(err)
+		}
+		return nil
 	}); err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -354,11 +354,6 @@ func TestSync(t *testing.T) {
 	//
 	// First Sync from an initial state
 	//
-	var vars struct {
-		Rollup   *common.RollupVariables
-		Auction  *common.AuctionVariables
-		WDelayer *common.WDelayerVariables
-	}
 	stats := s.Stats()
 	assert.Equal(t, false, stats.Synced())
 
@@ -375,7 +370,7 @@ func TestSync(t *testing.T) {
 	assert.Equal(t, int64(1), stats.Eth.FirstBlockNum)
 	assert.Equal(t, int64(1), stats.Eth.LastBlock.Num)
 	assert.Equal(t, int64(1), stats.Sync.LastBlock.Num)
-	vars.Rollup, vars.Auction, vars.WDelayer = s.SCVars()
+	vars := s.SCVars()
 	assert.Equal(t, clientSetup.RollupVariables, vars.Rollup)
 	assert.Equal(t, clientSetup.AuctionVariables, vars.Auction)
 	assert.Equal(t, clientSetup.WDelayerVariables, vars.WDelayer)
@@ -524,7 +519,7 @@ func TestSync(t *testing.T) {
 	assert.Equal(t, int64(1), stats.Eth.FirstBlockNum)
 	assert.Equal(t, int64(4), stats.Eth.LastBlock.Num)
 	assert.Equal(t, int64(4), stats.Sync.LastBlock.Num)
-	vars.Rollup, vars.Auction, vars.WDelayer = s.SCVars()
+	vars = s.SCVars()
 	assert.Equal(t, clientSetup.RollupVariables, vars.Rollup)
 	assert.Equal(t, clientSetup.AuctionVariables, vars.Auction)
 	assert.Equal(t, clientSetup.WDelayerVariables, vars.WDelayer)
@@ -575,7 +570,7 @@ func TestSync(t *testing.T) {
 	assert.Equal(t, int64(1), stats.Eth.FirstBlockNum)
 	assert.Equal(t, int64(5), stats.Eth.LastBlock.Num)
 	assert.Equal(t, int64(5), stats.Sync.LastBlock.Num)
-	vars.Rollup, vars.Auction, vars.WDelayer = s.SCVars()
+	vars = s.SCVars()
 	assert.NotEqual(t, clientSetup.RollupVariables, vars.Rollup)
 	assert.NotEqual(t, clientSetup.AuctionVariables, vars.Auction)
 	assert.NotEqual(t, clientSetup.WDelayerVariables, vars.WDelayer)
@@ -649,7 +644,7 @@ func TestSync(t *testing.T) {
 	stats = s.Stats()
 	assert.Equal(t, false, stats.Synced())
 	assert.Equal(t, int64(6), stats.Eth.LastBlock.Num)
-	vars.Rollup, vars.Auction, vars.WDelayer = s.SCVars()
+	vars = s.SCVars()
 	assert.Equal(t, clientSetup.RollupVariables, vars.Rollup)
 	assert.Equal(t, clientSetup.AuctionVariables, vars.Auction)
 	assert.Equal(t, clientSetup.WDelayerVariables, vars.WDelayer)
@@ -688,7 +683,7 @@ func TestSync(t *testing.T) {
 			assert.Equal(t, false, stats.Synced())
 		}
 
-		vars.Rollup, vars.Auction, vars.WDelayer = s.SCVars()
+		vars = s.SCVars()
 		assert.Equal(t, clientSetup.RollupVariables, vars.Rollup)
 		assert.Equal(t, clientSetup.AuctionVariables, vars.Auction)
 		assert.Equal(t, clientSetup.WDelayerVariables, vars.WDelayer)

--- a/test/ethclient.go
+++ b/test/ethclient.go
@@ -333,11 +333,11 @@ func NewClientSetupExample() *ClientSetup {
 		HermezRollup:         auctionConstants.HermezRollup,
 	}
 	wDelayerVariables := &common.WDelayerVariables{
-		HermezGovernanceAddress:   ethCommon.HexToAddress("0xcfD0d163AE6432a72682323E2C3A5a69e6B37D12"),
-		EmergencyCouncilAddress:   ethCommon.HexToAddress("0x2730700932a4FDB97B9268A3Ca29f97Ea5fd7EA0"),
-		WithdrawalDelay:           60,
-		EmergencyModeStartingTime: 0,
-		EmergencyMode:             false,
+		HermezGovernanceAddress:    ethCommon.HexToAddress("0xcfD0d163AE6432a72682323E2C3A5a69e6B37D12"),
+		EmergencyCouncilAddress:    ethCommon.HexToAddress("0x2730700932a4FDB97B9268A3Ca29f97Ea5fd7EA0"),
+		WithdrawalDelay:            60,
+		EmergencyModeStartingBlock: 0,
+		EmergencyMode:              false,
 	}
 	return &ClientSetup{
 		RollupConstants:   rollupConstants,


### PR DESCRIPTION
- API:
	- Replace `emergencyModeStaringTime` by `emercengyModeStartingBlock`
- Synchronizer:
	- Track emergency mode starting block
- cli/node
	- Add working coordinator config
- coordinator:
	- Retry handler for synchronizer stats in case of error (instead of
	  waiting for the next block to try again)
	- On init, trigger an initial call to the handler for synced block
	  before waiting for the synchronizer, to force the coordinator to start
	  its logic even if there's no new block right after the node has been
	  started (very useful for running in testnet where the frequency of
	  blocks is variable)

@arnaubennassar please review the changes in the API (no need to review the rest)
	- Merge Msg for synced block and updated vars into one: `MsgSyncBlock`.