### PR TITLE
Add Last db view in kvdb and statedb

### DIFF
--- a/api/account_test.go
+++ b/api/account_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testAccount struct {
@@ -76,40 +77,40 @@ func TestGetAccounts(t *testing.T) {
 	// Filter by BJJ
 	path := fmt.Sprintf("%s?BJJ=%s&limit=%d", endpoint, tc.accounts[0].PublicKey, limit)
 	err := doGoodReqPaginated(path, historydb.OrderAsc, &testAccountsResponse{}, appendIter)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, len(fetchedAccounts), 0)
 	assert.LessOrEqual(t, len(fetchedAccounts), len(tc.accounts))
 	fetchedAccounts = []testAccount{}
 	// Filter by ethAddr
 	path = fmt.Sprintf("%s?hezEthereumAddress=%s&limit=%d", endpoint, tc.accounts[3].EthAddr, limit)
 	err = doGoodReqPaginated(path, historydb.OrderAsc, &testAccountsResponse{}, appendIter)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, len(fetchedAccounts), 0)
 	assert.LessOrEqual(t, len(fetchedAccounts), len(tc.accounts))
 	fetchedAccounts = []testAccount{}
 	// both filters (incompatible)
 	path = fmt.Sprintf("%s?hezEthereumAddress=%s&BJJ=%s&limit=%d", endpoint, tc.accounts[0].EthAddr, tc.accounts[0].PublicKey, limit)
 	err = doBadReq("GET", path, nil, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fetchedAccounts = []testAccount{}
 	// Filter by token IDs
 	path = fmt.Sprintf("%s?tokenIds=%s&limit=%d", endpoint, stringIds, limit)
 	err = doGoodReqPaginated(path, historydb.OrderAsc, &testAccountsResponse{}, appendIter)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, len(fetchedAccounts), 0)
 	assert.LessOrEqual(t, len(fetchedAccounts), len(tc.accounts))
 	fetchedAccounts = []testAccount{}
 	// Token Ids + bjj
 	path = fmt.Sprintf("%s?tokenIds=%s&BJJ=%s&limit=%d", endpoint, stringIds, tc.accounts[10].PublicKey, limit)
 	err = doGoodReqPaginated(path, historydb.OrderAsc, &testAccountsResponse{}, appendIter)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, len(fetchedAccounts), 0)
 	assert.LessOrEqual(t, len(fetchedAccounts), len(tc.accounts))
 	fetchedAccounts = []testAccount{}
 	// No filters (checks response content)
 	path = fmt.Sprintf("%s?limit=%d", endpoint, limit)
 	err = doGoodReqPaginated(path, historydb.OrderAsc, &testAccountsResponse{}, appendIter)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, len(tc.accounts), len(fetchedAccounts))
 	for i := 0; i < len(fetchedAccounts); i++ {
 		fetchedAccounts[i].Token.ItemID = 0
@@ -132,7 +133,7 @@ func TestGetAccounts(t *testing.T) {
 		}
 	}
 	err = doGoodReqPaginated(path, historydb.OrderDesc, &testAccountsResponse{}, appendIter)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, len(reversedAccounts), len(fetchedAccounts))
 	for i := 0; i < len(fetchedAccounts); i++ {
 		reversedAccounts[i].Token.ItemID = 0
@@ -147,21 +148,21 @@ func TestGetAccounts(t *testing.T) {
 	// 400
 	path = fmt.Sprintf("%s?hezEthereumAddress=hez:0x123456", endpoint)
 	err = doBadReq("GET", path, nil, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Test GetAccount
 	path = fmt.Sprintf("%s/%s", endpoint, fetchedAccounts[2].Idx)
 	account := testAccount{}
-	assert.NoError(t, doGoodReq("GET", path, nil, &account))
+	require.NoError(t, doGoodReq("GET", path, nil, &account))
 	account.Token.ItemID = 0
 	assert.Equal(t, fetchedAccounts[2], account)
 
 	// 400
 	path = fmt.Sprintf("%s/hez:12345", endpoint)
 	err = doBadReq("GET", path, nil, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// 404
 	path = fmt.Sprintf("%s/hez:10:12345", endpoint)
 	err = doBadReq("GET", path, nil, 404)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -355,6 +355,10 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 	}
+	// Make a checkpoint to make the accounts available in Last
+	if err := api.s.MakeCheckpoint(); err != nil {
+		panic(err)
+	}
 
 	// Generate Coordinators and add them to HistoryDB
 	const nCoords = 10

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -170,7 +170,7 @@ func (a *API) verifyPoolL2TxWrite(txw *l2db.PoolL2TxWrite) error {
 		return tracerr.Wrap(err)
 	}
 	// Get public key
-	account, err := a.s.GetAccount(poolTx.FromIdx)
+	account, err := a.s.LastGetAccount(poolTx.FromIdx)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}

--- a/coordinator/pipeline_test.go
+++ b/coordinator/pipeline_test.go
@@ -150,7 +150,7 @@ func preloadSync(t *testing.T, ethClient *test.Client, sync *synchronizer.Synchr
 	require.Nil(t, err)
 	require.Equal(t, testTokensLen*testUsersLen, len(dbAccounts))
 
-	sdbAccounts, err := stateDB.GetAccounts()
+	sdbAccounts, err := stateDB.TestGetAccounts()
 	require.Nil(t, err)
 	require.Equal(t, testTokensLen*testUsersLen, len(sdbAccounts))
 
@@ -200,12 +200,12 @@ PoolTransfer(0) User2-User3: 300 (126)
 	})
 	require.NoError(t, err)
 	// Sanity check
-	sdbAccounts, err := pipeline.txSelector.LocalAccountsDB().GetAccounts()
+	sdbAccounts, err := pipeline.txSelector.LocalAccountsDB().TestGetAccounts()
 	require.Nil(t, err)
 	require.Equal(t, testTokensLen*testUsersLen, len(sdbAccounts))
 
 	// Sanity check
-	sdbAccounts, err = pipeline.batchBuilder.LocalStateDB().GetAccounts()
+	sdbAccounts, err = pipeline.batchBuilder.LocalStateDB().TestGetAccounts()
 	require.Nil(t, err)
 	require.Equal(t, testTokensLen*testUsersLen, len(sdbAccounts))
 

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/hermeznetwork/hermez-node/db/statedb"
 	"github.com/hermeznetwork/hermez-node/eth"
+	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/hermez-node/test"
 	"github.com/hermeznetwork/hermez-node/test/til"
 	"github.com/jinzhu/copier"
@@ -253,7 +254,7 @@ func checkSyncBlock(t *testing.T, s *Synchronizer, blockNum int, block, syncBloc
 	// Compare accounts from HistoryDB with StateDB (they should match)
 	dbAccounts, err := s.historyDB.GetAllAccounts()
 	require.NoError(t, err)
-	sdbAccounts, err := s.stateDB.GetAccounts()
+	sdbAccounts, err := s.stateDB.TestGetAccounts()
 	require.NoError(t, err)
 	assertEqualAccountsHistoryDBStateDB(t, dbAccounts, sdbAccounts)
 }
@@ -338,6 +339,7 @@ func TestSyncGeneral(t *testing.T) {
 	s, err := NewSynchronizer(client, historyDB, stateDB, Config{
 		StatsRefreshPeriod: 0 * time.Second,
 	})
+	log.Error(err)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -651,7 +653,7 @@ func TestSyncGeneral(t *testing.T) {
 	// Accounts in HistoryDB and StateDB must be empty
 	dbAccounts, err := s.historyDB.GetAllAccounts()
 	require.NoError(t, err)
-	sdbAccounts, err := s.stateDB.GetAccounts()
+	sdbAccounts, err := s.stateDB.TestGetAccounts()
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(dbAccounts))
 	assertEqualAccountsHistoryDBStateDB(t, dbAccounts, sdbAccounts)
@@ -690,7 +692,7 @@ func TestSyncGeneral(t *testing.T) {
 	// Accounts in HistoryDB and StateDB is only 2 entries
 	dbAccounts, err = s.historyDB.GetAllAccounts()
 	require.NoError(t, err)
-	sdbAccounts, err = s.stateDB.GetAccounts()
+	sdbAccounts, err = s.stateDB.TestGetAccounts()
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(dbAccounts))
 	assertEqualAccountsHistoryDBStateDB(t, dbAccounts, sdbAccounts)

--- a/test/debugapi/debugapi.go
+++ b/test/debugapi/debugapi.go
@@ -55,7 +55,7 @@ func (a *DebugAPI) handleAccount(c *gin.Context) {
 		badReq(err, c)
 		return
 	}
-	account, err := a.stateDB.GetAccount(common.Idx(uri.Idx))
+	account, err := a.stateDB.LastGetAccount(common.Idx(uri.Idx))
 	if err != nil {
 		badReq(err, c)
 		return
@@ -64,8 +64,12 @@ func (a *DebugAPI) handleAccount(c *gin.Context) {
 }
 
 func (a *DebugAPI) handleAccounts(c *gin.Context) {
-	accounts, err := a.stateDB.GetAccounts()
-	if err != nil {
+	var accounts []common.Account
+	if err := a.stateDB.LastRead(func(sdb *statedb.Last) error {
+		var err error
+		accounts, err = sdb.GetAccounts()
+		return err
+	}); err != nil {
 		badReq(err, c)
 		return
 	}
@@ -73,7 +77,7 @@ func (a *DebugAPI) handleAccounts(c *gin.Context) {
 }
 
 func (a *DebugAPI) handleCurrentBatch(c *gin.Context) {
-	batchNum, err := a.stateDB.GetCurrentBatch()
+	batchNum, err := a.stateDB.LastGetCurrentBatch()
 	if err != nil {
 		badReq(err, c)
 		return
@@ -82,7 +86,11 @@ func (a *DebugAPI) handleCurrentBatch(c *gin.Context) {
 }
 
 func (a *DebugAPI) handleMTRoot(c *gin.Context) {
-	root := a.stateDB.MTGetRoot()
+	root, err := a.stateDB.LastMTGetRoot()
+	if err != nil {
+		badReq(err, c)
+		return
+	}
 	c.JSON(http.StatusOK, root)
 }
 

--- a/test/debugapi/debugapi_test.go
+++ b/test/debugapi/debugapi_test.go
@@ -66,6 +66,9 @@ func TestDebugAPI(t *testing.T) {
 		_, err = sdb.CreateAccount(account.Idx, account)
 		require.Nil(t, err)
 	}
+	// Make a checkpoint (batchNum 2) to make the accounts available in Last
+	err = sdb.MakeCheckpoint()
+	require.Nil(t, err)
 
 	url := fmt.Sprintf("http://%v/debug/", addr)
 
@@ -73,7 +76,7 @@ func TestDebugAPI(t *testing.T) {
 	req, err := sling.New().Get(url).Path("sdb/batchnum").ReceiveSuccess(&batchNum)
 	require.Equal(t, http.StatusOK, req.StatusCode)
 	require.Nil(t, err)
-	assert.Equal(t, common.BatchNum(1), batchNum)
+	assert.Equal(t, common.BatchNum(2), batchNum)
 
 	var mtroot *big.Int
 	req, err = sling.New().Get(url).Path("sdb/mtroot").ReceiveSuccess(&mtroot)

--- a/txprocessor/zkinputsgen_test.go
+++ b/txprocessor/zkinputsgen_test.go
@@ -176,7 +176,7 @@ func TestZKInputsEmpty(t *testing.T) {
 	assert.Equal(t, "0", ptOut.ZKInputs.Metadata.NewExitRootRaw.BigInt().String())
 
 	// check that there are no accounts
-	accs, err := sdb.GetAccounts()
+	accs, err := sdb.TestGetAccounts()
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(accs))
 
@@ -208,7 +208,7 @@ func TestZKInputsEmpty(t *testing.T) {
 	rootNonZero := sdb.MT.Root()
 
 	// check that there is 1 account
-	accs, err = sdb.GetAccounts()
+	accs, err = sdb.TestGetAccounts()
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(accs))
 
@@ -234,7 +234,7 @@ func TestZKInputsEmpty(t *testing.T) {
 	assert.Equal(t, "0", ptOut.ZKInputs.Metadata.NewExitRootRaw.BigInt().String())
 
 	// check that there is still 1 account
-	accs, err = sdb.GetAccounts()
+	accs, err = sdb.TestGetAccounts()
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(accs))
 


### PR DESCRIPTION
Last db view is an opened pebble db which always contains a checkpoint from the
last batch.  Methods to access this last batch are thread safe so that views of
the last checkpoint can be made anywhere and with a consistent view of the
state.

Resolve #522 