### PR TITLE
Update TxID to use eth Keccak256

### DIFF
--- a/common/account.go
+++ b/common/account.go
@@ -17,14 +17,17 @@ import (
 const (
 	// NLeafElems is the number of elements for a leaf
 	NLeafElems = 4
-	// maxNonceValue is the maximum value that the Account.Nonce can have (40 bits: maxNonceValue=2**40-1)
+	// maxNonceValue is the maximum value that the Account.Nonce can have
+	// (40 bits: maxNonceValue=2**40-1)
 	maxNonceValue = 0xffffffffff
-	// maxBalanceBytes is the maximum bytes that can use the Account.Balance *big.Int
+	// maxBalanceBytes is the maximum bytes that can use the
+	// Account.Balance *big.Int
 	maxBalanceBytes = 24
 
 	// IdxBytesLen idx bytes
 	IdxBytesLen = 6
-	// maxIdxValue is the maximum value that Idx can have (48 bits: maxIdxValue=2**48-1)
+	// maxIdxValue is the maximum value that Idx can have (48 bits:
+	// maxIdxValue=2**48-1)
 	maxIdxValue = 0xffffffffffff
 
 	// UserThreshold determines the threshold from the User Idxs can be
@@ -85,7 +88,8 @@ func IdxFromBigInt(b *big.Int) (Idx, error) {
 	return Idx(uint64(b.Int64())), nil
 }
 
-// Nonce represents the nonce value in a uint64, which has the method Bytes that returns a byte array of length 5 (40 bits).
+// Nonce represents the nonce value in a uint64, which has the method Bytes
+// that returns a byte array of length 5 (40 bits).
 type Nonce uint64
 
 // Bytes returns a byte array of length 5 representing the Nonce
@@ -113,7 +117,9 @@ func NonceFromBytes(b [5]byte) Nonce {
 	return Nonce(nonce)
 }
 
-// Account is a struct that gives information of the holdings of an address and a specific token. Is the data structure that generates the Value stored in the leaf of the MerkleTree
+// Account is a struct that gives information of the holdings of an address and
+// a specific token. Is the data structure that generates the Value stored in
+// the leaf of the MerkleTree
 type Account struct {
 	Idx      Idx                   `meddler:"idx"`
 	TokenID  TokenID               `meddler:"token_id"`

--- a/common/accountcreationauths_test.go
+++ b/common/accountcreationauths_test.go
@@ -51,7 +51,7 @@ func TestAccountCreationAuthSignVerify(t *testing.T) {
 
 func TestKeccak256JSComp(t *testing.T) {
 	// check keccak256 compatible with js version
-	h := ethCrypto.Keccak256Hash([]byte("test")).Bytes()
+	h := ethCrypto.Keccak256([]byte("test"))
 	assert.Equal(t, "9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658",
 		hex.EncodeToString(h))
 }

--- a/common/l1tx_test.go
+++ b/common/l1tx_test.go
@@ -29,7 +29,7 @@ func TestNewL1UserTx(t *testing.T) {
 	}
 	l1Tx, err := NewL1Tx(l1Tx)
 	assert.NoError(t, err)
-	assert.Equal(t, "0x00eb5e95e1ce5e9f6c4ed402d415e8d0bdd7664769cfd2064d28da04a2c76be432", l1Tx.TxID.String())
+	assert.Equal(t, "0x00a6cbae3b8661fb75b0919ca6605a02cfb04d9c6dd16870fa0fcdf01befa32768", l1Tx.TxID.String())
 }
 
 func TestNewL1CoordinatorTx(t *testing.T) {
@@ -46,7 +46,7 @@ func TestNewL1CoordinatorTx(t *testing.T) {
 	}
 	l1Tx, err := NewL1Tx(l1Tx)
 	assert.NoError(t, err)
-	assert.Equal(t, "0x01b8ae2bf60cb8f7c2315a27f13c8863fa2370d15ccc2e68490e197030ba22b97e", l1Tx.TxID.String())
+	assert.Equal(t, "0x01274482d73df4dab34a1b6740adfca347a462513aa14e82f27b12f818d1b68c84", l1Tx.TxID.String())
 }
 
 func TestL1TxCompressedData(t *testing.T) {

--- a/common/l2tx.go
+++ b/common/l2tx.go
@@ -1,10 +1,10 @@
 package common
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"math/big"
 
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/hermeznetwork/tracerr"
 )
 
@@ -104,15 +104,10 @@ func (tx L2Tx) CalculateTxID() ([TxIDLen]byte, error) {
 	b = append(b, byte(tx.Fee))
 
 	// calculate hash
-	h := sha256.New()
-	_, err = h.Write(b)
-	if err != nil {
-		return txID, tracerr.Wrap(err)
-	}
-	r := h.Sum(nil)
+	h := ethCrypto.Keccak256Hash(b).Bytes()
 
 	txID[0] = TxIDPrefixL2Tx
-	copy(txID[1:], r)
+	copy(txID[1:], h)
 	return txID, nil
 }
 

--- a/common/l2tx_test.go
+++ b/common/l2tx_test.go
@@ -19,7 +19,78 @@ func TestNewL2Tx(t *testing.T) {
 	}
 	l2Tx, err := NewL2Tx(l2Tx)
 	assert.NoError(t, err)
-	assert.Equal(t, "0x024f67ec893467419cdfacfc9152e55dc7ce16088952bf2b3442732fd046bd031c", l2Tx.TxID.String())
+	assert.Equal(t, "0x02fb52b5d0b9ef2626c11701bb751b2720c76d59946b9a48146ac153bb6e63bf6a", l2Tx.TxID.String())
+
+	l2Tx = &L2Tx{
+		FromIdx: 87654,
+		ToIdx:   300,
+		TokenID: 5,
+		Amount:  big.NewInt(4),
+		Nonce:   1,
+	}
+	l2Tx, err = NewL2Tx(l2Tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x0276114a8f666fa1ff7dbf34b4a9da577808dc501e3b2760d01fe3ef5473f5737f", l2Tx.TxID.String())
+
+	l2Tx = &L2Tx{
+		FromIdx: 87654,
+		ToIdx:   300,
+		TokenID: 5,
+		Amount:  big.NewInt(4),
+		Fee:     126,
+		Nonce:   3,
+	}
+	l2Tx, err = NewL2Tx(l2Tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x025afb63126d3067f61f633d13e5a51da0551af3a4567a9af2db5321ed04214ff4", l2Tx.TxID.String())
+
+	l2Tx = &L2Tx{
+		FromIdx: 87654,
+		ToIdx:   300,
+		TokenID: 5,
+		Amount:  big.NewInt(4),
+		Nonce:   1003,
+		Fee:     144,
+	}
+	l2Tx, err = NewL2Tx(l2Tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x02cf390157041c3b1b59f0aaed4da464f0d0d48f1d026e46fd89c7fe1e5aed7fcf", l2Tx.TxID.String())
+
+	l2Tx = &L2Tx{
+		FromIdx: 1,
+		ToIdx:   1,
+		TokenID: 1,
+		Amount:  big.NewInt(1),
+		Nonce:   1,
+		Fee:     1,
+	}
+	l2Tx, err = NewL2Tx(l2Tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x020ec18eaae67fcd545998841a9c4be09ee3083e12db6ae5e5213a2ecaaa52d5cf", l2Tx.TxID.String())
+
+	l2Tx = &L2Tx{
+		FromIdx: 999,
+		ToIdx:   999,
+		TokenID: 999,
+		Amount:  big.NewInt(999),
+		Nonce:   999,
+		Fee:     255,
+	}
+	l2Tx, err = NewL2Tx(l2Tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x02f036223e79fac776de107f50822552cc964ee9fc4caa304613285f6976bcc940", l2Tx.TxID.String())
+
+	l2Tx = &L2Tx{
+		FromIdx: 4444,
+		ToIdx:   300,
+		TokenID: 0,
+		Amount:  big.NewInt(3400000000),
+		Nonce:   2,
+		Fee:     25,
+	}
+	l2Tx, err = NewL2Tx(l2Tx)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x029c8aef9ef24531e4cf84e78cbab1018ba1626a5a10afb6b7c356be1b5c28e92c", l2Tx.TxID.String())
 }
 
 func TestL2TxByteParsers(t *testing.T) {

--- a/common/pooll2tx_test.go
+++ b/common/pooll2tx_test.go
@@ -21,7 +21,7 @@ func TestNewPoolL2Tx(t *testing.T) {
 	}
 	poolL2Tx, err := NewPoolL2Tx(poolL2Tx)
 	assert.NoError(t, err)
-	assert.Equal(t, "0x024f67ec893467419cdfacfc9152e55dc7ce16088952bf2b3442732fd046bd031c", poolL2Tx.TxID.String())
+	assert.Equal(t, "0x02fb52b5d0b9ef2626c11701bb751b2720c76d59946b9a48146ac153bb6e63bf6a", poolL2Tx.TxID.String())
 }
 
 func TestTxCompressedData(t *testing.T) {

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -484,16 +484,16 @@ func TestTxs(t *testing.T) {
 	assert.Equal(t, common.TxTypeCreateAccountDeposit, dbL1Txs[9].Type)
 
 	// Tx ID
-	assert.Equal(t, "0x00c4f3fb5c0f7f76b3fe0a74a6ae7472e6a5ef9d66db08df7d0a7e4980c578c55a", dbL1Txs[0].TxID.String())
-	assert.Equal(t, "0x00b0c7398bfd31f7a6c0b4d3f80c73cfe9cdb541bdb6eccc6b9097976f9535fb01", dbL1Txs[1].TxID.String())
-	assert.Equal(t, "0x00bc12304d5d1aca95c356394bfa2e331e4ccb21e250c6a7442d92e02371eca9ff", dbL1Txs[2].TxID.String())
-	assert.Equal(t, "0x0063077b5c07999b460aa31dc3ea300f5923afa08f117e8ed7476aae299ed4b74b", dbL1Txs[3].TxID.String())
-	assert.Equal(t, "0x003f8b27b160e7b98ee5275de5ace264ae45891ac219a1b7c03863b5a764176b03", dbL1Txs[4].TxID.String())
-	assert.Equal(t, "0x00937115a38e1c049aab568b3281e005c206a3e18e87400ce6c62c83599a3bafbd", dbL1Txs[5].TxID.String())
-	assert.Equal(t, "0x006118820894c0acdc230d65fe739a4082c9eed3be1f5020f544d855e36dc4eae6", dbL1Txs[6].TxID.String())
-	assert.Equal(t, "0x003e5aede622ad4ebbc436d178eb83d15f8b38614eda6e90b1acb88034a0eb177d", dbL1Txs[7].TxID.String())
-	assert.Equal(t, "0x007682bb57dfd4d2e98a5c7836d0dc92bee86edefad6db6ad123415991d79fd69d", dbL1Txs[8].TxID.String())
-	assert.Equal(t, "0x006d068c5ee574706ed23bc357390da1c5bc5e144f51a32dcd38faf50be60813d6", dbL1Txs[9].TxID.String())
+	assert.Equal(t, "0x00e979da4b80d60a17ce56fa19278c6f3a7e1b43359fb8a8ea46d0264de7d653ab", dbL1Txs[0].TxID.String())
+	assert.Equal(t, "0x00af9bf96eb60f2d618519402a2f6b07057a034fa2baefd379fe8e1c969f1c5cf4", dbL1Txs[1].TxID.String())
+	assert.Equal(t, "0x00a256ee191905243320ea830840fd666a73c7b4e6f89ce4bd47ddf998dfee627a", dbL1Txs[2].TxID.String())
+	assert.Equal(t, "0x00930696d03ae0a1e6150b6ccb88043cb539a4e06a7f8baf213029ce9a0600197e", dbL1Txs[3].TxID.String())
+	assert.Equal(t, "0x00de8e41d49f23832f66364e8702c4b78237eb0c95542a94d34188e51696e74fc8", dbL1Txs[4].TxID.String())
+	assert.Equal(t, "0x007a44d6d60b15f3789d4ff49d62377a70255bf13a8d42e41ef49bf4c7b77d2c1b", dbL1Txs[5].TxID.String())
+	assert.Equal(t, "0x00c33f316240f8d33a973db2d0e901e4ac1c96de30b185fcc6b63dac4d0e147bd4", dbL1Txs[6].TxID.String())
+	assert.Equal(t, "0x00b55f0882c5229d1be3d9d3c1a076290f249cd0bae5ae6e609234606befb91233", dbL1Txs[7].TxID.String())
+	assert.Equal(t, "0x009133d4c8a412ca45f50bccdbcfdb8393b0dd8efe953d0cc3bcc82796b7a581b6", dbL1Txs[8].TxID.String())
+	assert.Equal(t, "0x00f5e8ab141ac16d673e654ba7747c2f12e93ea2c50ba6c05563752ca531968c62", dbL1Txs[9].TxID.String())
 
 	// Tx From IDx
 	assert.Equal(t, common.Idx(0), dbL1Txs[0].FromIdx)
@@ -610,10 +610,10 @@ func TestTxs(t *testing.T) {
 	assert.Equal(t, common.TxTypeExit, dbL2Txs[3].Type)
 
 	// Tx ID
-	assert.Equal(t, "0x0216d6fd29ec664d30a5db5c11401b79624388acc1c8bdd7ec4d29c9fbc82e6bbd", dbL2Txs[0].TxID.String())
-	assert.Equal(t, "0x024a99c757c9ded6156cea463e9e7b1ebed51c323dae1f1dc1bea5068f5c688f3a", dbL2Txs[1].TxID.String())
-	assert.Equal(t, "0x0239d316ab550bf8ee20a48f9a89d511baa069207d24ccdc4cfcea0dc04e0659df", dbL2Txs[2].TxID.String())
-	assert.Equal(t, "0x02c7233141caf1f99d4d5d2013da01c709e73ee3c9b46f3d5635b02d14e6177a9d", dbL2Txs[3].TxID.String())
+	assert.Equal(t, "0x02d709307533c4e3c03f20751fc4d72bc18b225d14f9616525540a64342c7c350d", dbL2Txs[0].TxID.String())
+	assert.Equal(t, "0x02e88bc5503f282cca045847668511290e642410a459bb67b1fafcd1b6097c149c", dbL2Txs[1].TxID.String())
+	assert.Equal(t, "0x027911262b43315c0b24942a02fe228274b6e4d57a476bfcdd7a324b3091362c7d", dbL2Txs[2].TxID.String())
+	assert.Equal(t, "0x02f572b63f2a5c302e1b9337ea6944bfbac3d199e4ddd262b5a53759c72ec10ee6", dbL2Txs[3].TxID.String())
 
 	// Tx From and To IDx
 	assert.Equal(t, dbL2Txs[0].ToIdx, dbL2Txs[2].FromIdx)


### PR DESCRIPTION
- Update TxID to use eth Keccak256
- Added more tests to L2Tx TxID calculation to check compatibility with
js version from https://github.com/hermeznetwork/hermezjs/pull/57