### PR TITLE
In pool l2tx, store effective in aux column

### DIFF
--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -143,9 +143,9 @@ func (l2db *L2DB) AddTxTest(tx *common.PoolL2Tx) error {
 }
 
 // selectPoolTxAPI select part of queries to get PoolL2TxRead
-const selectPoolTxAPI = `SELECT  tx_pool.tx_id, hez_idx(tx_pool.from_idx, token.symbol) AS from_idx, tx_pool.from_eth_addr, 
-tx_pool.from_bjj, hez_idx(tx_pool.to_idx, token.symbol) AS to_idx, tx_pool.to_eth_addr, 
-tx_pool.to_bjj, tx_pool.token_id, tx_pool.amount, tx_pool.fee, tx_pool.nonce, 
+const selectPoolTxAPI = `SELECT  tx_pool.tx_id, hez_idx(tx_pool.from_idx, token.symbol) AS from_idx, tx_pool.effective_from_eth_addr, 
+tx_pool.effective_from_bjj, hez_idx(tx_pool.to_idx, token.symbol) AS to_idx, tx_pool.effective_to_eth_addr, 
+tx_pool.effective_to_bjj, tx_pool.token_id, tx_pool.amount, tx_pool.fee, tx_pool.nonce, 
 tx_pool.state, tx_pool.signature, tx_pool.timestamp, tx_pool.batch_num, hez_idx(tx_pool.rq_from_idx, token.symbol) AS rq_from_idx, 
 hez_idx(tx_pool.rq_to_idx, token.symbol) AS rq_to_idx, tx_pool.rq_to_eth_addr, tx_pool.rq_to_bjj, tx_pool.rq_token_id, tx_pool.rq_amount, 
 tx_pool.rq_fee, tx_pool.rq_nonce, tx_pool.tx_type, 

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -38,27 +38,27 @@ type PoolL2TxWrite struct {
 
 // PoolTxAPI represents a L2 Tx pool with extra metadata used by the API
 type PoolTxAPI struct {
-	TxID        common.TxID           `meddler:"tx_id"`
-	FromIdx     apitypes.HezIdx       `meddler:"from_idx"`
-	FromEthAddr *apitypes.HezEthAddr  `meddler:"from_eth_addr"`
-	FromBJJ     *apitypes.HezBJJ      `meddler:"from_bjj"`
-	ToIdx       *apitypes.HezIdx      `meddler:"to_idx"`
-	ToEthAddr   *apitypes.HezEthAddr  `meddler:"to_eth_addr"`
-	ToBJJ       *apitypes.HezBJJ      `meddler:"to_bjj"`
-	Amount      apitypes.BigIntStr    `meddler:"amount"`
-	Fee         common.FeeSelector    `meddler:"fee"`
-	Nonce       common.Nonce          `meddler:"nonce"`
-	State       common.PoolL2TxState  `meddler:"state"`
-	Signature   babyjub.SignatureComp `meddler:"signature"`
-	RqFromIdx   *apitypes.HezIdx      `meddler:"rq_from_idx"`
-	RqToIdx     *apitypes.HezIdx      `meddler:"rq_to_idx"`
-	RqToEthAddr *apitypes.HezEthAddr  `meddler:"rq_to_eth_addr"`
-	RqToBJJ     *apitypes.HezBJJ      `meddler:"rq_to_bjj"`
-	RqTokenID   *common.TokenID       `meddler:"rq_token_id"`
-	RqAmount    *apitypes.BigIntStr   `meddler:"rq_amount"`
-	RqFee       *common.FeeSelector   `meddler:"rq_fee"`
-	RqNonce     *common.Nonce         `meddler:"rq_nonce"`
-	Type        common.TxType         `meddler:"tx_type"`
+	TxID                 common.TxID           `meddler:"tx_id"`
+	FromIdx              apitypes.HezIdx       `meddler:"from_idx"`
+	EffectiveFromEthAddr *apitypes.HezEthAddr  `meddler:"effective_from_eth_addr"`
+	EffectiveFromBJJ     *apitypes.HezBJJ      `meddler:"effective_from_bjj"`
+	ToIdx                *apitypes.HezIdx      `meddler:"to_idx"`
+	EffectiveToEthAddr   *apitypes.HezEthAddr  `meddler:"effective_to_eth_addr"`
+	EffectiveToBJJ       *apitypes.HezBJJ      `meddler:"effective_to_bjj"`
+	Amount               apitypes.BigIntStr    `meddler:"amount"`
+	Fee                  common.FeeSelector    `meddler:"fee"`
+	Nonce                common.Nonce          `meddler:"nonce"`
+	State                common.PoolL2TxState  `meddler:"state"`
+	Signature            babyjub.SignatureComp `meddler:"signature"`
+	RqFromIdx            *apitypes.HezIdx      `meddler:"rq_from_idx"`
+	RqToIdx              *apitypes.HezIdx      `meddler:"rq_to_idx"`
+	RqToEthAddr          *apitypes.HezEthAddr  `meddler:"rq_to_eth_addr"`
+	RqToBJJ              *apitypes.HezBJJ      `meddler:"rq_to_bjj"`
+	RqTokenID            *common.TokenID       `meddler:"rq_token_id"`
+	RqAmount             *apitypes.BigIntStr   `meddler:"rq_amount"`
+	RqFee                *common.FeeSelector   `meddler:"rq_fee"`
+	RqNonce              *common.Nonce         `meddler:"rq_nonce"`
+	Type                 common.TxType         `meddler:"tx_type"`
 	// Extra read fileds
 	BatchNum         *common.BatchNum  `meddler:"batch_num"`
 	Timestamp        time.Time         `meddler:"timestamp,utctime"`
@@ -81,11 +81,11 @@ func (tx PoolTxAPI) MarshalJSON() ([]byte, error) {
 		"id":                          tx.TxID,
 		"type":                        tx.Type,
 		"fromAccountIndex":            tx.FromIdx,
-		"fromHezEthereumAddress":      tx.FromEthAddr,
-		"fromBJJ":                     tx.FromBJJ,
+		"fromHezEthereumAddress":      tx.EffectiveFromEthAddr,
+		"fromBJJ":                     tx.EffectiveFromBJJ,
 		"toAccountIndex":              tx.ToIdx,
-		"toHezEthereumAddress":        tx.ToEthAddr,
-		"toBjj":                       tx.ToBJJ,
+		"toHezEthereumAddress":        tx.EffectiveToEthAddr,
+		"toBjj":                       tx.EffectiveToBJJ,
 		"amount":                      tx.Amount,
 		"fee":                         tx.Fee,
 		"nonce":                       tx.Nonce,

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -593,11 +593,13 @@ CREATE TABLE wdelayer_vars (
 CREATE TABLE tx_pool (
     tx_id BYTEA PRIMARY KEY,
     from_idx BIGINT NOT NULL,
-    from_eth_addr BYTEA,
-    from_bjj BYTEA,
+    effective_from_eth_addr BYTEA,
+    effective_from_bjj BYTEA,
     to_idx BIGINT,
     to_eth_addr BYTEA,
     to_bjj BYTEA,
+    effective_to_eth_addr BYTEA,
+    effective_to_bjj BYTEA,
     token_id INT NOT NULL REFERENCES token (token_id) ON DELETE CASCADE,
     amount BYTEA NOT NULL,
     amount_f NUMERIC NOT NULL,
@@ -624,10 +626,13 @@ CREATE FUNCTION set_pool_tx()
 AS 
 $BODY$
 BEGIN
-    SELECT INTO NEW."from_eth_addr", NEW."from_bjj" eth_addr, bjj FROM account WHERE idx = NEW."from_idx";
+    SELECT INTO NEW."effective_from_eth_addr", NEW."effective_from_bjj" eth_addr, bjj FROM account WHERE idx = NEW."from_idx";
      -- Set to_{eth_addr,bjj}
     IF NEW.to_idx > 255 THEN
-        SELECT INTO NEW."to_eth_addr", NEW."to_bjj" eth_addr, bjj FROM account WHERE idx = NEW."to_idx";
+        SELECT INTO NEW."effective_to_eth_addr", NEW."effective_to_bjj" eth_addr, bjj FROM account WHERE idx = NEW."to_idx";
+    ELSE
+        NEW."effective_to_eth_addr" = NEW."to_eth_addr";
+        NEW."effective_to_bjj" = NEW."to_bjj";
     END IF;
     RETURN NEW;
 END;


### PR DESCRIPTION
- Rename `from_eth_addr` and `from_bjj` to `effective_from_eth_addr` and `effective_from_bjj` columns in `tx_pool` table to make it clear that these fields are calculated after the fact (they are not in the original tx)
- Add `effective_to_eth_addr` and `effective_to_bjj` in `tx_pool` table to make it clear that these fields are calculated after the fact (they are not in the original tx) and to avoid overwriting the values of `to_eth_addr` and `to_bjj` so that the signature remains always valid and no field sent by the user is changed.
Resolve #488