### PR TITLE
Update node and apply some fixes

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -40,11 +40,19 @@ TokenHEZName = "Hermez Network Token"
 
 [Coordinator]
 # ForgerAddress = "0x05c23b938a85ab26A36E6314a0D02080E9ca6BeD" # Non-Boot Coordinator
+# ForgerAddressPrivateKey = "0x30f5fddb34cd4166adb2c6003fa6b18f380fd2341376be42cf1c7937004ac7a3"
 ForgerAddress = "0xb4124ceb3451635dacedd11767f004d8a28c6ee7" # Boot Coordinator
+# ForgerAddressPrivateKey = "0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563"
 ConfirmBlocks = 10
-L1BatchTimeoutPerc = 0.6
+L1BatchTimeoutPerc = 0.4
 ProofServerPollInterval = "1s"
 SyncRetryInterval = "1s"
+
+[Coordinator.FeeAccount]
+Address = "0x56232B1c5B10038125Bc7345664B4AFD745bcF8E"
+# PrivateKey = "0x3a9270c020e169097808da4b02e8d9100be0f8a38cfad3dcfc0b398076381fdd"
+BJJ = "0x1b176232f78ba0d388ecc5f4896eca2d3b3d4f272092469f559247297f5c0c13"
+# BJJPrivateKey = "0xb556862fb60e7cf4c0a8a7f44baf2ab06a4c90ac39decc4eef363b6142d07a34"
 
 [Coordinator.L2DB]
 SafetyPeriod = 10
@@ -71,10 +79,11 @@ NLevels = 32
 [Coordinator.EthClient]
 ReceiptTimeout      = "60s"
 ReceiptLoopInterval = "500ms"
-
 CheckLoopInterval = "500ms"
 Attempts = 8
 AttemptsDelay = "200ms"
+CallGasLimit = 300000
+GasPriceDiv = 100
 
 [Coordinator.EthClient.Keystore]
 Path = "/tmp/iden3-test/hermez/ethkeystore"

--- a/cli/node/load-sk-example.sh
+++ b/cli/node/load-sk-example.sh
@@ -5,3 +5,6 @@ go run . --mode coord --cfg cfg.buidler.toml importkey --privatekey 0x30f5fddb34
 
 # Boot Coordinator
 go run . --mode coord --cfg cfg.buidler.toml importkey --privatekey 0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563
+
+# FeeAccount
+go run . --mode coord --cfg cfg.buidler.toml importkey --privatekey 0x3a9270c020e169097808da4b02e8d9100be0f8a38cfad3dcfc0b398076381fdd

--- a/cli/node/main.go
+++ b/cli/node/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/signal"
@@ -13,6 +14,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/hermez-node/node"
 	"github.com/hermeznetwork/tracerr"
+	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/urfave/cli/v2"
 )
 
@@ -24,6 +26,15 @@ const (
 	modeSync  = "sync"
 	modeCoord = "coord"
 )
+
+func cmdGenBJJ(c *cli.Context) error {
+	sk := babyjub.NewRandPrivKey()
+	skBuf := [32]byte(sk)
+	pk := sk.Public()
+	fmt.Printf("BJJ = \"0x%s\"\n", pk.String())
+	fmt.Printf("BJJPrivateKey = \"0x%s\"\n", hex.EncodeToString(skBuf[:]))
+	return nil
+}
 
 func cmdImportKey(c *cli.Context) error {
 	_cfg, err := parseCli(c)
@@ -195,6 +206,12 @@ func main() {
 					Usage:    "ethereum `PRIVATE_KEY` in hex",
 					Required: true,
 				}},
