### PR TITLE
Pass StateDB constructor parameters as Config type

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -213,7 +213,7 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 	}()
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeTxSelector, 0)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128, Type: statedb.TypeTxSelector, NLevels: 0})
 	if err != nil {
 		panic(err)
 	}

--- a/batchbuilder/batchbuilder.go
+++ b/batchbuilder/batchbuilder.go
@@ -2,6 +2,7 @@ package batchbuilder
 
 import (
 	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/db/kvdb"
 	"github.com/hermeznetwork/hermez-node/db/statedb"
 	"github.com/hermeznetwork/hermez-node/txprocessor"
 	"github.com/hermeznetwork/tracerr"
@@ -28,8 +29,14 @@ type ConfigBatch struct {
 // NewBatchBuilder constructs a new BatchBuilder, and executes the bb.Reset
 // method
 func NewBatchBuilder(dbpath string, synchronizerStateDB *statedb.StateDB, batchNum common.BatchNum, nLevels uint64) (*BatchBuilder, error) {
-	localStateDB, err := statedb.NewLocalStateDB(dbpath, 128, synchronizerStateDB,
-		statedb.TypeBatchBuilder, int(nLevels))
+	localStateDB, err := statedb.NewLocalStateDB(
+		statedb.Config{
+			Path:    dbpath,
+			Keep:    kvdb.DefaultKeep,
+			Type:    statedb.TypeBatchBuilder,
+			NLevels: int(nLevels),
+		},
+		synchronizerStateDB)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/batchbuilder/batchbuilder_test.go
+++ b/batchbuilder/batchbuilder_test.go
@@ -15,7 +15,7 @@ func TestBatchBuilder(t *testing.T) {
 	require.Nil(t, err)
 	defer assert.Nil(t, os.RemoveAll(dir))
 
-	synchDB, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, 0)
+	synchDB, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128, Type: statedb.TypeBatchBuilder, NLevels: 0})
 	assert.Nil(t, err)
 
 	bbDir, err := ioutil.TempDir("", "tmpBatchBuilderDB")

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -97,7 +97,8 @@ func newTestModules(t *testing.T) modules {
 	syncDBPath, err = ioutil.TempDir("", "tmpSyncDB")
 	require.NoError(t, err)
 	deleteme = append(deleteme, syncDBPath)
-	syncStateDB, err := statedb.NewStateDB(syncDBPath, 128, statedb.TypeSynchronizer, 48)
+	syncStateDB, err := statedb.NewStateDB(statedb.Config{Path: syncDBPath, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 48})
 	assert.NoError(t, err)
 
 	pass := os.Getenv("POSTGRES_PASS")

--- a/coordinator/purger_test.go
+++ b/coordinator/purger_test.go
@@ -28,12 +28,14 @@ func newStateDB(t *testing.T) *statedb.LocalStateDB {
 	syncDBPath, err := ioutil.TempDir("", "tmpSyncDB")
 	require.NoError(t, err)
 	deleteme = append(deleteme, syncDBPath)
-	syncStateDB, err := statedb.NewStateDB(syncDBPath, 128, statedb.TypeSynchronizer, 48)
+	syncStateDB, err := statedb.NewStateDB(statedb.Config{Path: syncDBPath, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 48})
 	assert.NoError(t, err)
 	stateDBPath, err := ioutil.TempDir("", "tmpStateDB")
 	require.NoError(t, err)
 	deleteme = append(deleteme, stateDBPath)
-	stateDB, err := statedb.NewLocalStateDB(stateDBPath, 128, syncStateDB, statedb.TypeTxSelector, 0)
+	stateDB, err := statedb.NewLocalStateDB(statedb.Config{Path: stateDBPath, Keep: 128,
+		Type: statedb.TypeTxSelector, NLevels: 0}, syncStateDB)
 	require.NoError(t, err)
 	return stateDB
 }

--- a/db/kvdb/kvdb_test.go
+++ b/db/kvdb/kvdb_test.go
@@ -37,7 +37,7 @@ func TestCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	db, err := NewKVDB(dir, 128)
+	db, err := NewKVDB(Config{Path: dir, Keep: 128})
 	require.NoError(t, err)
 
 	// add test key-values
@@ -72,7 +72,7 @@ func TestCheckpoints(t *testing.T) {
 	err = db.Reset(3)
 	require.NoError(t, err)
 
-	printCheckpoints(t, db.path)
+	printCheckpoints(t, db.cfg.Path)
 
 	// check that currentBatch is as expected after Reset
 	cb, err = db.GetCurrentBatch()
@@ -99,7 +99,7 @@ func TestCheckpoints(t *testing.T) {
 	dirLocal, err := ioutil.TempDir("", "ldb")
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dirLocal))
-	ldb, err := NewKVDB(dirLocal, 128)
+	ldb, err := NewKVDB(Config{Path: dirLocal, Keep: 128})
 	require.NoError(t, err)
 
 	// get checkpoint 4 from sdb (StateDB) to ldb (LocalStateDB)
@@ -120,7 +120,7 @@ func TestCheckpoints(t *testing.T) {
 	dirLocal2, err := ioutil.TempDir("", "ldb2")
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dirLocal2))
-	ldb2, err := NewKVDB(dirLocal2, 128)
+	ldb2, err := NewKVDB(Config{Path: dirLocal2, Keep: 128})
 	require.NoError(t, err)
 
 	// get checkpoint 4 from sdb (StateDB) to ldb (LocalStateDB)
@@ -139,9 +139,9 @@ func TestCheckpoints(t *testing.T) {
 
 	debug := false
 	if debug {
-		printCheckpoints(t, db.path)
-		printCheckpoints(t, ldb.path)
-		printCheckpoints(t, ldb2.path)
+		printCheckpoints(t, db.cfg.Path)
+		printCheckpoints(t, ldb.cfg.Path)
+		printCheckpoints(t, ldb2.cfg.Path)
 	}
 }
 
@@ -150,7 +150,7 @@ func TestListCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	db, err := NewKVDB(dir, 128)
+	db, err := NewKVDB(Config{Path: dir, Keep: 128})
 	require.NoError(t, err)
 
 	numCheckpoints := 16
@@ -181,7 +181,7 @@ func TestDeleteOldCheckpoints(t *testing.T) {
 	defer require.NoError(t, os.RemoveAll(dir))
 
 	keep := 16
-	db, err := NewKVDB(dir, keep)
+	db, err := NewKVDB(Config{Path: dir, Keep: keep})
 	require.NoError(t, err)
 
 	numCheckpoints := 32
@@ -202,7 +202,7 @@ func TestGetCurrentIdx(t *testing.T) {
 	defer require.NoError(t, os.RemoveAll(dir))
 
 	keep := 16
-	db, err := NewKVDB(dir, keep)
+	db, err := NewKVDB(Config{Path: dir, Keep: keep})
 	require.NoError(t, err)
 
 	idx, err := db.GetCurrentIdx()
@@ -211,7 +211,7 @@ func TestGetCurrentIdx(t *testing.T) {
 
 	db.Close()
 
-	db, err = NewKVDB(dir, keep)
+	db, err = NewKVDB(Config{Path: dir, Keep: keep})
 	require.NoError(t, err)
 
 	idx, err = db.GetCurrentIdx()
@@ -227,7 +227,7 @@ func TestGetCurrentIdx(t *testing.T) {
 
 	db.Close()
 
-	db, err = NewKVDB(dir, keep)
+	db, err = NewKVDB(Config{Path: dir, Keep: keep})
 	require.NoError(t, err)
 
 	idx, err = db.GetCurrentIdx()

--- a/db/statedb/statedb_test.go
+++ b/db/statedb/statedb_test.go
@@ -45,7 +45,7 @@ func TestNewStateDBIntermediateState(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := NewStateDB(dir, 128, TypeTxSelector, 0)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeTxSelector, NLevels: 0})
 	require.NoError(t, err)
 
 	// test values
@@ -78,7 +78,7 @@ func TestNewStateDBIntermediateState(t *testing.T) {
 
 	// call NewStateDB which should get the db at the last checkpoint state
 	// executing a Reset (discarding the last 'testkey0'&'testvalue0' data)
-	sdb, err = NewStateDB(dir, 128, TypeTxSelector, 0)
+	sdb, err = NewStateDB(Config{Path: dir, Keep: 128, Type: TypeTxSelector, NLevels: 0})
 	require.NoError(t, err)
 	v, err = sdb.db.DB().Get(k0)
 	assert.NotNil(t, err)
@@ -158,7 +158,7 @@ func TestNewStateDBIntermediateState(t *testing.T) {
 
 	// call NewStateDB which should get the db at the last checkpoint state
 	// executing a Reset (discarding the last 'testkey1'&'testvalue1' data)
-	sdb, err = NewStateDB(dir, 128, TypeTxSelector, 0)
+	sdb, err = NewStateDB(Config{Path: dir, Keep: 128, Type: TypeTxSelector, NLevels: 0})
 	require.NoError(t, err)
 
 	bn, err = sdb.getCurrentBatch()
@@ -182,7 +182,7 @@ func TestStateDBWithoutMT(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := NewStateDB(dir, 128, TypeTxSelector, 0)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeTxSelector, NLevels: 0})
 	require.NoError(t, err)
 
 	// create test accounts
@@ -236,7 +236,7 @@ func TestStateDBWithMT(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := NewStateDB(dir, 128, TypeSynchronizer, 32)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	// create test accounts
@@ -290,7 +290,7 @@ func TestCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := NewStateDB(dir, 128, TypeSynchronizer, 32)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	err = sdb.Reset(0)
@@ -335,7 +335,7 @@ func TestCheckpoints(t *testing.T) {
 		assert.Equal(t, common.BatchNum(i+1), cb)
 	}
 
-	// printCheckpoints(t, sdb.path)
+	// printCheckpoints(t, sdb.cfg.Path)
 
 	// reset checkpoint
 	err = sdb.Reset(3)
@@ -371,7 +371,7 @@ func TestCheckpoints(t *testing.T) {
 	dirLocal, err := ioutil.TempDir("", "ldb")
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dirLocal))
-	ldb, err := NewLocalStateDB(dirLocal, 128, sdb, TypeBatchBuilder, 32)
+	ldb, err := NewLocalStateDB(Config{Path: dirLocal, Keep: 128, Type: TypeBatchBuilder, NLevels: 32}, sdb)
 	require.NoError(t, err)
 
 	// get checkpoint 4 from sdb (StateDB) to ldb (LocalStateDB)
@@ -392,7 +392,7 @@ func TestCheckpoints(t *testing.T) {
 	dirLocal2, err := ioutil.TempDir("", "ldb2")
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dirLocal2))
-	ldb2, err := NewLocalStateDB(dirLocal2, 128, sdb, TypeBatchBuilder, 32)
+	ldb2, err := NewLocalStateDB(Config{Path: dirLocal2, Keep: 128, Type: TypeBatchBuilder, NLevels: 32}, sdb)
 	require.NoError(t, err)
 
 	// get checkpoint 4 from sdb (StateDB) to ldb (LocalStateDB)
@@ -409,9 +409,9 @@ func TestCheckpoints(t *testing.T) {
 
 	debug := false
 	if debug {
-		printCheckpoints(t, sdb.path)
-		printCheckpoints(t, ldb.path)
-		printCheckpoints(t, ldb2.path)
+		printCheckpoints(t, sdb.cfg.Path)
+		printCheckpoints(t, ldb.cfg.Path)
+		printCheckpoints(t, ldb2.cfg.Path)
 	}
 }
 
@@ -419,7 +419,7 @@ func TestStateDBGetAccounts(t *testing.T) {
 	dir, err := ioutil.TempDir("", "tmpdb")
 	require.NoError(t, err)
 
-	sdb, err := NewStateDB(dir, 128, TypeTxSelector, 0)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeTxSelector, NLevels: 0})
 	require.NoError(t, err)
 
 	// create test accounts
@@ -466,7 +466,7 @@ func TestCheckAccountsTreeTestVectors(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := NewStateDB(dir, 128, TypeSynchronizer, 32)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	ay0 := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(253), nil), big.NewInt(1))
@@ -540,7 +540,7 @@ func TestListCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	defer require.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := NewStateDB(dir, 128, TypeSynchronizer, 32)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	numCheckpoints := 16
@@ -573,7 +573,7 @@ func TestDeleteOldCheckpoints(t *testing.T) {
 	defer require.NoError(t, os.RemoveAll(dir))
 
 	keep := 16
-	sdb, err := NewStateDB(dir, keep, TypeSynchronizer, 32)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: keep, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	numCheckpoints := 32
@@ -594,7 +594,7 @@ func TestCurrentIdx(t *testing.T) {
 	defer require.NoError(t, os.RemoveAll(dir))
 
 	keep := 16
-	sdb, err := NewStateDB(dir, keep, TypeSynchronizer, 32)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: keep, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	idx := sdb.CurrentIdx()
@@ -602,7 +602,7 @@ func TestCurrentIdx(t *testing.T) {
 
 	sdb.Close()
 
-	sdb, err = NewStateDB(dir, keep, TypeSynchronizer, 32)
+	sdb, err = NewStateDB(Config{Path: dir, Keep: keep, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	idx = sdb.CurrentIdx()
@@ -616,7 +616,7 @@ func TestCurrentIdx(t *testing.T) {
 
 	sdb.Close()
 
-	sdb, err = NewStateDB(dir, keep, TypeSynchronizer, 32)
+	sdb, err = NewStateDB(Config{Path: dir, Keep: keep, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	idx = sdb.CurrentIdx()
@@ -629,7 +629,7 @@ func TestResetFromBadCheckpoint(t *testing.T) {
 	defer require.NoError(t, os.RemoveAll(dir))
 
 	keep := 16
-	sdb, err := NewStateDB(dir, keep, TypeSynchronizer, 32)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: keep, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	err = sdb.MakeCheckpoint()

--- a/db/statedb/utils_test.go
+++ b/db/statedb/utils_test.go
@@ -18,7 +18,7 @@ func TestGetIdx(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := NewStateDB(dir, 128, TypeTxSelector, 0)
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeTxSelector, NLevels: 0})
 	assert.NoError(t, err)
 
 	var sk babyjub.PrivateKey

--- a/node/node.go
+++ b/node/node.go
@@ -164,8 +164,12 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		return nil, tracerr.Wrap(fmt.Errorf("cfg.StateDB.Keep = %v < %v, which is unsafe",
 			cfg.StateDB.Keep, safeStateDBKeep))
 	}
-	stateDB, err := statedb.NewStateDB(cfg.StateDB.Path, cfg.StateDB.Keep,
-		statedb.TypeSynchronizer, 32)
+	stateDB, err := statedb.NewStateDB(statedb.Config{
+		Path:    cfg.StateDB.Path,
+		Keep:    cfg.StateDB.Keep,
+		Type:    statedb.TypeSynchronizer,
+		NLevels: statedb.MaxNLevels,
+	})
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -307,7 +307,7 @@ func newTestModules(t *testing.T) (*statedb.StateDB, *historydb.HistoryDB) {
 	require.NoError(t, err)
 	deleteme = append(deleteme, dir)
 
-	stateDB, err := statedb.NewStateDB(dir, 128, statedb.TypeSynchronizer, 32)
+	stateDB, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128, Type: statedb.TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
 	// Init History DB

--- a/test/debugapi/debugapi_test.go
+++ b/test/debugapi/debugapi_test.go
@@ -44,7 +44,7 @@ func TestDebugAPI(t *testing.T) {
 	dir, err := ioutil.TempDir("", "tmpdb")
 	require.Nil(t, err)
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeSynchronizer, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128, Type: statedb.TypeSynchronizer, NLevels: 32})
 	require.Nil(t, err)
 	err = sdb.MakeCheckpoint() // Make a checkpoint to increment the batchNum
 	require.Nil(t, err)

--- a/test/zkproof/flows_test.go
+++ b/test/zkproof/flows_test.go
@@ -80,7 +80,8 @@ func initTxSelector(t *testing.T, chainID uint16, hermezContractAddr ethCommon.A
 	dir, err := ioutil.TempDir("", "tmpSyncDB")
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
-	syncStateDB, err := statedb.NewStateDB(dir, 128, statedb.TypeSynchronizer, 0)
+	syncStateDB, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 0})
 	require.NoError(t, err)
 
 	txselDir, err := ioutil.TempDir("", "tmpTxSelDB")

--- a/test/zkproof/zkproof_test.go
+++ b/test/zkproof/zkproof_test.go
@@ -50,7 +50,7 @@ func initStateDB(t *testing.T, typ statedb.TypeStateDB) *statedb.StateDB {
 	require.NoError(t, err)
 	defer assert.Nil(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, typ, NLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128, Type: typ, NLevels: NLevels})
 	require.NoError(t, err)
 	return sdb
 }

--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -127,7 +127,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 
 	exits := make([]processedExit, nTx)
 
-	if tp.s.Typ == statedb.TypeBatchBuilder {
+	if tp.s.Type() == statedb.TypeBatchBuilder {
 		tp.zki = common.NewZKInputs(tp.config.ChainID, tp.config.MaxTx, tp.config.MaxL1Tx,
 			tp.config.MaxFeeTx, tp.config.NLevels, (tp.s.CurrentBatch() + 1).BigInt())
 		tp.zki.OldLastIdx = tp.s.CurrentIdx().BigInt()
@@ -137,7 +137,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 
 	// TBD if ExitTree is only in memory or stored in disk, for the moment
 	// is only needed in memory
-	if tp.s.Typ == statedb.TypeSynchronizer || tp.s.Typ == statedb.TypeBatchBuilder {
+	if tp.s.Type() == statedb.TypeSynchronizer || tp.s.Type() == statedb.TypeBatchBuilder {
 		tmpDir, err := ioutil.TempDir("", "hermez-statedb-exittree")
 		if err != nil {
 			return nil, tracerr.Wrap(err)
@@ -166,7 +166,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 		if err != nil {
 			return nil, tracerr.Wrap(err)
 		}
-		if tp.s.Typ == statedb.TypeSynchronizer {
+		if tp.s.Type() == statedb.TypeSynchronizer {
 			if createdAccount != nil {
 				createdAccounts = append(createdAccounts, *createdAccount)
 				l1usertxs[i].EffectiveFromIdx = createdAccount.Idx
@@ -195,7 +195,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 				tp.zki.ISExitRoot[tp.i] = exitTree.Root().BigInt()
 			}
 		}
-		if tp.s.Typ == statedb.TypeSynchronizer || tp.s.Typ == statedb.TypeBatchBuilder {
+		if tp.s.Type() == statedb.TypeSynchronizer || tp.s.Type() == statedb.TypeBatchBuilder {
 			if exitIdx != nil && exitTree != nil {
 				exits[tp.i] = processedExit{
 					exit:    true,
@@ -217,7 +217,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 		if exitIdx != nil {
 			log.Error("Unexpected Exit in L1CoordinatorTx")
 		}
-		if tp.s.Typ == statedb.TypeSynchronizer {
+		if tp.s.Type() == statedb.TypeSynchronizer {
 			if createdAccount != nil {
 				createdAccounts = append(createdAccounts, *createdAccount)
 				l1coordinatortxs[i].EffectiveFromIdx = createdAccount.Idx
@@ -276,7 +276,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 	// collectedFees will contain the amount of fee collected for each
 	// TokenID
 	var collectedFees map[common.TokenID]*big.Int
-	if tp.s.Typ == statedb.TypeSynchronizer || tp.s.Typ == statedb.TypeBatchBuilder {
+	if tp.s.Type() == statedb.TypeSynchronizer || tp.s.Type() == statedb.TypeBatchBuilder {
 		collectedFees = make(map[common.TokenID]*big.Int)
 		for tokenID := range coordIdxsMap {
 			collectedFees[tokenID] = big.NewInt(0)
@@ -317,7 +317,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 				}
 			}
 		}
-		if tp.s.Typ == statedb.TypeSynchronizer || tp.s.Typ == statedb.TypeBatchBuilder {
+		if tp.s.Type() == statedb.TypeSynchronizer || tp.s.Type() == statedb.TypeBatchBuilder {
 			if exitIdx != nil && exitTree != nil {
 				exits[tp.i] = processedExit{
 					exit:    true,
@@ -401,7 +401,7 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 		}
 	}
 
-	if tp.s.Typ == statedb.TypeTxSelector {
+	if tp.s.Type() == statedb.TypeTxSelector {
 		return nil, nil
 	}
 
@@ -436,8 +436,8 @@ func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinat
 		}
 	}
 
-	if tp.s.Typ == statedb.TypeSynchronizer {
-		// return exitInfos, createdAccounts and collectedFees, so Synchronizer will
+	if tp.s.Type() == statedb.TypeSynchronizer {
+		// retuTypeexitInfos, createdAccounts and collectedFees, so Synchronizer will
 		// be able to store it into HistoryDB for the concrete BatchNum
 		return &ProcessTxOutput{
 			ZKInputs:           nil,
@@ -588,7 +588,7 @@ func (tp *TxProcessor) ProcessL1Tx(exitTree *merkletree.MerkleTree, tx *common.L
 	}
 
 	var createdAccount *common.Account
-	if tp.s.Typ == statedb.TypeSynchronizer &&
+	if tp.s.Type() == statedb.TypeSynchronizer &&
 		(tx.Type == common.TxTypeCreateAccountDeposit ||
 			tx.Type == common.TxTypeCreateAccountDepositTransfer) {
 		var err error
@@ -612,8 +612,8 @@ func (tp *TxProcessor) ProcessL2Tx(coordIdxsMap map[common.TokenID]common.Idx,
 	var err error
 	// if tx.ToIdx==0, get toIdx by ToEthAddr or ToBJJ
 	if tx.ToIdx == common.Idx(0) && tx.AuxToIdx == common.Idx(0) {
-		if tp.s.Typ == statedb.TypeSynchronizer {
-			// this should never be reached
+		if tp.s.Type() == statedb.TypeSynchronizer {
+			// thisTypeould never be reached
 			log.Error("WARNING: In StateDB with Synchronizer mode L2.ToIdx can't be 0")
 			return nil, nil, false, tracerr.Wrap(fmt.Errorf("In StateDB with Synchronizer mode L2.ToIdx can't be 0"))
 		}
@@ -676,8 +676,8 @@ func (tp *TxProcessor) ProcessL2Tx(coordIdxsMap map[common.TokenID]common.Idx,
 	}
 
 	// if StateDB type==TypeSynchronizer, will need to add Nonce
-	if tp.s.Typ == statedb.TypeSynchronizer {
-		// as type==TypeSynchronizer, always tx.ToIdx!=0
+	if tp.s.Type() == statedb.TypeSynchronizer {
+		// as tType==TypeSynchronizer, always tx.ToIdx!=0
 		acc, err := tp.s.GetAccount(tx.FromIdx)
 		if err != nil {
 			log.Errorw("GetAccount", "fromIdx", tx.FromIdx, "err", err)
@@ -889,8 +889,8 @@ func (tp *TxProcessor) applyTransfer(coordIdxsMap map[common.TokenID]common.Idx,
 			accumulated := tp.AccumulatedFees[accCoord.Idx]
 			accumulated.Add(accumulated, fee)
 
-			if tp.s.Typ == statedb.TypeSynchronizer ||
-				tp.s.Typ == statedb.TypeBatchBuilder {
+			if tp.s.Type() == statedb.TypeSynchronizer ||
+				tp.s.Type() == statedb.TypeBatchBuilder {
 				collected := collectedFees[accCoord.TokenID]
 				collected.Add(collected, fee)
 			}
@@ -1094,8 +1094,8 @@ func (tp *TxProcessor) applyExit(coordIdxsMap map[common.TokenID]common.Idx,
 			accumulated := tp.AccumulatedFees[accCoord.Idx]
 			accumulated.Add(accumulated, fee)
 
-			if tp.s.Typ == statedb.TypeSynchronizer ||
-				tp.s.Typ == statedb.TypeBatchBuilder {
+			if tp.s.Type() == statedb.TypeSynchronizer ||
+				tp.s.Type() == statedb.TypeBatchBuilder {
 				collected := collectedFees[accCoord.TokenID]
 				collected.Add(collected, fee)
 			}

--- a/txprocessor/txprocessor_test.go
+++ b/txprocessor/txprocessor_test.go
@@ -36,7 +36,8 @@ func TestComputeEffectiveAmounts(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeSynchronizer, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 32})
 	assert.NoError(t, err)
 
 	set := `
@@ -212,7 +213,8 @@ func TestProcessTxsBalances(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeSynchronizer, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 32})
 	assert.NoError(t, err)
 
 	chainID := uint16(0)
@@ -358,7 +360,8 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeSynchronizer, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 32})
 	assert.NoError(t, err)
 
 	chainID := uint16(0)
@@ -489,7 +492,8 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: 32})
 	assert.NoError(t, err)
 
 	chainID := uint16(0)
@@ -580,7 +584,8 @@ func TestProcessTxsRootTestVectors(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: 32})
 	assert.NoError(t, err)
 
 	// same values than in the js test
@@ -631,7 +636,8 @@ func TestCreateAccountDepositMaxValue(t *testing.T) {
 	defer assert.NoError(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	assert.NoError(t, err)
 
 	users := txsets.GenerateJsUsers(t)
@@ -700,7 +706,8 @@ func initTestMultipleCoordIdxForTokenID(t *testing.T) (*TxProcessor, *til.Contex
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: 32})
 	assert.NoError(t, err)
 
 	chainID := uint16(1)
@@ -798,7 +805,8 @@ func TestTwoExits(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeSynchronizer, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 32})
 	assert.NoError(t, err)
 
 	chainID := uint16(1)
@@ -865,7 +873,8 @@ func TestTwoExits(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir2))
 
-	sdb2, err := statedb.NewStateDB(dir2, 128, statedb.TypeSynchronizer, 32)
+	sdb2, err := statedb.NewStateDB(statedb.Config{Path: dir2, Keep: 128,
+		Type: statedb.TypeSynchronizer, NLevels: 32})
 	assert.NoError(t, err)
 
 	tc = til.NewContext(chainID, common.RollupConstMaxL1UserTx)

--- a/txprocessor/zkinputsgen_test.go
+++ b/txprocessor/zkinputsgen_test.go
@@ -41,7 +41,8 @@ func TestZKInputsHashTestVector0(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.Nil(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: 32})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -90,7 +91,8 @@ func TestZKInputsHashTestVector1(t *testing.T) {
 	require.NoError(t, err)
 	defer assert.Nil(t, os.RemoveAll(dir))
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, 32)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: 32})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -149,7 +151,8 @@ func TestZKInputsEmpty(t *testing.T) {
 
 	nLevels := 16
 
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -266,7 +269,8 @@ func TestZKInputs0(t *testing.T) {
 	defer assert.Nil(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -322,7 +326,8 @@ func TestZKInputs1(t *testing.T) {
 	defer assert.Nil(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -385,7 +390,8 @@ func TestZKInputs2(t *testing.T) {
 	defer assert.Nil(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -456,7 +462,8 @@ func TestZKInputs3(t *testing.T) {
 	defer assert.Nil(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -527,7 +534,8 @@ func TestZKInputs4(t *testing.T) {
 	defer assert.Nil(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -598,7 +606,8 @@ func TestZKInputs5(t *testing.T) {
 	defer assert.Nil(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)
@@ -661,7 +670,8 @@ func TestZKInputs6(t *testing.T) {
 	defer assert.Nil(t, os.RemoveAll(dir))
 
 	nLevels := 16
-	sdb, err := statedb.NewStateDB(dir, 128, statedb.TypeBatchBuilder, nLevels)
+	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeBatchBuilder, NLevels: nLevels})
 	require.NoError(t, err)
 
 	chainID := uint16(0)

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -10,6 +10,7 @@ import (
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/db/kvdb"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/db/statedb"
 	"github.com/hermeznetwork/hermez-node/log"
@@ -62,8 +63,14 @@ type TxSelector struct {
 // NewTxSelector returns a *TxSelector
 func NewTxSelector(coordAccount *CoordAccount, dbpath string,
 	synchronizerStateDB *statedb.StateDB, l2 *l2db.L2DB) (*TxSelector, error) {
-	localAccountsDB, err := statedb.NewLocalStateDB(dbpath, 128,
-		synchronizerStateDB, statedb.TypeTxSelector, 0) // without merkletree
+	localAccountsDB, err := statedb.NewLocalStateDB(
+		statedb.Config{
+			Path:    dbpath,
+			Keep:    kvdb.DefaultKeep,
+			Type:    statedb.TypeTxSelector,
+			NLevels: 0,
+		},
+		synchronizerStateDB) // without merkletree
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -34,7 +34,8 @@ func initTest(t *testing.T, chainID uint16, hermezContractAddr ethCommon.Address
 	dir, err := ioutil.TempDir("", "tmpdb")
 	require.NoError(t, err)
 	defer assert.NoError(t, os.RemoveAll(dir))
-	syncStateDB, err := statedb.NewStateDB(dir, 128, statedb.TypeTxSelector, 0)
+	syncStateDB, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
+		Type: statedb.TypeTxSelector, NLevels: 0})
 	require.NoError(t, err)
 
 	txselDir, err := ioutil.TempDir("", "tmpTxSelDB")


### PR DESCRIPTION
- KVDB/StateDB
        - Pass config parameters in a Config type instead of using many
          arguments in constructor.
	- Add new parameter `NoLast` which disables having an opened DB with a
	  checkpoint to the last batchNum for thread-safe reads.  Last will be
	  disabled in the StateDB used by the TxSelector and BatchBuilder.
	- Add new parameter `NoGapsCheck` which skips checking gaps in the list
	  of checkpoints and returning errors if there are gaps.  Gaps check
	  will be disabled in the StateDB used by the TxSelector and
	  BatchBuilder, because we expect to have gaps when there are multiple
	  coordinators forging (slots not forged by our coordinator will leave
	  gaps).

Resolve #464 