### PR TITLE
Add bootCoord to coord table, get coord by forgerAddr

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -100,7 +100,6 @@ func NewAPI(
 		server.GET("/tokens", a.getTokens)
 		server.GET("/tokens/:id", a.getToken)
 		server.GET("/coordinators", a.getCoordinators)
-		server.GET("/coordinators/:bidderAddr", a.getCoordinator)
 	}
 
 	return a, nil

--- a/api/coordinator.go
+++ b/api/coordinator.go
@@ -7,29 +7,17 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 )
 
-func (a *API) getCoordinator(c *gin.Context) {
-	// Get bidderAddr
-	const name = "bidderAddr"
-	bidderAddr, err := parseParamEthAddr(name, c)
-
+func (a *API) getCoordinators(c *gin.Context) {
+	bidderAddr, err := parseQueryEthAddr("bidderAddr", c)
 	if err != nil {
 		retBadReq(err, c)
 		return
-	} else if bidderAddr == nil {
-		retBadReq(ErrNillBidderAddr, c)
-		return
 	}
-
-	coordinator, err := a.h.GetCoordinatorAPI(*bidderAddr)
+	forgerAddr, err := parseQueryEthAddr("forgerAddr", c)
 	if err != nil {
-		retSQLErr(err, c)
+		retBadReq(err, c)
 		return
 	}
-
-	c.JSON(http.StatusOK, coordinator)
-}
-
-func (a *API) getCoordinators(c *gin.Context) {
 	// Pagination
 	fromItem, order, limit, err := parsePagination(c)
 	if err != nil {
@@ -38,7 +26,7 @@ func (a *API) getCoordinators(c *gin.Context) {
 	}
 
 	// Fetch coordinators from historyDB
-	coordinators, pendingItems, err := a.h.GetCoordinatorsAPI(fromItem, limit, order)
+	coordinators, pendingItems, err := a.h.GetCoordinatorsAPI(bidderAddr, forgerAddr, fromItem, limit, order)
 	if err != nil {
 		retSQLErr(err, c)
 		return

--- a/api/parsers.go
+++ b/api/parsers.go
@@ -406,14 +406,6 @@ func parseQueryEthAddr(name string, c querier) (*ethCommon.Address, error) {
 	return parseEthAddr(addrStr)
 }
 
-func parseParamEthAddr(name string, c paramer) (*ethCommon.Address, error) {
-	addrStr := c.Param(name)
-	if addrStr == "" {
-		return nil, nil
-	}
-	return parseEthAddr(addrStr)
-}
-
 func parseEthAddr(ethAddrStr string) (*ethCommon.Address, error) {
 	var addr ethCommon.Address
 	err := addr.UnmarshalText([]byte(ethAddrStr))

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1144,6 +1144,18 @@ paths:
       description: Get information about coordinators.
       operationId: getCoordinators
       parameters:
+        - name: forgerAddr
+          in: query
+          required: false
+          description: Get coordinators by it's forger address.
+          schema:
+            $ref: '#/components/schemas/EthereumAddress'
+        - name: bidderAddr
+          in: query
+          required: false
+          description: Get coordinators by it's bidder address.
+          schema:
+            $ref: '#/components/schemas/EthereumAddress'
         - name: fromItem
           in: query
           required: false
@@ -1181,45 +1193,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '500':
-          description: Internal server error.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error500'
-  '/coordinators/{bidderAddr}':
-    get:
-      tags:
-        - Hermez status
-      summary: Get the information of a coordinator.
-      description: Get the information of a coordinator.
-      operationId: getCoordinator
-      parameters:
-        - name: bidderAddr
-          in: path
-          description: Coordinator identifier
-          required: true
-          schema:
-            $ref: '#/components/schemas/EthereumAddress'
-      responses:
-        '200':
-          description: Successful operation.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Coordinator'
-        '400':
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -1621,15 +1621,38 @@ func (hdb *HistoryDB) GetCoordinatorAPI(bidderAddr ethCommon.Address) (*Coordina
 }
 
 // GetCoordinatorsAPI returns a list of coordinators from the DB and pagination info
-func (hdb *HistoryDB) GetCoordinatorsAPI(fromItem, limit *uint, order string) ([]CoordinatorAPI, uint64, error) {
+func (hdb *HistoryDB) GetCoordinatorsAPI(
+	bidderAddr, forgerAddr *ethCommon.Address,
+	fromItem, limit *uint, order string,
+) ([]CoordinatorAPI, uint64, error) {
 	var query string
 	var args []interface{}
 	queryStr := `SELECT coordinator.*, 
 	COUNT(*) OVER() AS total_items
 	FROM coordinator `
 	// Apply filters
+	nextIsAnd := false
+	if bidderAddr != nil {
+		queryStr += "WHERE bidder_addr = ? "
+		nextIsAnd = true
+		args = append(args, bidderAddr)
+	}
+	if forgerAddr != nil {
+		if nextIsAnd {
+			queryStr += "AND "
+		} else {
+			queryStr += "WHERE "
+		}
+		queryStr += "forger_addr = ? "
+		nextIsAnd = true
+		args = append(args, forgerAddr)
+	}
 	if fromItem != nil {
-		queryStr += "WHERE "
+		if nextIsAnd {
+			queryStr += "AND "
+		} else {
+			queryStr += "WHERE "
+		}
 		if order == OrderAsc {
 			queryStr += "coordinator.item_id >= ? "
 		} else {


### PR DESCRIPTION
- Add boot coordinator to coordinator table at historydb, close #374 
- Change coordinator endpoints: a single endpoint with filters by `bidderAddr` and `forgerAddr`, close #375  