### PR TITLE
Add PoolL2Tx.Info about the status of the tx

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1314,6 +1314,12 @@ components:
           $ref: '#/components/schemas/Nonce'
         state:
           $ref: '#/components/schemas/PoolL2TransactionState'
+        info:
+          type: string
+          description: "Info contains information about the status & State of the transaction. As for example, if the Tx has not been selected in the last batch due not enough Balance at the Sender account, this reason would appear at this parameter."
+          pattern: ".*"
+          example: "Tx not selected due not enough Balance at the sender."
+          nullable: true
         signature:
           allOf:
             - $ref: '#/components/schemas/BJJSignature'
@@ -1429,6 +1435,7 @@ components:
         - fee
         - nonce
         - state
+        - info
         - signature
         - timestamp
         - batchNum

--- a/common/l2tx.go
+++ b/common/l2tx.go
@@ -23,7 +23,7 @@ type L2Tx struct {
 	// Nonce is filled by the TxProcessor
 	Nonce       Nonce  `meddler:"nonce"`
 	Type        TxType `meddler:"type"`
-	EthBlockNum int64  `meddler:"eth_block_num"` // Ethereum Block Number in which this L2Tx was added to the queue
+	EthBlockNum int64  `meddler:"eth_block_num"` // EthereumBlockNumber in which this L2Tx was added to the queue
 }
 
 // NewL2Tx returns the given L2Tx with the TxId & Type parameters calculated

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -40,6 +40,11 @@ type PoolL2Tx struct {
 	Fee       FeeSelector           `meddler:"fee"`
 	Nonce     Nonce                 `meddler:"nonce"` // effective 40 bits used
 	State     PoolL2TxState         `meddler:"state"`
+	// Info contains information about the status & State of the
+	// transaction. As for example, if the Tx has not been selected in the
+	// last batch due not enough Balance at the Sender account, this reason
+	// would appear at this parameter.
+	Info      string                `meddler:"info,zeroisnull"`
 	Signature babyjub.SignatureComp `meddler:"signature"`         // tx signature
 	Timestamp time.Time             `meddler:"timestamp,utctime"` // time when added to the tx pool
 	// Stored in DB: optional fileds, may be uninitialized

--- a/db/l2db/l2db_test.go
+++ b/db/l2db/l2db_test.go
@@ -162,6 +162,30 @@ func TestAddTxTest(t *testing.T) {
 		assert.Equal(t, 0, offset)
 	}
 }
+func TestUpdateTxsInfo(t *testing.T) {
+	err := prepareHistoryDB(historyDB)
+	if err != nil {
+		log.Error("Error prepare historyDB", err)
+	}
+	poolL2Txs, err := generatePoolL2Txs()
+	assert.NoError(t, err)
+	for i := range poolL2Txs {
+		err := l2DB.AddTxTest(&poolL2Txs[i])
+		require.NoError(t, err)
+
+		// once added, change the Info parameter
+		poolL2Txs[i].Info = "test"
+	}
+	// update the txs
+	err = l2DB.UpdateTxsInfo(poolL2Txs)
+	require.NoError(t, err)
+
+	for i := range poolL2Txs {
+		fetchedTx, err := l2DB.GetTx(poolL2Txs[i].TxID)
+		assert.NoError(t, err)
+		assert.Equal(t, "test", fetchedTx.Info)
+	}
+}
 
 func assertTx(t *testing.T, expected, actual *common.PoolL2Tx) {
 	// Check that timestamp has been set within the last 3 seconds

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -49,6 +49,7 @@ type PoolTxAPI struct {
 	Fee                  common.FeeSelector    `meddler:"fee"`
 	Nonce                common.Nonce          `meddler:"nonce"`
 	State                common.PoolL2TxState  `meddler:"state"`
+	Info                 *string               `meddler:"info"`
 	Signature            babyjub.SignatureComp `meddler:"signature"`
 	RqFromIdx            *apitypes.HezIdx      `meddler:"rq_from_idx"`
 	RqToIdx              *apitypes.HezIdx      `meddler:"rq_to_idx"`
@@ -90,6 +91,7 @@ func (tx PoolTxAPI) MarshalJSON() ([]byte, error) {
 		"fee":                         tx.Fee,
 		"nonce":                       tx.Nonce,
 		"state":                       tx.State,
+		"info":                        tx.Info,
 		"signature":                   tx.Signature,
 		"timestamp":                   tx.Timestamp,
 		"batchNum":                    tx.BatchNum,

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -606,6 +606,7 @@ CREATE TABLE tx_pool (
     fee SMALLINT NOT NULL,
     nonce BIGINT NOT NULL,
     state CHAR(4) NOT NULL,
+    info VARCHAR,
     signature BYTEA NOT NULL,
     timestamp TIMESTAMP WITHOUT TIME ZONE DEFAULT timezone('utc', now()),
     batch_num BIGINT,

--- a/test/zkproof/flows_test.go
+++ b/test/zkproof/flows_test.go
@@ -152,7 +152,7 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 			l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[i].Batch.ForgeL1TxsNum])
 		}
 		// TxSelector select the transactions for the next Batch
-		coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+		coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 		require.NoError(t, err)
 		// BatchBuilder build Batch
 		zki, err := bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
@@ -175,7 +175,7 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 	addL2Txs(t, l2DBTxSel, l2Txs) // Add L2s to TxSelector.L2DB
 	l1UserTxs := til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[6].Batch.ForgeL1TxsNum])
 	// TxSelector select the transactions for the next Batch
