### PR TITLE
Load ethereum private key

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -38,7 +38,8 @@ TokenHEZ = "0x5D94e3e7aeC542aB0F9129B9a7BAdeb5B3Ca0f77"
 TokenHEZName = "Hermez Network Token"
 
 [Coordinator]
-ForgerAddress = "0x6BB84Cc84D4A34467aD12a2039A312f7029e2071"
+# ForgerAddress = "0x05c23b938a85ab26A36E6314a0D02080E9ca6BeD" # Non-Boot Coordinator
+ForgerAddress = "0xb4124ceb3451635dacedd11767f004d8a28c6ee7" # Boot Coordinator
 ConfirmBlocks = 10
 L1BatchTimeoutPerc = 0.6
 ProofServerPollInterval = "1s"
@@ -60,7 +61,7 @@ Path = "/tmp/iden3-test/hermez/txselector"
 Path = "/tmp/iden3-test/hermez/batchbuilder"
 
 [[Coordinator.ServerProofs]]
-URL = "http://localhost:3000"
+URL = "http://localhost:3000/api"
 
 [Coordinator.EthClient]
 CallGasLimit        = 300000
@@ -73,8 +74,13 @@ CheckLoopInterval = "500ms"
 Attempts = 8
 AttemptsDelay = "200ms"
 
+[Coordinator.EthClient.Keystore]
+Path = "/tmp/iden3-test/hermez/ethkeystore"
+Password = "yourpasswordhere"
+
 [Coordinator.API]
 Coordinator = true
 
 [Coordinator.Debug]
 BatchPath = "/tmp/iden3-test/hermez/batchesdebug"
+LightScrypt = true

--- a/cli/node/load-sk-example.sh
+++ b/cli/node/load-sk-example.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Non-Boot Coordinator
+go run . --mode coord --cfg cfg.buidler.toml importkey --privatekey 0x30f5fddb34cd4166adb2c6003fa6b18f380fd2341376be42cf1c7937004ac7a3
+
+# Boot Coordinator
+go run . --mode coord --cfg cfg.buidler.toml importkey --privatekey 0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,10 @@ type Coordinator struct {
 		// AttemptsDelay is delay between attempts do do an eth client
 		// RPC call
 		AttemptsDelay Duration `validate:"required"`
+		Keystore      struct {
+			Path     string `validate:"required"`
+			Password string `validate:"required"`
+		} `validate:"required"`
 	} `validate:"required"`
 	API struct {
 		Coordinator bool
@@ -91,6 +95,9 @@ type Coordinator struct {
 		// BatchPath if set, specifies the path where batchInfo is stored
 		// in JSON in every step/update of the pipeline
 		BatchPath string
+		// LightScrypt if set, uses light parameters for the ethereum
+		// keystore encryption algorithm.
+		LightScrypt bool
 	}
 }
 

--- a/db/statedb/statedb_test.go
+++ b/db/statedb/statedb_test.go
@@ -112,6 +112,10 @@ func TestNewStateDBIntermediateState(t *testing.T) {
 	sdb, err = NewStateDB(dir, 128, TypeTxSelector, 0)
 	assert.NoError(t, err)
 
+	bn, err = sdb.db.GetCurrentBatch()
+	assert.NoError(t, err)
+	assert.Equal(t, common.BatchNum(1), bn)
+
 	v, err = sdb.db.DB().Get(k0)
 	assert.NoError(t, err)
 	assert.Equal(t, v0, v)

--- a/eth/client.go
+++ b/eth/client.go
@@ -65,7 +65,10 @@ type ClientConfig struct {
 
 // NewClient creates a new Client to interact with Ethereum and the Hermez smart contracts.
 func NewClient(client *ethclient.Client, account *accounts.Account, ks *ethKeystore.KeyStore, cfg *ClientConfig) (*Client, error) {
-	ethereumClient := NewEthereumClient(client, account, ks, &cfg.Ethereum)
+	ethereumClient, err := NewEthereumClient(client, account, ks, &cfg.Ethereum)
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
 	auctionClient, err := NewAuctionClient(ethereumClient, cfg.Auction.Address, cfg.Auction.TokenHEZ)
 	if err != nil {
 		return nil, tracerr.Wrap(err)

--- a/eth/ethereum_test.go
+++ b/eth/ethereum_test.go
@@ -11,7 +11,8 @@ import (
 func TestEthERC20(t *testing.T) {
 	ethClient, err := ethclient.Dial(ethClientDialURL)
 	require.Nil(t, err)
-	client := NewEthereumClient(ethClient, auxAccount, ks, nil)
+	client, err := NewEthereumClient(ethClient, auxAccount, ks, nil)
+	require.Nil(t, err)
 
 	consts, err := client.EthERC20Consts(tokenHEZAddressConst)
 	require.Nil(t, err)

--- a/eth/main_test.go
+++ b/eth/main_test.go
@@ -164,7 +164,10 @@ func TestMain(m *testing.M) {
 		}
 
 		// Controllable Governance Address
-		ethereumClientGov := NewEthereumClient(ethClient, governanceAccount, ks, nil)
+		ethereumClientGov, err := NewEthereumClient(ethClient, governanceAccount, ks, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
 		auctionClient, err = NewAuctionClient(ethereumClientGov, auctionAddressConst, tokenHEZ)
 		if err != nil {
 			log.Fatal(err)
@@ -186,10 +189,22 @@ func TestMain(m *testing.M) {
 			log.Fatal(err)
 		}
 
-		ethereumClientEmergencyCouncil = NewEthereumClient(ethClient, emergencyCouncilAccount, ks, nil)
-		ethereumClientAux = NewEthereumClient(ethClient, auxAccount, ks, nil)
-		ethereumClientAux2 = NewEthereumClient(ethClient, aux2Account, ks, nil)
-		ethereumClientHermez = NewEthereumClient(ethClient, hermezRollupTestAccount, ks, nil)
+		ethereumClientEmergencyCouncil, err = NewEthereumClient(ethClient, emergencyCouncilAccount, ks, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		ethereumClientAux, err = NewEthereumClient(ethClient, auxAccount, ks, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		ethereumClientAux2, err = NewEthereumClient(ethClient, aux2Account, ks, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		ethereumClientHermez, err = NewEthereumClient(ethClient, hermezRollupTestAccount, ks, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		exitVal = m.Run()
 	}


### PR DESCRIPTION
Load an ethereum keystore when the node is started in coordinator mode.  The
private key corresponding to the forger address must be imported into the
keystore before running the node in coordinator mode.  You can see an examples
in `cli/node/load-sk-example.sh`.

Resolve #430 
Resolve #388 