### PR TITLE
Fix exit tree nonces

### DIFF
--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -1134,7 +1134,6 @@ func (tp *TxProcessor) applyExit(coordIdxsMap map[common.TokenID]common.Idx,
 	} else if err != nil {
 		return exitAccount, false, tracerr.Wrap(err)
 	}
-	exitAccount.Nonce = exitAccount.Nonce + 1
 
 	// 1b. if idx already exist in exitTree:
 	if tp.zki != nil {


### PR DESCRIPTION
Remove increment in exit tree leaf nonce when there are multiple exits for the
same account in the same batch.

Add a test to verify the correct implementation of exit leafs caused by
multiple exits.