-	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	// BatchBuilder build Batch
 	zki, err := bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
@@ -183,6 +183,8 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 	assert.Equal(t, "7614010373759339299470010949167613050707822522530721724565424494781010548240", bb.LocalStateDB().MT.Root().BigInt().String())
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(oL2Txs), txsel.LocalAccountsDB().CurrentBatch())
+	require.NoError(t, err)
+	err = l2DBTxSel.UpdateTxsInfo(discardedL2Txs)
 	require.NoError(t, err)
 
 	log.Debug("block:0 batch:8")
@@ -198,7 +200,7 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 	addL2Txs(t, l2DBTxSel, l2Txs) // Add L2s to TxSelector.L2DB
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[7].Batch.ForgeL1TxsNum])
 	// TxSelector select the transactions for the next Batch
-	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	// BatchBuilder build Batch
 	zki, err = bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
@@ -206,6 +208,8 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 	assert.Equal(t, "21231789250434471575486264439945776732824482207853465397552873521865656677689", bb.LocalStateDB().MT.Root().BigInt().String())
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(l2Txs), txsel.LocalAccountsDB().CurrentBatch())
+	require.NoError(t, err)
+	err = l2DBTxSel.UpdateTxsInfo(discardedL2Txs)
 	require.NoError(t, err)
 
 	log.Debug("(batch9) block:1 batch:1")
@@ -219,7 +223,7 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 	addL2Txs(t, l2DBTxSel, l2Txs) // Add L2s to TxSelector.L2DB
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[1].Rollup.Batches[0].Batch.ForgeL1TxsNum])
 	// TxSelector select the transactions for the next Batch
-	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	// BatchBuilder build Batch
 	zki, err = bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
@@ -228,12 +232,14 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(l2Txs), txsel.LocalAccountsDB().CurrentBatch())
 	require.NoError(t, err)
+	err = l2DBTxSel.UpdateTxsInfo(discardedL2Txs)
+	require.NoError(t, err)
 
 	log.Debug("(batch10) block:1 batch:2")
 	l2Txs = []common.PoolL2Tx{}
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[1].Rollup.Batches[1].Batch.ForgeL1TxsNum])
 	// TxSelector select the transactions for the next Batch
-	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	coordIdxs, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	// BatchBuilder build Batch
 	zki, err = bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
@@ -243,5 +249,7 @@ func TestTxSelectorBatchBuilderZKInputs(t *testing.T) {
 	assert.Equal(t, "11289313644810782435120113035387729451095637380468777086895109386127538554246", bb.LocalStateDB().MT.Root().BigInt().String())
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(l2Txs), txsel.LocalAccountsDB().CurrentBatch())
+	require.NoError(t, err)
+	err = l2DBTxSel.UpdateTxsInfo(discardedL2Txs)
 	require.NoError(t, err)
 }

