### PR TITLE
Delete pending txs by external mark, store tx IP

### DIFF
--- a/api/txspool.go
+++ b/api/txspool.go
@@ -27,6 +27,7 @@ func (a *API) postPoolTx(c *gin.Context) {
 		retBadReq(err, c)
 		return
 	}
+	writeTx.ClientIP = c.ClientIP()
 	// Insert to DB
 	if err := a.l2.AddTxAPI(writeTx); err != nil {
 		retSQLErr(err, c)

--- a/cli/node/.gitignore
+++ b/cli/node/.gitignore
@@ -1,2 +1,3 @@
 cfg.example.secret.toml
 cfg.toml
+node

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -32,6 +32,7 @@ URL = "http://localhost:8545"
 [Synchronizer]
 SyncLoopInterval = "1s"
 StatsRefreshPeriod = "1s"
+StoreAccountUpdates = true
 
 [SmartContracts]
 Rollup   = "0x8EEaea23686c319133a7cC110b840d1591d9AeE0"
@@ -55,6 +56,7 @@ ForgeRetryInterval = "500ms"
 SyncRetryInterval = "1s"
 ForgeDelay = "10s"
 ForgeNoTxsDelay = "0s"
+PurgeByExtDelInterval = "1m"
 
 [Coordinator.FeeAccount]
 Address = "0x56232B1c5B10038125Bc7345664B4AFD745bcF8E"

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,10 @@ type Coordinator struct {
 	// SyncRetryInterval is the waiting interval between calls to the main
 	// handler of a synced block after an error
 	SyncRetryInterval Duration `validate:"required"`
+	// PurgeByExtDelInterval is the waiting interval between calls
+	// to the PurgeByExternalDelete function of the l2db which deletes
+	// pending txs externally marked by the column `external_delete`
+	PurgeByExtDelInterval Duration `validate:"required"`
 	// L2DB is the DB that holds the pool of L2Txs
 	L2DB struct {
 		// SafetyPeriod is the number of batches after which

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -34,6 +34,7 @@ type PoolL2TxWrite struct {
 	RqFee       *common.FeeSelector    `meddler:"rq_fee"`
 	RqNonce     *common.Nonce          `meddler:"rq_nonce"`
 	Type        common.TxType          `meddler:"tx_type"`
+	ClientIP    string                 `meddler:"client_ip"`
 }
 
 // PoolTxAPI represents a L2 Tx pool with extra metadata used by the API

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -627,7 +627,9 @@ CREATE TABLE tx_pool (
     rq_amount BYTEA,
     rq_fee SMALLINT,
     rq_nonce BIGINT,
-    tx_type VARCHAR(40) NOT NULL
+    tx_type VARCHAR(40) NOT NULL,
+    client_ip VARCHAR,
+    external_delete BOOLEAN NOT NULL DEFAULT false
 );
 
 -- +migrate StatementBegin

--- a/node/node.go
+++ b/node/node.go
@@ -303,6 +303,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 				ForgeDelay:             cfg.Coordinator.ForgeDelay.Duration,
 				ForgeNoTxsDelay:        cfg.Coordinator.ForgeNoTxsDelay.Duration,
 				SyncRetryInterval:      cfg.Coordinator.SyncRetryInterval.Duration,
+				PurgeByExtDelInterval:  cfg.Coordinator.PurgeByExtDelInterval.Duration,
 				EthClientAttempts:      cfg.Coordinator.EthClient.Attempts,
 				EthClientAttemptsDelay: cfg.Coordinator.EthClient.AttemptsDelay.Duration,
 				EthNoReuseNonce:        cfg.Coordinator.EthClient.NoReuseNonce,


### PR DESCRIPTION
- In tx_pool, add a column called `external_delete` that can be set to true
  externally.  Regularly, the coordinator will delete all pending txs with this
  column set to true.  The interval for this action is set via the new config
  parameter `Coordinator.PurgeByExtDelInterval`.
- In tx_pool, add a column for the client ip that sent the transaction.  The
  api fills this value using the ClientIP method from gin.Context, which should
  work even under a reverse-proxy.