### PR TITLE
Sync ForgerCommitment and use it in coord

### DIFF
--- a/common/bid.go
+++ b/common/bid.go
@@ -26,13 +26,14 @@ type BidCoordinator struct {
 
 // Slot contains relevant information of a slot
 type Slot struct {
-	SlotNum        int64
-	DefaultSlotBid *big.Int
-	StartBlock     int64
-	EndBlock       int64
-	BatchesLen     int
-	BidValue       *big.Int
-	BootCoord      bool
+	SlotNum          int64
+	DefaultSlotBid   *big.Int
+	StartBlock       int64
+	EndBlock         int64
+	ForgerCommitment bool
+	// BatchesLen       int
+	BidValue  *big.Int
+	BootCoord bool
 	// Bidder, Forer and URL correspond to the winner of the slot (which is
 	// not always the highest bidder).  These are the values of the
 	// coordinator that is able to forge exclusively before the deadline.

--- a/coordinator/batch.go
+++ b/coordinator/batch.go
@@ -47,7 +47,7 @@ type BatchInfo struct {
 // DebugStore is a debug function to store the BatchInfo as a json text file in
 // storePath
 func (b *BatchInfo) DebugStore(storePath string) error {
-	batchJSON, err := json.Marshal(b)
+	batchJSON, err := json.MarshalIndent(b, "", "  ")
 	if err != nil {
 		return tracerr.Wrap(err)
 	}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -190,9 +190,10 @@ func (c *Coordinator) syncSCVars(vars synchronizer.SCVariablesPtr) {
 
 func (c *Coordinator) canForge(stats *synchronizer.Stats) bool {
 	anyoneForge := false
-	if stats.Sync.Auction.CurrentSlot.BatchesLen == 0 &&
-		c.consts.Auction.RelativeBlock(stats.Eth.LastBlock.Num+1) > int64(c.vars.Auction.SlotDeadline) {
-		log.Debug("Coordinator: anyone can forge in the current slot (slotDeadline passed)")
+	if !stats.Sync.Auction.CurrentSlot.ForgerCommitment &&
+		c.consts.Auction.RelativeBlock(stats.Eth.LastBlock.Num+1) >= int64(c.vars.Auction.SlotDeadline) {
+		log.Debugw("Coordinator: anyone can forge in the current slot (slotDeadline passed)",
+			"block", stats.Eth.LastBlock.Num)
 		anyoneForge = true
 	}
 	if stats.Sync.Auction.CurrentSlot.Forger == c.cfg.ForgerAddress || anyoneForge {

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -213,6 +213,7 @@ func TestCoordinatorFlow(t *testing.T) {
 		return
 	}
 	ethClientSetup := test.NewClientSetupExample()
+	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
 	modules := newTestModules(t)
@@ -294,6 +295,7 @@ func TestCoordinatorFlow(t *testing.T) {
 
 func TestCoordinatorStartStop(t *testing.T) {
 	ethClientSetup := test.NewClientSetupExample()
+	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
 	modules := newTestModules(t)
@@ -304,6 +306,7 @@ func TestCoordinatorStartStop(t *testing.T) {
 
 func TestCoordCanForge(t *testing.T) {
 	ethClientSetup := test.NewClientSetupExample()
+	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	bootForger := ethClientSetup.AuctionVariables.BootCoordinator
 
 	var timer timer
@@ -356,6 +359,7 @@ func TestCoordCanForge(t *testing.T) {
 
 func TestCoordHandleMsgSyncBlock(t *testing.T) {
 	ethClientSetup := test.NewClientSetupExample()
+	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	bootForger := ethClientSetup.AuctionVariables.BootCoordinator
 
 	var timer timer
@@ -417,6 +421,7 @@ func TestCoordHandleMsgSyncBlock(t *testing.T) {
 
 func TestPipelineShouldL1L2Batch(t *testing.T) {
 	ethClientSetup := test.NewClientSetupExample()
+	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 
 	var timer timer
 	ctx := context.Background()
@@ -562,6 +567,7 @@ func preloadSync(t *testing.T, ethClient *test.Client, sync *synchronizer.Synchr
 
 func TestPipeline1(t *testing.T) {
 	ethClientSetup := test.NewClientSetupExample()
+	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 
 	var timer timer
 	ctx := context.Background()
@@ -646,6 +652,7 @@ func TestCoordinatorStress(t *testing.T) {
 	}
 	log.Info("Begin Test Coord Stress")
 	ethClientSetup := test.NewClientSetupExample()
+	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
 	modules := newTestModules(t)
@@ -691,7 +698,7 @@ func TestCoordinatorStress(t *testing.T) {
 			case <-ctx.Done():
 				wg.Done()
 				return
-			case <-time.After(100 * time.Millisecond):
+			case <-time.After(1 * time.Second):
 				ethClient.CtlMineBlock()
 			}
 		}

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -293,11 +293,15 @@ func (hdb *HistoryDB) GetBatches(from, to common.BatchNum) ([]common.Batch, erro
 	return db.SlicePtrsToSlice(batches).([]common.Batch), tracerr.Wrap(err)
 }
 
-// GetBatchesLen retrieve number of batches from the DB, given a slotNum
-func (hdb *HistoryDB) GetBatchesLen(slotNum int64) (int, error) {
-	row := hdb.db.QueryRow("SELECT COUNT(*) FROM batch WHERE slot_num = $1;", slotNum)
-	var batchesLen int
-	return batchesLen, tracerr.Wrap(row.Scan(&batchesLen))
+// GetFirstBatchBlockNumBySlot returns the ethereum block number of the first
+// batch within a slot
+func (hdb *HistoryDB) GetFirstBatchBlockNumBySlot(slotNum int64) (int64, error) {
+	row := hdb.db.QueryRow(
+		`SELECT eth_block_num FROM batch
+		WHERE slot_num = $1 ORDER BY batch_num ASC LIMIT 1;`, slotNum,
+	)
+	var blockNum int64
+	return blockNum, tracerr.Wrap(row.Scan(&blockNum))
 }
 
 // GetLastBatchNum returns the BatchNum of the latest forged batch

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -288,7 +288,8 @@ func (p *ProofServerClient) WaitReady(ctx context.Context) error {
 
 // MockClient is a mock ServerProof to be used in tests.  It doesn't calculate anything
 type MockClient struct {
-	Delay time.Duration
+	counter int64
+	Delay   time.Duration
 }
 
 // CalculateProof sends the *common.ZKInputs to the ServerProof to compute the
@@ -302,7 +303,24 @@ func (p *MockClient) GetProof(ctx context.Context) (*Proof, []*big.Int, error) {
 	// Simulate a delay
 	select {
 	case <-time.After(p.Delay): //nolint:gomnd
-		return &Proof{}, []*big.Int{big.NewInt(1234)}, nil //nolint:gomnd
+		i := p.counter * 100 //nolint:gomnd
+		p.counter++
+		return &Proof{
+				PiA: [3]*big.Int{
+					big.NewInt(i), big.NewInt(i + 1), big.NewInt(1), //nolint:gomnd
+				},
+				PiB: [3][2]*big.Int{
+					{big.NewInt(i + 2), big.NewInt(i + 3)}, //nolint:gomnd
+					{big.NewInt(i + 4), big.NewInt(i + 5)}, //nolint:gomnd
+					{big.NewInt(1), big.NewInt(0)},         //nolint:gomnd
+				},
+				PiC: [3]*big.Int{
+					big.NewInt(i + 6), big.NewInt(i + 7), big.NewInt(1), //nolint:gomnd
+				},
+				Protocol: "groth",
+			},
+			[]*big.Int{big.NewInt(i + 42)}, //nolint:gomnd
+			nil
 	case <-ctx.Done():
 		return nil, nil, tracerr.Wrap(common.ErrDone)
 	}

--- a/test/ethclient.go
+++ b/test/ethclient.go
@@ -399,6 +399,8 @@ type Client struct {
 
 	forgeBatchArgsPending map[ethCommon.Hash]*batch
 	forgeBatchArgs        map[ethCommon.Hash]*batch
+
+	startBlock int64
 }
 
 // NewClient returns a new test Client that implements the eth.IClient
@@ -480,7 +482,10 @@ func NewClient(l bool, timer Timer, addr *ethCommon.Address, setup *ClientSetup)
 		maxBlockNum:           blockNum,
 	}
 
-	for i := int64(1); i < setup.AuctionConstants.GenesisBlockNum+1; i++ {
+	if c.startBlock == 0 {
+		c.startBlock = 2
+	}
+	for i := int64(1); i < c.startBlock; i++ {
 		c.CtlMineBlock()
 	}
 

--- a/test/proofserver/proofserver.go
+++ b/test/proofserver/proofserver.go
@@ -180,7 +180,7 @@ func (s *Mock) runProver(ctx context.Context) {
 				"pi_a": ["%v", "%v", "1"],
 				"pi_b": [["%v", "%v"],["%v", "%v"],["1", "0"]],
 				"pi_c": ["%v", "%v", "1"],
-				"protocol": "groth16"
+				"protocol": "groth"
 			}`, i, i+1, i+2, i+3, i+4, i+5, i+6, i+7) //nolint:gomnd
 			s.pubData = fmt.Sprintf(`[
 				"%v"


### PR DESCRIPTION
Previously the coordinator was erroneously using Slot.BatchesLen to determine
when anyone can forge.  The correct behaviour is implmenented with the boolean
flag `ForgerCommitment`, that is set to true only when there's a batch before
the deadline within a slot.

Delete Slot.BatchesLen, and the synchronization code of this value from the
Synchronizer, as this is not needed