### PR TITLE
Fix repeated items when coordinator is updated

### DIFF
--- a/api/coordinator_test.go
+++ b/api/coordinator_test.go
@@ -31,12 +31,27 @@ func (t testCoordinatorsResponse) New() Pendinger { return &testCoordinatorsResp
 func genTestCoordinators(coordinators []common.Coordinator) []historydb.CoordinatorAPI {
 	testCoords := []historydb.CoordinatorAPI{}
 	for i := 0; i < len(coordinators); i++ {
-		testCoords = append(testCoords, historydb.CoordinatorAPI{
-			Bidder:      coordinators[i].Bidder,
-			Forger:      coordinators[i].Forger,
-			EthBlockNum: coordinators[i].EthBlockNum,
-			URL:         coordinators[i].URL,
-		})
+		alreadyRegistered := false
+		for j := 0; j < len(testCoords); j++ {
+			// coordinator already registered
+			if coordinators[i].Bidder == testCoords[j].Bidder {
+				alreadyRegistered = true
+				if coordinators[i].EthBlockNum > testCoords[j].EthBlockNum {
+					// This occurrence is more updated, delete current and append new
+					testCoords = append(testCoords[:j], testCoords[j+1:]...)
+					alreadyRegistered = false
+				}
+				break
+			}
+		}
+		if !alreadyRegistered {
+			testCoords = append(testCoords, historydb.CoordinatorAPI{
+				Bidder:      coordinators[i].Bidder,
+				Forger:      coordinators[i].Forger,
+				EthBlockNum: coordinators[i].EthBlockNum,
+				URL:         coordinators[i].URL,
+			})
+		}
 	}
 	return testCoords
 }

--- a/api/slots_test.go
+++ b/api/slots_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/mitchellh/copystructure"
@@ -148,7 +149,12 @@ func TestGetSlots(t *testing.T) {
 	// maxSlotNum & wonByEthereumAddress
 	fetchedSlots = []testSlot{}
 	limit = 1
-	bidderAddr := tc.coordinators[0].Bidder
+	var bidderAddr ethCommon.Address
+	for i := 0; i < len(tc.slots); i++ {
+		if tc.slots[i].WinnerBid != nil {
+			bidderAddr = tc.slots[i].WinnerBid.Bidder
+		}
+	}
 	path = fmt.Sprintf("%s?maxSlotNum=%d&wonByEthereumAddress=%s&limit=%d", endpoint, maxSlotNum, bidderAddr.String(), limit)
 	err = doGoodReqPaginated(path, historydb.OrderAsc, &testSlotsResponse{}, appendIter)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixed some problems in the API that occurred when the same coordinator (bidder address) has multiple entries on the `coordinator` table on the HistoryDB. Those problems where basically:
- SQL joins were causing duplication
- Not having the most updated response

Close #466 