### PR TITLE
Fix api resopnse format for recommended fee

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2193,6 +2193,11 @@ components:
           description: Recommended fee if the destination account of the transaction doesn't exist, but the coordinator has the ability to create a valid account associated to a BJJ public key controlled by the receiver. Note that these kind of accounts are not associated with an Ethereum address and therefore can only operate in L2. 
           minimum: 0
           example: 0.5
+      required:
+        - existingAccount
+        - createAccount
+        - createAccountInternal
+      additionalProperties: false
     Token:
       type: object
       description: Hermez Network compatible and registered token.

--- a/common/fee.go
+++ b/common/fee.go
@@ -22,9 +22,9 @@ var FeeFactorLsh60 [256]*big.Int
 // the coordinator according to the tx type (if the tx requires to create an
 // account and register, only register or he account already esists)
 type RecommendedFee struct {
-	ExistingAccount           float64
-	CreatesAccount            float64
-	CreatesAccountAndRegister float64
+	ExistingAccount           float64 `json:"existingAccount"`
+	CreatesAccount            float64 `json:"createAccount"`
+	CreatesAccountAndRegister float64 `json:"createAccountInternal"`
 }
 
 // FeeSelector is used to select a percentage from the FeePlan.


### PR DESCRIPTION
- Fix upper case of recommended fee api response, close #508 
- Return specific error for API POSTs when the item already exists. It will always return `{"message": "Item already exists"}`, close #509 