### PR TITLE
Update TxSelector to return CoordIdxs used & other

### DIFF
--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/txprocessor"
 	"github.com/hermeznetwork/hermez-node/txselector"
 	"github.com/hermeznetwork/tracerr"
+	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/iden3/go-merkletree"
 	"github.com/iden3/go-merkletree/db/pebble"
 	"github.com/stretchr/testify/assert"
@@ -115,9 +116,12 @@ func newTestModules(t *testing.T) modules {
 	require.NoError(t, err)
 	deleteme = append(deleteme, txSelDBPath)
 
+	var bjj babyjub.PublicKeyComp
+	err = bjj.UnmarshalText([]byte("c433f7a696b7aa3a5224efb3993baf0ccd9e92eecee0c29a3f6c8208a9e81d9e"))
+	require.NoError(t, err)
 	coordAccount := &txselector.CoordAccount{ // TODO TMP
 		Addr:                ethCommon.HexToAddress("0xc58d29fA6e86E4FAe04DDcEd660d45BCf3Cb2370"),
-		BJJ:                 common.EmptyBJJComp,
+		BJJ:                 bjj,
 		AccountCreationAuth: nil,
 	}
 	txSelector, err := txselector.NewTxSelector(coordAccount, txSelDBPath, syncStateDB, l2DB)

--- a/db/kvdb/kvdb.go
+++ b/db/kvdb/kvdb.go
@@ -123,7 +123,7 @@ func (kvdb *KVDB) reset(batchNum common.BatchNum, closeCurrent bool) error {
 		}
 		kvdb.db = sto
 		kvdb.CurrentIdx = 255
-		kvdb.CurrentBatch = batchNum
+		kvdb.CurrentBatch = 0
 
 		return nil
 	}
@@ -207,6 +207,11 @@ func (kvdb *KVDB) ResetFromSynchronizer(batchNum common.BatchNum, synchronizerKV
 
 	// get currentBatch num
 	kvdb.CurrentBatch, err = kvdb.GetCurrentBatch()
+	if err != nil {
+		return tracerr.Wrap(err)
+	}
+	// get currentIdx
+	kvdb.CurrentIdx, err = kvdb.GetCurrentIdx()
 	if err != nil {
 		return tracerr.Wrap(err)
 	}

--- a/db/statedb/statedb.go
+++ b/db/statedb/statedb.go
@@ -22,9 +22,9 @@ var (
 	// Account already exists
 	ErrAccountAlreadyExists = errors.New("Can not CreateAccount because Account already exists")
 
-	// ErrToIdxNotFound is used when trying to get the ToIdx from ToEthAddr
-	// or ToEthAddr&ToBJJ
-	ErrToIdxNotFound = errors.New("ToIdx can not be found")
+	// ErrIdxNotFound is used when trying to get the Idx from EthAddr or
+	// EthAddr&ToBJJ
+	ErrIdxNotFound = errors.New("Idx can not be found")
 	// ErrGetIdxNoCase is used when trying to get the Idx from EthAddr &
 	// BJJ with not compatible combination
 	ErrGetIdxNoCase = errors.New("Can not get Idx due unexpected combination of ethereum Address & BabyJubJub PublicKey")
@@ -148,6 +148,7 @@ func (s *StateDB) Reset(batchNum common.BatchNum) error {
 		}
 		s.MT = mt
 	}
+	log.Debugw("Making StateDB Reset", "batch", batchNum)
 	return nil
 }
 

