### PR TITLE
Fix synchronizer, add verifier index config param

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -96,3 +96,4 @@ Coordinator = true
 [Coordinator.Debug]
 BatchPath = "/tmp/iden3-test/hermez/batchesdebug"
 LightScrypt = true
+# RollupVerifierIndex = 0

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,6 @@ type Coordinator struct {
 	} `validate:"required"`
 	ServerProofs []ServerProof `validate:"required"`
 	Circuit      struct {
-		// VerifierIdx uint8  `validate:"required"`
 		// MaxTx is the maximum number of txs supported by the circuit
 		MaxTx int64 `validate:"required"`
 		// NLevels is the maximum number of merkle tree levels
@@ -132,6 +131,10 @@ type Coordinator struct {
 		// LightScrypt if set, uses light parameters for the ethereum
 		// keystore encryption algorithm.
 		LightScrypt bool
+		// RollupVerifierIndex is the index of the verifier to use in
+		// the Rollup smart contract.  The verifier chosen by index
+		// must match with the Circuit parameters.
+		RollupVerifierIndex *int
 	}
 }
 

--- a/eth/auction.go
+++ b/eth/auction.go
@@ -799,14 +799,14 @@ func (c *AuctionClient) AuctionEventInit() (*AuctionEventInitialize, int64, erro
 // AuctionEventsByBlock returns the events in a block that happened in the
 // Auction Smart Contract.
 // To query by blockNum, set blockNum >= 0 and blockHash == nil.
-// To query by blockHash, set blockNum == -1 and blockHash != nil.
+// To query by blockHash set blockHash != nil, and blockNum will be ignored.
 // If there are no events in that block the result is nil.
 func (c *AuctionClient) AuctionEventsByBlock(blockNum int64,
 	blockHash *ethCommon.Hash) (*AuctionEvents, error) {
 	var auctionEvents AuctionEvents
 
 	var blockNumBigInt *big.Int
-	if blockNum >= 0 {
+	if blockHash == nil {
 		blockNumBigInt = big.NewInt(blockNum)
 	}
 	query := ethereum.FilterQuery{

--- a/eth/rollup.go
+++ b/eth/rollup.go
@@ -738,14 +738,14 @@ func (c *RollupClient) RollupEventInit() (*RollupEventInitialize, int64, error) 
 // RollupEventsByBlock returns the events in a block that happened in the
 // Rollup Smart Contract.
 // To query by blockNum, set blockNum >= 0 and blockHash == nil.
-// To query by blockHash, set blockNum == -1 and blockHash != nil.
+// To query by blockHash set blockHash != nil, and blockNum will be ignored.
 // If there are no events in that block the result is nil.
 func (c *RollupClient) RollupEventsByBlock(blockNum int64,
 	blockHash *ethCommon.Hash) (*RollupEvents, error) {
 	var rollupEvents RollupEvents
 
 	var blockNumBigInt *big.Int
-	if blockNum >= 0 {
+	if blockHash == nil {
 		blockNumBigInt = big.NewInt(blockNum)
 	}
 	query := ethereum.FilterQuery{

--- a/eth/wdelayer.go
+++ b/eth/wdelayer.go
@@ -426,14 +426,14 @@ func (c *WDelayerClient) WDelayerEventInit() (*WDelayerEventInitialize, int64, e
 // WDelayerEventsByBlock returns the events in a block that happened in the
 // WDelayer Smart Contract.
 // To query by blockNum, set blockNum >= 0 and blockHash == nil.
-// To query by blockHash, set blockNum == -1 and blockHash != nil.
+// To query by blockHash set blockHash != nil, and blockNum will be ignored.
 // If there are no events in that block the result is nil.
 func (c *WDelayerClient) WDelayerEventsByBlock(blockNum int64,
 	blockHash *ethCommon.Hash) (*WDelayerEvents, error) {
 	var wdelayerEvents WDelayerEvents
 
 	var blockNumBigInt *big.Int
-	if blockNum >= 0 {
+	if blockHash == nil {
 		blockNumBigInt = big.NewInt(blockNum)
 	}
 	query := ethereum.FilterQuery{


### PR DESCRIPTION
- eth
    - In EventsByBlock calls ignore blockNum if blockHash != nil.  This fixes
      the issue where a blockNumber and blockHash was being passed, which the
      eth events query function doesn't allow, causing the synchronizer to fail
      at every iteration.
- Node/Config
    - Add Coordinator.Debug.RollupVerifierIndex to force choosing a particular
      verifier by index in the Rollup smart contract.