### PR TITLE
empty array instead of 404

### DIFF
--- a/api/exits_test.go
+++ b/api/exits_test.go
@@ -43,6 +43,9 @@ type testExitsResponse struct {
 }
 
 func (t testExitsResponse) GetPending() (pendingItems, lastItemID uint64) {
+	if len(t.Exits) == 0 {
+		return 0, 0
+	}
 	pendingItems = t.PendingItems
 	lastItemID = t.Exits[len(t.Exits)-1].ItemID
 	return pendingItems, lastItemID
@@ -248,6 +251,12 @@ func TestGetExits(t *testing.T) {
 	err = doGoodReqPaginated(path, historydb.OrderDesc, &testExitsResponse{}, appendIter)
 	assert.NoError(t, err)
 	assertExitAPIs(t, flipedExits, fetchedExits)
+	// Empty array
+	fetchedExits = []testExit{}
+	path = fmt.Sprintf("%s?batchNum=999999", endpoint)
+	err = doGoodReqPaginated(path, historydb.OrderDesc, &testExitsResponse{}, appendIter)
+	assert.NoError(t, err)
+	assertExitAPIs(t, []testExit{}, fetchedExits)
 	// 400
 	path = fmt.Sprintf(
 		"%s?accountIndex=%s&hezEthereumAddress=%s",
@@ -257,13 +266,6 @@ func TestGetExits(t *testing.T) {
 	assert.NoError(t, err)
 	path = fmt.Sprintf("%s?tokenId=X", endpoint)
 	err = doBadReq("GET", path, nil, 400)
-	assert.NoError(t, err)
-	// 404
-	path = fmt.Sprintf("%s?batchNum=999999", endpoint)
-	err = doBadReq("GET", path, nil, 404)
-	assert.NoError(t, err)
-	path = fmt.Sprintf("%s?fromItem=1000999999", endpoint)
-	err = doBadReq("GET", path, nil, 404)
 	assert.NoError(t, err)
 }
 

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -215,12 +215,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:
@@ -347,12 +341,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:
@@ -565,12 +553,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:
@@ -687,12 +669,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:
@@ -850,12 +826,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:
@@ -960,12 +930,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:
@@ -1085,12 +1049,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error400'
-        '404':
-          description: Not found.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: Internal server error.
           content:

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -1,7 +1,6 @@
 package historydb
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"math"
@@ -265,7 +264,7 @@ func (hdb *HistoryDB) GetBatchesAPI(
 	}
 	batches := db.SlicePtrsToSlice(batchPtrs).([]BatchAPI)
 	if len(batches) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return batches, 0, nil
 	}
 	return batches, batches[0].TotalItems - uint64(len(batches)), nil
 }
@@ -441,7 +440,7 @@ func (hdb *HistoryDB) GetBestBidsAPI(
 	// log.Debug(query)
 	bids := db.SlicePtrsToSlice(bidPtrs).([]BidAPI)
 	if len(bids) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return bids, 0, nil
 	}
 	return bids, bids[0].TotalItems - uint64(len(bids)), nil
 }
@@ -512,7 +511,7 @@ func (hdb *HistoryDB) GetBidsAPI(
 		return nil, 0, tracerr.Wrap(err)
 	}
 	if len(bids) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return []BidAPI{}, 0, nil
 	}
 	return db.SlicePtrsToSlice(bids).([]BidAPI), bids[0].TotalItems - uint64(len(bids)), nil
 }
@@ -739,7 +738,7 @@ func (hdb *HistoryDB) GetTokens(
 		return nil, 0, tracerr.Wrap(err)
 	}
 	if len(tokens) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return []TokenWithUSD{}, 0, nil
 	}
 	return db.SlicePtrsToSlice(tokens).([]TokenWithUSD), uint64(len(tokens)) - tokens[0].TotalItems, nil
 }
@@ -1056,7 +1055,7 @@ func (hdb *HistoryDB) GetHistoryTxs(
 	}
 	txs := db.SlicePtrsToSlice(txsPtrs).([]TxAPI)
 	if len(txs) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return txs, 0, nil
 	}
 	return txs, txs[0].TotalItems - uint64(len(txs)), nil
 }
@@ -1199,7 +1198,7 @@ func (hdb *HistoryDB) GetExitsAPI(
 		return nil, 0, tracerr.Wrap(err)
 	}
 	if len(exits) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return []ExitAPI{}, 0, nil
 	}
 	return db.SlicePtrsToSlice(exits).([]ExitAPI), exits[0].TotalItems - uint64(len(exits)), nil
 }
@@ -1688,7 +1687,7 @@ func (hdb *HistoryDB) GetCoordinatorsAPI(
 		return nil, 0, tracerr.Wrap(err)
 	}
 	if len(coordinators) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return []CoordinatorAPI{}, 0, nil
 	}
 	return db.SlicePtrsToSlice(coordinators).([]CoordinatorAPI),
 		coordinators[0].TotalItems - uint64(len(coordinators)), nil
@@ -1811,7 +1810,7 @@ func (hdb *HistoryDB) GetAccountsAPI(
 		return nil, 0, tracerr.Wrap(err)
 	}
 	if len(accounts) == 0 {
-		return nil, 0, tracerr.Wrap(sql.ErrNoRows)
+		return []AccountAPI{}, 0, nil
 	}
 
 	return db.SlicePtrsToSlice(accounts).([]AccountAPI),


### PR DESCRIPTION
Paginated API endpoints return empty arrays instead of 404.
Close #384 