### PR TITLE
Fix StateDB & Til Nonce increment

### DIFF
--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -551,10 +551,10 @@ func TestTxs(t *testing.T) {
 	assert.Equal(t, common.TxTypeExit, dbL2Txs[3].Type)
 
 	// Tx ID
-	assert.Equal(t, "0x020000000001030000000001", dbL2Txs[0].TxID.String())
-	assert.Equal(t, "0x020000000001010000000001", dbL2Txs[1].TxID.String())
-	assert.Equal(t, "0x020000000001000000000001", dbL2Txs[2].TxID.String())
-	assert.Equal(t, "0x020000000001000000000002", dbL2Txs[3].TxID.String())
+	assert.Equal(t, "0x020000000001030000000000", dbL2Txs[0].TxID.String())
+	assert.Equal(t, "0x020000000001010000000000", dbL2Txs[1].TxID.String())
+	assert.Equal(t, "0x020000000001000000000000", dbL2Txs[2].TxID.String())
+	assert.Equal(t, "0x020000000001000000000001", dbL2Txs[3].TxID.String())
 
 	// Tx From and To IDx
 	assert.Equal(t, dbL2Txs[0].ToIdx, dbL2Txs[2].FromIdx)

--- a/db/statedb/txprocessors.go
+++ b/db/statedb/txprocessors.go
@@ -595,7 +595,7 @@ func (s *StateDB) ProcessL2Tx(coordIdxsMap map[common.TokenID]common.Idx, collec
 			log.Errorw("GetAccount", "fromIdx", tx.FromIdx, "err", err)
 			return nil, nil, false, tracerr.Wrap(err)
 		}
-		tx.Nonce = acc.Nonce + 1
+		tx.Nonce = acc.Nonce
 		tx.TokenID = acc.TokenID
 	}
 

--- a/db/statedb/txprocessors_test.go
+++ b/db/statedb/txprocessors_test.go
@@ -413,9 +413,9 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	require.NoError(t, err)
 
 	// after processing expect l2Txs[0:2].Nonce!=0 and has expected value
-	assert.Equal(t, common.Nonce(6), l2Txs[0].Nonce)
-	assert.Equal(t, common.Nonce(7), l2Txs[1].Nonce)
-	assert.Equal(t, common.Nonce(8), l2Txs[2].Nonce)
+	assert.Equal(t, common.Nonce(5), l2Txs[0].Nonce)
+	assert.Equal(t, common.Nonce(6), l2Txs[1].Nonce)
+	assert.Equal(t, common.Nonce(7), l2Txs[2].Nonce)
 
 	assert.Equal(t, 4, len(ptOut.ExitInfos)) // the 'ForceExit(1)' is not computed yet, as the batch is without L1UserTxs
 	assert.Equal(t, 1, len(ptOut.CreatedAccounts))

--- a/test/til/txs.go
+++ b/test/til/txs.go
@@ -880,8 +880,8 @@ func (tc *Context) FillBlocksExtra(blocks []common.BlockData, cfg *ConfigExtra) 
 				tx := &batch.L2Txs[k]
 				tx.Position = position
 				position++
-				tc.extra.nonces[tx.FromIdx]++
 				tx.Nonce = tc.extra.nonces[tx.FromIdx]
+				tc.extra.nonces[tx.FromIdx]++
 				if err := tx.SetID(); err != nil {
 					return tracerr.Wrap(err)
 				}


### PR DESCRIPTION
Nonce was used as 'last used nonce', which in the contracts is used as 'next nonce to be used', now the StateDB uses the Nonce as 'next nonce to be used' also.