### PR TITLE
Feature/accountupdatetable

### DIFF
--- a/common/account.go
+++ b/common/account.go
@@ -263,3 +263,13 @@ type IdxNonce struct {
 	Idx   Idx   `db:"idx"`
 	Nonce Nonce `db:"nonce"`
 }
+
+// AccountUpdate represents an account balance and/or nonce update after a
+// processed batch
+type AccountUpdate struct {
+	EthBlockNum int64    `meddler:"eth_block_num"`
+	BatchNum    BatchNum `meddler:"batch_num"`
+	Idx         Idx      `meddler:"idx"`
+	Nonce       Nonce    `meddler:"nonce"`
+	Balance     *big.Int `meddler:"balance,bigint"`
+}

--- a/common/batch.go
+++ b/common/batch.go
@@ -77,6 +77,7 @@ type BatchData struct {
 	L1CoordinatorTxs []L1Tx
 	L2Txs            []L2Tx
 	CreatedAccounts  []Account
+	UpdatedAccounts  []AccountUpdate
 	ExitTree         []ExitInfo
 	Batch            Batch
 }

--- a/config/config.go
+++ b/config/config.go
@@ -232,6 +232,11 @@ type Node struct {
 		// `Eth.LastBatch`).  This value only affects the reported % of
 		// synchronization of blocks and batches, nothing else.
 		StatsRefreshPeriod Duration `validate:"required"`
+		// StoreAccountUpdates when set to true makes the synchronizer
+		// store every account update in the account_update SQL table.
+		// This allows querying nonces and balances from the HistoryDB
+		// via SQL.
+		StoreAccountUpdates bool
 	} `validate:"required"`
 	SmartContracts struct {
 		// Rollup is the address of the Hermez.sol smart contract

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -377,6 +377,22 @@ func TestAccounts(t *testing.T) {
 		accs[i].Balance = nil
 		assert.Equal(t, accs[i], acc)
 	}
+	// Test AccountBalances
+	accUpdates := make([]common.AccountUpdate, len(accs))
+	for i, acc := range accs {
+		accUpdates[i] = common.AccountUpdate{
+			EthBlockNum: batches[acc.BatchNum-1].EthBlockNum,
+			BatchNum:    acc.BatchNum,
+			Idx:         acc.Idx,
+			Nonce:       common.Nonce(i),
+			Balance:     big.NewInt(int64(i)),
+		}
+	}
+	err = historyDB.AddAccountUpdates(accUpdates)
+	require.NoError(t, err)
+	fetchedAccBalances, err := historyDB.GetAllAccountUpdates()
+	require.NoError(t, err)
+	assert.Equal(t, accUpdates, fetchedAccBalances)
 }
 
 func TestTxs(t *testing.T) {

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -100,6 +100,15 @@ CREATE TABLE account (
     eth_addr BYTEA NOT NULL
 );
 
+CREATE TABLE account_update (
+    item_id SERIAL,
+    eth_block_num BIGINT NOT NULL REFERENCES block (eth_block_num) ON DELETE CASCADE,
+    batch_num BIGINT NOT NULL REFERENCES batch (batch_num) ON DELETE CASCADE,
+    idx BIGINT NOT NULL REFERENCES account (idx) ON DELETE CASCADE,
+    nonce BIGINT NOT NULL,
+    balance BYTEA NOT NULL
+);
+
 CREATE TABLE exit_tree (
     item_id SERIAL PRIMARY KEY,
     batch_num BIGINT REFERENCES batch (batch_num) ON DELETE CASCADE,
@@ -674,6 +683,7 @@ DROP TABLE token_exchange;
 DROP TABLE wdelayer_vars;
 DROP TABLE tx;
 DROP TABLE exit_tree;
+DROP TABLE account_update;
 DROP TABLE account;
 DROP TABLE token;
 DROP TABLE bid;

--- a/node/node.go
+++ b/node/node.go
@@ -183,8 +183,9 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 	}
 
 	sync, err := synchronizer.NewSynchronizer(client, historyDB, stateDB, synchronizer.Config{
-		StatsRefreshPeriod: cfg.Synchronizer.StatsRefreshPeriod.Duration,
-		ChainID:            chainIDU16,
+		StatsRefreshPeriod:  cfg.Synchronizer.StatsRefreshPeriod.Duration,
+		StoreAccountUpdates: cfg.Synchronizer.StoreAccountUpdates,
+		ChainID:             chainIDU16,
 	})
 	if err != nil {
 		return nil, tracerr.Wrap(err)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -206,8 +206,9 @@ type SCConsts struct {
 
 // Config is the Synchronizer configuration
 type Config struct {
-	StatsRefreshPeriod time.Duration
-	ChainID            uint16
+	StatsRefreshPeriod  time.Duration
+	StoreAccountUpdates bool
+	ChainID             uint16
 }
 
 // Synchronizer implements the Synchronizer type
@@ -992,6 +993,21 @@ func (s *Synchronizer) rollupSync(ethBlock *common.Block) (*common.RollupData, e
 			createdAccount.BatchNum = batchNum
 		}
 		batchData.CreatedAccounts = processTxsOut.CreatedAccounts
+
+		if s.cfg.StoreAccountUpdates {
+			batchData.UpdatedAccounts = make([]common.AccountUpdate, 0,
+				len(processTxsOut.UpdatedAccounts))
+			for _, acc := range processTxsOut.UpdatedAccounts {
+				batchData.UpdatedAccounts = append(batchData.UpdatedAccounts,
+					common.AccountUpdate{
+						EthBlockNum: blockNum,
+						BatchNum:    batchNum,
+						Idx:         acc.Idx,
+						Nonce:       acc.Nonce,
+						Balance:     acc.Balance,
+					})
+			}
+		}
 
 		slotNum := int64(0)
 		if ethBlock.Num >= s.consts.Auction.GenesisBlockNum {

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -171,6 +171,8 @@ func checkSyncBlock(t *testing.T, s *Synchronizer, blockNum int, block, syncBloc
 			*exit = syncBatch.ExitTree[j]
 		}
 		assert.Equal(t, batch.Batch, syncBatch.Batch)
+		// Ignore updated accounts
+		syncBatch.UpdatedAccounts = nil
 		assert.Equal(t, batch, syncBatch)
 		assert.Equal(t, &batch.Batch, dbBatch) //nolint:gosec
 
@@ -344,7 +346,8 @@ func TestSyncGeneral(t *testing.T) {
 
 	// Create Synchronizer
 	s, err := NewSynchronizer(client, historyDB, stateDB, Config{
-		StatsRefreshPeriod: 0 * time.Second,
+		StatsRefreshPeriod:  0 * time.Second,
+		StoreAccountUpdates: true,
 	})
 	require.NoError(t, err)
 
@@ -735,7 +738,8 @@ func TestSyncForgerCommitment(t *testing.T) {
 
 	// Create Synchronizer
 	s, err := NewSynchronizer(client, historyDB, stateDB, Config{
-		StatsRefreshPeriod: 0 * time.Second,
+		StatsRefreshPeriod:  0 * time.Second,
+		StoreAccountUpdates: true,
 	})
 	require.NoError(t, err)
 
@@ -835,7 +839,8 @@ func TestSyncForgerCommitment(t *testing.T) {
 		syncCommitment[syncBlock.Block.Num] = stats.Sync.Auction.CurrentSlot.ForgerCommitment
 
 		s2, err := NewSynchronizer(client, historyDB, stateDB, Config{
-			StatsRefreshPeriod: 0 * time.Second,
+			StatsRefreshPeriod:  0 * time.Second,
+			StoreAccountUpdates: true,
 		})
 		require.NoError(t, err)
 		stats = s2.Stats()


### PR DESCRIPTION
- Remove unecessary slice indexing
- Simplify historyDB test and make it faster
    - The test `TestGetMetricsAPIMoreThan24Hours` now only generates 30 blocks and 30 txs instead of 3000 blocks and 3000 txs.  Now the test passes in 0.26s in my machine.
- Add account_update SQL table with balances and nonces 
    - Resolve https://github.com/hermeznetwork/hermez-node/issues/519 