--- a/db/statedb/utils_test.go
+++ b/db/statedb/utils_test.go
@@ -1,7 +1,6 @@
 package statedb
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -83,8 +82,7 @@ func TestGetIdx(t *testing.T) {
 	// expect error when trying to get Idx by addr2 & pk2
 	idxR, err = sdb.GetIdxByEthAddrBJJ(addr2, pk2.Compress(), tokenID0)
 	assert.NotNil(t, err)
-	expectedErr := fmt.Errorf("GetIdxByEthAddrBJJ: %s: ToEthAddr: %s, ToBJJ: %s, TokenID: %d", ErrToIdxNotFound, addr2.Hex(), pk2, tokenID0)
-	assert.Equal(t, expectedErr, tracerr.Unwrap(err))
+	assert.Equal(t, ErrIdxNotFound, tracerr.Unwrap(err))
 	assert.Equal(t, common.Idx(0), idxR)
 	// expect error when trying to get Idx by addr with not used TokenID
 	_, err = sdb.GetIdxByEthAddr(addr, tokenID1)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gobuffalo/packr/v2 v2.8.1
 	github.com/hermeznetwork/tracerr v0.3.1-0.20201126162137-de9930d0cf29
 	github.com/iden3/go-iden3-crypto v0.0.6-0.20201221160344-58e589b6eb4c
-	github.com/iden3/go-merkletree v0.0.0-20201230093451-4280a9914f51
+	github.com/iden3/go-merkletree v0.0.0-20201231091158-d73b96c55fbb
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/jmoiron/sqlx v1.2.1-0.20200615141059-0794cb1f47ee
 	github.com/joho/godotenv v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,8 @@ github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3
 github.com/iden3/go-iden3-crypto v0.0.6-0.20201218111145-a2015adb2f1b/go.mod h1:oBgthFLboAWi9feaBUFy7OxEcyn9vA1khHSL/WwWFyg=
 github.com/iden3/go-iden3-crypto v0.0.6-0.20201221160344-58e589b6eb4c h1:D2u8FFYey6iFXLsqqJZ8R7ch8gZum+/b98whvoSDbyg=
 github.com/iden3/go-iden3-crypto v0.0.6-0.20201221160344-58e589b6eb4c/go.mod h1:oBgthFLboAWi9feaBUFy7OxEcyn9vA1khHSL/WwWFyg=
-github.com/iden3/go-merkletree v0.0.0-20201230093451-4280a9914f51 h1:EqkLnC+JlOdX3hQnjq0u2JKcMMmmaQcpmG1udG6BTXw=
-github.com/iden3/go-merkletree v0.0.0-20201230093451-4280a9914f51/go.mod h1:MCXbnyoFRwt+7aYHtzVSB3sZZcHLjDf7VZZ2Zqrhqrc=
+github.com/iden3/go-merkletree v0.0.0-20201231091158-d73b96c55fbb h1:nwjQVe4nYNC6lwF4gAtSdmQ3vMkm0NpJzJVhoWpfSBc=
+github.com/iden3/go-merkletree v0.0.0-20201231091158-d73b96c55fbb/go.mod h1:MCXbnyoFRwt+7aYHtzVSB3sZZcHLjDf7VZZ2Zqrhqrc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=

--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -99,8 +99,6 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 		return nil, tracerr.Wrap(fmt.Errorf("CoordIdxs (%d) length must be smaller than MaxFeeTx (%d)", len(coordIdxs), tp.config.MaxFeeTx))
 	}
 
-	tp.AccumulatedFees = make(map[common.Idx]*big.Int)
-
 	nTx := len(l1usertxs) + len(l1coordinatortxs) + len(l2txs)
 
 	if nTx > int(tp.config.MaxTx) {

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -64,24 +64,6 @@ func addTokens(t *testing.T, tokens []common.Token, db *sqlx.DB) {
 	assert.NoError(t, hdb.AddTokens(tokens))
 }
 
-func TestCoordIdxsDB(t *testing.T) {
-	chainID := uint16(0)
-	txsel := initTest(t, chainID, til.SetPool0)
-	test.WipeDB(txsel.l2db.DB())
-
-	coordIdxs := make(map[common.TokenID]common.Idx)
-	coordIdxs[common.TokenID(0)] = common.Idx(256)
-	coordIdxs[common.TokenID(1)] = common.Idx(257)
-	coordIdxs[common.TokenID(2)] = common.Idx(258)
-
-	err := txsel.AddCoordIdxs(coordIdxs)
-	assert.NoError(t, err)
-
-	r, err := txsel.GetCoordIdxs()
-	assert.NoError(t, err)
-	assert.Equal(t, coordIdxs, r)
-}
-
 func TestGetL2TxSelection(t *testing.T) {
 	chainID := uint16(0)
 	txsel := initTest(t, chainID, til.SetPool0)
@@ -99,8 +81,6 @@ func TestGetL2TxSelection(t *testing.T) {
 	coordIdxs[common.TokenID(1)] = common.Idx(257)
 	coordIdxs[common.TokenID(2)] = common.Idx(258)
 	coordIdxs[common.TokenID(3)] = common.Idx(259)
-	err = txsel.AddCoordIdxs(coordIdxs)
-	assert.NoError(t, err)
 
 	// add tokens to HistoryDB to avoid breaking FK constrains
 	var tokens []common.Token


### PR DESCRIPTION
- StateDB
  - Update GetIdxByEthAddrBJJ to return ErrToIdxNotFound when idx not found, so can be checked at upper levels
- TxSelector
  - rm CoordIdxsDB that is no longer needed (also related methods)
  - add `getCoordIdx` method to get the Coordinator Idx for a given TokenID
  - Update coordinator account creation related to new TokenIDs from L2Txs
  - Reorganize GetL1L2TxSelection
  - return CoordIdxs used in the selection
- Update go-merkletree version which avoids marshaling Siblings to json with 'null' value in case of empty array