### PR TITLE
Make coordinator more robust agains failed forges

### DIFF
--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -417,6 +417,6 @@ func TestPipelineShouldL1L2Batch(t *testing.T) {
 // TODO: Test Reorg
 // TODO: Test Pipeline
 // TODO: Test TxMonitor
-// TODO: Test forgeSendServerProof
+// TODO: Test forgeBatch
 // TODO: Test waitServerProof
 // TODO: Test handleReorg


### PR DESCRIPTION
A part from the small rearrangement of code, the enhancement is that if a forge fails, the next iteration will retry the correct batchNum (previously it would try the following, skipping a batchNum)