### PR TITLE
Change metrics calculation when less than 24 hours running

### DIFF
--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -313,6 +313,8 @@ type MetricsTotals struct {
 	FirstBatchNum     common.BatchNum `meddler:"batch_num"`
 	TotalBatches      int64           `meddler:"total_batches"`
 	TotalFeesUSD      float64         `meddler:"total_fees"`
+	MinTimestamp      time.Time       `meddler:"min_timestamp,utctime"`
+	MaxTimestamp      time.Time       `meddler:"max_timestamp,utctime"`
 }
 
 // BidAPI is a representation of a bid with additional information


### PR DESCRIPTION
We can save one query for MaxTimestamp using time.Now() instead, but it will be less precise. As this will only get executed the first 24hours of the node life I think it will make the numbers be more accurate at the beginning.

We may look for getting all the values on a single query anyway.