+		},
+		{
+			Name:    "genbjj",
+			Aliases: []string{},
+			Usage:   "Generate a new BabyJubJub key",
+			Action:  cmdGenBJJ,
 		},
 		{
 			Name:    "wipesql",

--- a/common/ethrollup.go
+++ b/common/ethrollup.go
@@ -33,7 +33,7 @@ const (
 	// RollupConstInputSHAConstantBytes [6 bytes] lastIdx + [6 bytes] newLastIdx  + [32 bytes] stateRoot  + [32 bytes] newStRoot  + [32 bytes] newExitRoot +
 	// [_MAX_L1_TX * _L1_USER_TOTALBYTES bytes] l1TxsData + totalL2TxsDataLength + feeIdxCoordinatorLength + [2 bytes] chainID =
 	// 18542 bytes +  totalL2TxsDataLength + feeIdxCoordinatorLength
-	RollupConstInputSHAConstantBytes = 18542
+	RollupConstInputSHAConstantBytes = 18546
 	// RollupConstNumBuckets Number of buckets
 	RollupConstNumBuckets = 5
 	// RollupConstMaxWithdrawalDelay max withdrawal delay in seconds

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/tracerr"
+	"github.com/iden3/go-iden3-crypto/babyjub"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -37,6 +38,13 @@ type ServerProof struct {
 type Coordinator struct {
 	// ForgerAddress is the address under which this coordinator is forging
 	ForgerAddress ethCommon.Address `validate:"required"`
+	// FeeAccount is the Hermez account that the coordinator uses to receive fees
+	FeeAccount struct {
+		// Address is the ethereum address of the account to receive fees
+		Address ethCommon.Address `validate:"required"`
+		// BJJ is the baby jub jub public key of the account to receive fees
+		BJJ babyjub.PublicKeyComp `validate:"required"`
+	} `validate:"required"`
 	// ConfirmBlocks is the number of confirmation blocks to wait for sent
 	// ethereum transactions before forgetting about them
 	ConfirmBlocks int64 `validate:"required"`
@@ -162,7 +170,8 @@ type Node struct {
 		SyncLoopInterval Duration `validate:"required"`
 		// StatsRefreshPeriod is the interval between updates of the
 		// synchronizer state Eth parameters (`Eth.LastBlock` and
-		// `Eth.LastBatch`)
+		// `Eth.LastBatch`).  This value only affects the reported % of
+		// synchronization of blocks and batches, nothing else.
 		StatsRefreshPeriod Duration `validate:"required"`
 	} `validate:"required"`
 	SmartContracts struct {

--- a/coordinator/batch.go
+++ b/coordinator/batch.go
@@ -14,14 +14,22 @@ import (
 	"github.com/hermeznetwork/tracerr"
 )
 
-// TxStatus is used to mark the status of an ethereum transaction
-type TxStatus string
+// Status is used to mark the status of the batch
+type Status string
 
 const (
-	// TxStatusPending marks the Tx as Pending
-	TxStatusPending TxStatus = "pending"
-	// TxStatusSent marks the Tx as Sent
-	TxStatusSent TxStatus = "sent"
+	// StatusPending marks the Tx as Pending
+	StatusPending Status = "pending"
+	// StatusForged marks the batch as forged internally
+	StatusForged Status = "forged"
+	// StatusProof marks the batch as proof calculated
+	StatusProof Status = "proof"
+	// StatusSent marks the EthTx as Sent
+	StatusSent Status = "sent"
+	// StatusMined marks the EthTx as Mined
+	StatusMined Status = "mined"
+	// StatusFailed marks the EthTx as Failed
+	StatusFailed Status = "failed"
 )
 
 // BatchInfo contans the Batch information
@@ -40,9 +48,9 @@ type BatchInfo struct {
 	CoordIdxs             []common.Idx
 	ForgeBatchArgs        *eth.RollupForgeBatchArgs
 	// FeesInfo
-	TxStatus TxStatus
-	EthTx    *types.Transaction
-	Receipt  *types.Receipt
+	Status  Status
+	EthTx   *types.Transaction
+	Receipt *types.Receipt
 }
 
 // DebugStore is a debug function to store the BatchInfo as a json text file in

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -445,7 +445,7 @@ func TestPipelineShouldL1L2Batch(t *testing.T) {
 	modules := newTestModules(t)
 	var stats synchronizer.Stats
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
-	pipeline, err := coord.newPipeline(ctx, &stats)
+	pipeline, err := coord.newPipeline(ctx)
 	require.NoError(t, err)
 	pipeline.vars = coord.vars
 
@@ -598,7 +598,7 @@ func TestPipeline1(t *testing.T) {
 	batchNum := common.BatchNum(syncStats.Sync.LastBatch)
 	syncSCVars := sync.SCVars()
 
-	pipeline, err := coord.newPipeline(ctx, syncStats)
+	pipeline, err := coord.newPipeline(ctx)
 	require.NoError(t, err)
 
 	// Insert some l2txs in the Pool
@@ -616,7 +616,7 @@ PoolTransfer(0) User2-User3: 300 (126)
 		require.NoError(t, err)
 	}
 
-	err = pipeline.reset(batchNum, syncStats.Sync.LastForgeL1TxsNum, &synchronizer.SCVariables{
+	err = pipeline.reset(batchNum, syncStats.Sync.LastForgeL1TxsNum, syncStats, &synchronizer.SCVariables{
 		Rollup:   *syncSCVars.Rollup,
 		Auction:  *syncSCVars.Auction,
 		WDelayer: *syncSCVars.WDelayer,

--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -139,6 +139,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 		if err != nil {
 			return nil, tracerr.Wrap(err)
 		}
+		defer sto.Close()
 		exitTree, err = merkletree.NewMerkleTree(sto, tp.s.MT.MaxLevels())
 		if err != nil {
 			return nil, tracerr.Wrap(err)


### PR DESCRIPTION
- Node
	- Load Coordinator Fee Account from config
		- Sign the AccountCreationMsg to generate the
		  AccountCreationAuth
		- Resolve #465
	- Wait for synchronizer termination before stopping coordinator to avoid
	  getting stuck when closing in the following case:
		- The coordinator stops reading the synchronizer msg channel,
		  and the node gets stuck sending a message to that channel.
- Common
	- Move account creation auth signature code to common.
	- Update RollupConstInputSHAConstantBytes
- Coordinator
	- Set batch status in the debug file
	- Propagate SCVariables on reorg
	- Pipeline: Get SCVariables updates
		- Resolve #457
	- Fix off by 1 error in Pipeline.shouldL1L2Batch() (which shouldn't have
	  caused any problem, but it was not right)
- KVDB
	- Delete future checkpoints after reset
	- In `ResetFromSynchronizer`, remove all checkpoints first, and follow
	  the same logic as `reset()`.
- Cli
	- Add command to generate a BabyJubJub key pair (to be used for the
	  Coordinator Fee Account)
- Node
	- Adjust example config `Coordinator.L1BatchTimeoutPerc` to avoid
	  missing the L1Batch deadline with the following setup:
		- a block is mined every 2 seconds
		- single proof server that takes 2 seconds to calculate a proof
- TxProcessor
	- Close temporary pebble used for the exit tree after usage.
		- Resolve #463

Resolve #452