--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -1300,16 +1300,19 @@ func (tp *TxProcessor) computeEffectiveAmounts(tx *common.L1Tx) {
 }
 
 // CheckEnoughBalance returns true if the sender of the transaction has enough
-// balance in the account to send the Amount+Fee
-func (tp *TxProcessor) CheckEnoughBalance(tx common.PoolL2Tx) bool {
+// balance in the account to send the Amount+Fee, and also returns the account
+// Balance and the Fee+Amount (which is used to give information about why the
+// transaction is not selected in case that this method returns false.
+func (tp *TxProcessor) CheckEnoughBalance(tx common.PoolL2Tx) (bool, *big.Int, *big.Int) {
 	acc, err := tp.s.GetAccount(tx.FromIdx)
 	if err != nil {
-		return false
+		return false, nil, nil
 	}
 	fee, err := common.CalcFeeAmount(tx.Amount, tx.Fee)
 	if err != nil {
-		return false
+		return false, nil, nil
 	}
 	feeAndAmount := new(big.Int).Add(tx.Amount, fee)
-	return acc.Balance.Cmp(feeAndAmount) != -1 // !=-1 balance<amount
+	return acc.Balance.Cmp(feeAndAmount) != -1, // !=-1 balance<amount
+		acc.Balance, feeAndAmount
 }

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -177,7 +177,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 
 	log.Debug("block:0 batch:1")
 	l1UserTxs := []common.L1Tx{}
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
@@ -187,7 +187,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 
 	log.Debug("block:0 batch:2")
 	l1UserTxs = []common.L1Tx{}
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
@@ -197,7 +197,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 
 	log.Debug("block:0 batch:3")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[2].Batch.ForgeL1TxsNum])
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
@@ -209,7 +209,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 
 	log.Debug("block:0 batch:4")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[3].Batch.ForgeL1TxsNum])
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
@@ -222,7 +222,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 
 	log.Debug("block:0 batch:5")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[4].Batch.ForgeL1TxsNum])
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
@@ -235,7 +235,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 
 	log.Debug("block:0 batch:6")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[5].Batch.ForgeL1TxsNum])
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
@@ -268,7 +268,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 	assert.True(t, l2TxsFromDB[0].VerifySignature(chainID, tc.Users["A"].BJJ.Public().Compress()))
 	assert.True(t, l2TxsFromDB[1].VerifySignature(chainID, tc.Users["B"].BJJ.Public().Compress()))
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[6].Batch.ForgeL1TxsNum])
-	coordIdxs, accAuths, oL1UserTxs, oL1CoordTxs, oL2Txs, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	coordIdxs, accAuths, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, []common.Idx{261, 262}, coordIdxs)
 	assert.Equal(t, txsel.coordAccount.AccountCreationAuth, accAuths[0])
@@ -314,7 +314,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 	assert.True(t, l2TxsFromDB[2].VerifySignature(chainID, tc.Users["B"].BJJ.Public().Compress()))
 	assert.True(t, l2TxsFromDB[3].VerifySignature(chainID, tc.Users["A"].BJJ.Public().Compress()))
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[7].Batch.ForgeL1TxsNum])
-	coordIdxs, accAuths, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	coordIdxs, accAuths, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, []common.Idx{261, 262}, coordIdxs)
 	assert.Equal(t, 0, len(accAuths))
@@ -355,7 +355,7 @@ func TestGetL2TxSelectionMinimumFlow0(t *testing.T) {
 	assert.True(t, l2TxsFromDB[0].VerifySignature(chainID, tc.Users["D"].BJJ.Public().Compress()))
 	assert.True(t, l2TxsFromDB[1].VerifySignature(chainID, tc.Users["B"].BJJ.Public().Compress()))
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[1].Rollup.Batches[0].Batch.ForgeL1TxsNum])
-	coordIdxs, accAuths, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	coordIdxs, accAuths, oL1UserTxs, oL1CoordTxs, oL2Txs, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, []common.Idx{262}, coordIdxs)
 	assert.Equal(t, 0, len(accAuths))
