### PR TITLE
Include addrs in exit responses

### DIFF
--- a/api/exits_test.go
+++ b/api/exits_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hermeznetwork/hermez-node/apitypes"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/mitchellh/copystructure"
@@ -26,6 +27,8 @@ type testExit struct {
 	ItemID                 uint64                 `json:"itemId"`
 	BatchNum               common.BatchNum        `json:"batchNum"`
 	AccountIdx             string                 `json:"accountIndex"`
+	BJJ                    apitypes.HezBJJ        `json:"bjj"`
+	EthAddr                apitypes.HezEthAddr    `json:"hezEthereumAddress"`
 	MerkleProof            testCVP                `json:"merkleProof"`
 	Balance                string                 `json:"balance"`
 	InstantWithdrawn       *int64                 `json:"instantWithdrawn"`
@@ -63,9 +66,12 @@ func genTestExits(
 		for i := 0; i < len(exit.MerkleProof.Siblings); i++ {
 			siblings = append(siblings, exit.MerkleProof.Siblings[i].String())
 		}
+		acc := getAccountByIdx(exit.AccountIdx, accs)
 		allExits = append(allExits, testExit{
 			BatchNum:   exit.BatchNum,
 			AccountIdx: idxToHez(exit.AccountIdx, token.Symbol),
+			BJJ:        apitypes.NewHezBJJ(acc.PublicKey),
+			EthAddr:    apitypes.NewHezEthAddr(acc.EthAddr),
 			MerkleProof: testCVP{
 				Root:     exit.MerkleProof.Root.String(),
 				Siblings: siblings,

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2318,6 +2318,10 @@ components:
             - example: 7394
         accountIndex:
           $ref: '#/components/schemas/AccountIndex'
+        bjj:
+          $ref: '#/components/schemas/BJJ'      
+        hezEthereumAddress:
+          $ref: '#/components/schemas/HezEthereumAddress'
         itemId:
           $ref: '#/components/schemas/ItemId'
         merkleProof:
@@ -2382,6 +2386,8 @@ components:
       required:
           - batchNum
           - accountIndex
+          - bjj
+          - hezEthereumAddress
           - itemId
           - merkleProof
           - balance

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -1079,10 +1079,11 @@ func (hdb *HistoryDB) GetExitAPI(batchNum *uint, idx *common.Idx) (*ExitAPI, err
 	err := meddler.QueryRow(
 		hdb.db, exit, `SELECT exit_tree.item_id, exit_tree.batch_num,
 		hez_idx(exit_tree.account_idx, token.symbol) AS account_idx,
+		account.bjj, account.eth_addr,
 		exit_tree.merkle_proof, exit_tree.balance, exit_tree.instant_withdrawn,
 		exit_tree.delayed_withdraw_request, exit_tree.delayed_withdrawn,
 		token.token_id, token.item_id AS token_item_id, 
-		token.eth_block_num AS token_block, token.eth_addr, token.name, token.symbol, 
+		token.eth_block_num AS token_block, token.eth_addr AS token_eth_addr, token.name, token.symbol, 
 		token.decimals, token.usd, token.usd_update
 		FROM exit_tree INNER JOIN account ON exit_tree.account_idx = account.idx 
 		INNER JOIN token ON account.token_id = token.token_id 
@@ -1104,10 +1105,11 @@ func (hdb *HistoryDB) GetExitsAPI(
 	var args []interface{}
 	queryStr := `SELECT exit_tree.item_id, exit_tree.batch_num,
 	hez_idx(exit_tree.account_idx, token.symbol) AS account_idx,
+	account.bjj, account.eth_addr,
 	exit_tree.merkle_proof, exit_tree.balance, exit_tree.instant_withdrawn,
 	exit_tree.delayed_withdraw_request, exit_tree.delayed_withdrawn,
 	token.token_id, token.item_id AS token_item_id,
-	token.eth_block_num AS token_block, token.eth_addr, token.name, token.symbol,
+	token.eth_block_num AS token_block, token.eth_addr AS token_eth_addr, token.name, token.symbol,
 	token.decimals, token.usd, token.usd_update, COUNT(*) OVER() AS total_items
 	FROM exit_tree INNER JOIN account ON exit_tree.account_idx = account.idx 
 	INNER JOIN token ON account.token_id = token.token_id `

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -168,6 +168,8 @@ type ExitAPI struct {
 	ItemID                 uint64                          `meddler:"item_id"`
 	BatchNum               common.BatchNum                 `meddler:"batch_num"`
 	AccountIdx             apitypes.HezIdx                 `meddler:"account_idx"`
+	EthAddr                *apitypes.HezEthAddr            `meddler:"eth_addr"`
+	BJJ                    *apitypes.HezBJJ                `meddler:"bjj"`
 	MerkleProof            *merkletree.CircomVerifierProof `meddler:"merkle_proof,json"`
 	Balance                apitypes.BigIntStr              `meddler:"balance"`
 	InstantWithdrawn       *int64                          `meddler:"instant_withdrawn"`
@@ -179,7 +181,7 @@ type ExitAPI struct {
 	TokenID                common.TokenID                  `meddler:"token_id"`
 	TokenItemID            uint64                          `meddler:"token_item_id"`
 	TokenEthBlockNum       int64                           `meddler:"token_block"`
-	TokenEthAddr           ethCommon.Address               `meddler:"eth_addr"`
+	TokenEthAddr           ethCommon.Address               `meddler:"token_eth_addr"`
 	TokenName              string                          `meddler:"name"`
 	TokenSymbol            string                          `meddler:"symbol"`
 	TokenDecimals          uint64                          `meddler:"decimals"`
@@ -194,6 +196,8 @@ func (e ExitAPI) MarshalJSON() ([]byte, error) {
 		"itemId":                 e.ItemID,
 		"batchNum":               e.BatchNum,
 		"accountIndex":           e.AccountIdx,
+		"bjj":                    e.BJJ,
+		"hezEthereumAddress":     e.EthAddr,
 		"merkleProof":            e.MerkleProof,
 		"balance":                e.Balance,
 		"instantWithdrawn":       e.InstantWithdrawn,


### PR DESCRIPTION
Add ethereum address and BJJ in GET /exits API responses.
Close #309 