### PR TITLE
Replace github.com/marusama/semaphore by golang.org/x/sync

### DIFF
--- a/db/utils.go
+++ b/db/utils.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/tracerr"
 	"github.com/jmoiron/sqlx"
-	"github.com/marusama/semaphore/v2"
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/russross/meddler"
+	"golang.org/x/sync/semaphore"
 )
 
 var migrations *migrate.PackrMigrationSource
@@ -89,14 +89,14 @@ func InitSQLDB(port int, host, user, password, name string) (*sqlx.DB, error) {
 
 // APIConnectionController is used to limit the SQL open connections used by the API
 type APIConnectionController struct {
-	smphr   semaphore.Semaphore
+	smphr   *semaphore.Weighted
 	timeout time.Duration
 }
 
 // NewAPICnnectionController initialize APIConnectionController
 func NewAPICnnectionController(maxConnections int, timeout time.Duration) *APIConnectionController {
 	return &APIConnectionController{
-		smphr:   semaphore.New(maxConnections),
+		smphr:   semaphore.NewWeighted(int64(maxConnections)),
 		timeout: timeout,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/jmoiron/sqlx v1.2.1-0.20200615141059-0794cb1f47ee
 	github.com/joho/godotenv v1.3.0
 	github.com/lib/pq v1.8.0
-	github.com/marusama/semaphore/v2 v2.4.1
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/miguelmota/go-ethereum-hdwallet v0.0.0-20200123000308-a60dcd172b4c
 	github.com/mitchellh/copystructure v1.0.0
@@ -29,5 +28,6 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gopkg.in/go-playground/validator.v9 v9.29.1
 )

--- a/go.sum
+++ b/go.sum
@@ -415,9 +415,6 @@ github.com/markbates/oncer v1.0.0 h1:E83IaVAHygyndzPimgUYJjbshhDTALZyXxvk9FOlQRY
 github.com/markbates/oncer v1.0.0/go.mod h1:Z59JA581E9GP6w96jai+TGqafHPW+cPfRxz2aSZ0mcI=
 github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
-github.com/marusama/semaphore v0.0.0-20190110074507-6952cef993b2 h1:sq+a5mb8zHbmHhrIH06oqIMGsanjpbxNgxEgZVfgpvQ=
-github.com/marusama/semaphore/v2 v2.4.1 h1:Y29DhhFMvreVgoqF9EtaSJAF9t2E7Sk7i5VW81sqB8I=
-github.com/marusama/semaphore/v2 v2.4.1/go.mod h1:z9nMiNUekt/LTpTUQdpp+4sJeYqUGpwMHfW0Z8V8fnQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=


### PR DESCRIPTION
In a previous PR, the api test failed when testing the API connection controller timeout.  Rerunning the test solved the issue, but it made me wonder if there was any issue in the test.  I haven't found anything strange, but the code got stuck when acquiring the semaphore.  I've checked other implementations of the semaphore and found that there's one by the golang team at https://pkg.go.dev/golang.org/x/sync@v0.0.0-20201207232520-09787c993a3a/semaphore.  This PR replaces the semaphore we were using before by the one from the golang team (which gives me more confidence)