@@ -420,8 +420,12 @@ func TestPoolL2TxsWithoutEnoughBalance(t *testing.T) {
 	}
 	// batch1
 	l1UserTxs := []common.L1Tx{}
-	_, _, _, _, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, _, _, _, _, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
+
+	expectedTxID0 := "0x0248bae02b5c8c3847d312bfac3a33ae790616e888f2f711f22aeaff007cde92c2" // 1st TransferToEthAddr
+	expectedTxID1 := "0x0249af018311a393c337ab9174ca2466cba489e49942b4ca4e5c530903671c4aef" // 1st Exit
+	expectedTxID2 := "0x0228b93a261a0cdc62f35588c03bd179d31a0807c28afffdb6a7aaf0c4f017e4cf" // 2nd TransferToEthAddr
 
 	// batch2
 	// prepare the PoolL2Txs
@@ -435,11 +439,14 @@ func TestPoolL2TxsWithoutEnoughBalance(t *testing.T) {
 	addL2Txs(t, txsel, poolL2Txs)
 
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[1].Batch.ForgeL1TxsNum])
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err := txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
 	assert.Equal(t, 0, len(oL2Txs)) // should be 0 as the 2 PoolL2Txs does not have enough funds
+	assert.Equal(t, 2, len(discardedL2Txs))
+	assert.Equal(t, expectedTxID0, discardedL2Txs[0].TxID.String())
+	assert.Equal(t, expectedTxID1, discardedL2Txs[1].TxID.String())
 	err = txsel.l2db.StartForging(common.TxIDsFromPoolL2Txs(oL2Txs), txsel.localAccountsDB.CurrentBatch())
 	require.NoError(t, err)
 
@@ -460,11 +467,15 @@ func TestPoolL2TxsWithoutEnoughBalance(t *testing.T) {
 	addL2Txs(t, txsel, poolL2Txs)
 
 	l1UserTxs = []common.L1Tx{}
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
 	assert.Equal(t, 1, len(oL2Txs)) // see 'NOTE' at the beginning of 'batch3' of this test
+	assert.Equal(t, 2, len(discardedL2Txs))
+	assert.Equal(t, expectedTxID2, oL2Txs[0].TxID.String())
+	assert.Equal(t, expectedTxID0, discardedL2Txs[0].TxID.String())
+	assert.Equal(t, expectedTxID1, discardedL2Txs[1].TxID.String())
 	assert.Equal(t, common.TxTypeTransferToEthAddr, oL2Txs[0].Type)
 	err = txsel.l2db.StartForging(common.TxIDsFromPoolL2Txs(oL2Txs), txsel.localAccountsDB.CurrentBatch())
 	require.NoError(t, err)
@@ -473,11 +484,14 @@ func TestPoolL2TxsWithoutEnoughBalance(t *testing.T) {
 	// make the selection of another batch, which should include the
 	// initial PoolExit, which now is valid as B has enough Balance
 	l1UserTxs = []common.L1Tx{}
-	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
+	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err = txsel.GetL1L2TxSelection(selectionConfig, l1UserTxs)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))
 	assert.Equal(t, 1, len(oL2Txs))
+	assert.Equal(t, 1, len(discardedL2Txs))
+	assert.Equal(t, expectedTxID1, oL2Txs[0].TxID.String()) // the Exit that was not accepted at the batch2
+	assert.Equal(t, expectedTxID0, discardedL2Txs[0].TxID.String())
 	assert.Equal(t, common.TxTypeExit, oL2Txs[0].Type)
 	err = txsel.l2db.StartForging(common.TxIDsFromPoolL2Txs(oL2Txs), txsel.localAccountsDB.CurrentBatch())
 	require.NoError(t, err)


### PR DESCRIPTION
PoolL2Tx.Info contains information about the status & State of the
transaction. As for example, if the Tx has not been selected in the last
batch due not enough Balance at the Sender account, this reason would
appear at this parameter.
This will help the client (wallet, batchexplorer, etc) to reason why a
L2Tx is not selected in the forged batches.