### PR TITLE
Add minPriceUSD in L2DB, check maxTxs atomically

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -221,7 +221,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	// L2DB
-	l2DB := l2db.NewL2DB(database, 10, 1000, 24*time.Hour, apiConnCon)
+	l2DB := l2db.NewL2DB(database, 10, 1000, 0.0, 24*time.Hour, apiConnCon)
 	test.WipeDB(l2DB.DB()) // this will clean HistoryDB and L2DB
 	// Config (smart contract constants)
 	chainID := uint16(0)
@@ -585,7 +585,7 @@ func TestTimeout(t *testing.T) {
 	hdbTO := historydb.NewHistoryDB(databaseTO, apiConnConTO)
 	require.NoError(t, err)
 	// L2DB
-	l2DBTO := l2db.NewL2DB(databaseTO, 10, 1000, 24*time.Hour, apiConnConTO)
+	l2DBTO := l2db.NewL2DB(databaseTO, 10, 1000, 0.0, 24*time.Hour, apiConnConTO)
 
 	// API
 	apiGinTO := gin.Default()

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 
@@ -179,6 +180,11 @@ func (a *API) verifyPoolL2TxWrite(txw *l2db.PoolL2TxWrite) error {
 	_, err = common.CalcFeeAmount(poolTx.Amount, poolTx.Fee)
 	if err != nil {
 		return tracerr.Wrap(err)
+	}
+	// Validate TokenID
+	if poolTx.TokenID != account.TokenID {
+		return tracerr.Wrap(fmt.Errorf("tx.TokenID (%v) != account.TokenID (%v)",
+			poolTx.TokenID, account.TokenID))
 	}
 	// Check signature
 	if !poolTx.VerifySignature(a.chainID, account.BJJ) {

--- a/api/txspool_test.go
+++ b/api/txspool_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // testPoolTxReceive is a struct to be used to assert the response
@@ -170,9 +171,9 @@ func TestPoolTxs(t *testing.T) {
 	fetchedTxID := common.TxID{}
 	for _, tx := range tc.poolTxsToSend {
 		jsonTxBytes, err := json.Marshal(tx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		jsonTxReader := bytes.NewReader(jsonTxBytes)
-		assert.NoError(
+		require.NoError(
 			t, doGoodReq(
 				"POST",
 				endpoint,
@@ -187,42 +188,42 @@ func TestPoolTxs(t *testing.T) {
 	badTx.Amount = "99950000000000000"
 	badTx.Fee = 255
 	jsonTxBytes, err := json.Marshal(badTx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	jsonTxReader := bytes.NewReader(jsonTxBytes)
 	err = doBadReq("POST", endpoint, jsonTxReader, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Wrong signature
 	badTx = tc.poolTxsToSend[0]
 	badTx.FromIdx = "hez:foo:1000"
 	jsonTxBytes, err = json.Marshal(badTx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
 	err = doBadReq("POST", endpoint, jsonTxReader, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Wrong to
 	badTx = tc.poolTxsToSend[0]
 	ethAddr := "hez:0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
 	badTx.ToEthAddr = &ethAddr
 	badTx.ToIdx = nil
 	jsonTxBytes, err = json.Marshal(badTx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
 	err = doBadReq("POST", endpoint, jsonTxReader, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Wrong rq
 	badTx = tc.poolTxsToSend[0]
 	rqFromIdx := "hez:foo:30"
 	badTx.RqFromIdx = &rqFromIdx
 	jsonTxBytes, err = json.Marshal(badTx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
 	err = doBadReq("POST", endpoint, jsonTxReader, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// GET
 	endpoint += "/"
 	for _, tx := range tc.poolTxsToReceive {
 		fetchedTx := testPoolTxReceive{}
-		assert.NoError(
+		require.NoError(
 			t, doGoodReq(
 				"GET",
 				endpoint+tx.TxID.String(),
@@ -233,10 +234,10 @@ func TestPoolTxs(t *testing.T) {
 	}
 	// 400, due invalid TxID
 	err = doBadReq("GET", endpoint+"0xG2241b6f2b1dd772dba391f4a1a3407c7c21f598d86e2585a14e616fb4a255f823", nil, 400)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// 404, due inexistent TxID in DB
 	err = doBadReq("GET", endpoint+"0x02241b6f2b1dd772dba391f4a1a3407c7c21f598d86e2585a14e616fb4a255f823", nil, 404)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func assertPoolTx(t *testing.T, expected, actual testPoolTxReceive) {

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -67,6 +67,7 @@ BJJ = "0x1b176232f78ba0d388ecc5f4896eca2d3b3d4f272092469f559247297f5c0c13"
 [Coordinator.L2DB]
 SafetyPeriod = 10
 MaxTxs       = 512
+MinFeeUSD    = 0.0
 TTL          = "24h"
 PurgeBatchDelay = 10
 InvalidateBatchDelay = 20

--- a/cli/node/main.go
+++ b/cli/node/main.go
@@ -173,6 +173,7 @@ func cmdDiscard(c *cli.Context) error {
 		db,
 		cfg.Coordinator.L2DB.SafetyPeriod,
 		cfg.Coordinator.L2DB.MaxTxs,
+		cfg.Coordinator.L2DB.MinFeeUSD,
 		cfg.Coordinator.L2DB.TTL.Duration,
 		nil,
 	)

--- a/common/utils.go
+++ b/common/utils.go
@@ -62,3 +62,17 @@ func RmEndingZeroes(siblings []*merkletree.Hash) []*merkletree.Hash {
 	}
 	return siblings[:pos]
 }
+
+// TokensToUSD is a helper function to calculate the USD value of a certain
+// amount of tokens considering the normalized token price (which is the price
+// commonly reported by exhanges)
+func TokensToUSD(amount *big.Int, decimals uint64, valueUSD float64) float64 {
+	amountF := new(big.Float).SetInt(amount)
+	// Divide by 10^decimals to normalize the amount
+	baseF := new(big.Float).SetInt(new(big.Int).Exp(
+		big.NewInt(10), big.NewInt(int64(decimals)), nil)) //nolint:gomnd
+	amountF.Mul(amountF, big.NewFloat(valueUSD))
+	amountF.Quo(amountF, baseF)
+	amountUSD, _ := amountF.Float64()
+	return amountUSD
+}

--- a/config/config.go
+++ b/config/config.go
@@ -105,6 +105,10 @@ type Coordinator struct {
 		// reached, inserts to the pool will be denied until some of
 		// the pending txs are forged.
 		MaxTxs uint32 `validate:"required"`
+		// MinFeeUSD is the minimum fee in USD that a tx must pay in
+		// order to be accepted into the pool.  Txs with lower than
+		// minimum fee will be rejected at the API level.
+		MinFeeUSD float64
 		// TTL is the Time To Live for L2Txs in the pool.  Once MaxTxs
 		// L2Txs is reached, L2Txs older than TTL will be deleted.
 		TTL Duration `validate:"required"`

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -105,7 +105,7 @@ func newTestModules(t *testing.T) modules {
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
 	test.WipeDB(db)
-	l2DB := l2db.NewL2DB(db, 10, 100, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
 	historyDB := historydb.NewHistoryDB(db, nil)
 
 	txSelDBPath, err = ioutil.TempDir("", "tmpTxSelDB")

--- a/coordinator/purger_test.go
+++ b/coordinator/purger_test.go
@@ -21,7 +21,7 @@ func newL2DB(t *testing.T) *l2db.L2DB {
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
 	test.WipeDB(db)
-	return l2db.NewL2DB(db, 10, 100, 24*time.Hour, nil)
+	return l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
 }
 
 func newStateDB(t *testing.T) *statedb.LocalStateDB {

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -447,7 +447,8 @@ func (hdb *HistoryDB) addTokens(d meddler.DB, tokens []common.Token) error {
 	))
 }
 
-// UpdateTokenValue updates the USD value of a token
+// UpdateTokenValue updates the USD value of a token.  Value is the price in
+// USD of a normalized token (1 token = 10^decimals units)
 func (hdb *HistoryDB) UpdateTokenValue(tokenSymbol string, value float64) error {
 	// Sanitize symbol
 	tokenSymbol = strings.ToValidUTF8(tokenSymbol, " ")

--- a/db/migrations/0001.sql
+++ b/db/migrations/0001.sql
@@ -47,7 +47,7 @@ CREATE TABLE token (
     name VARCHAR(20) NOT NULL,
     symbol VARCHAR(10) NOT NULL,
     decimals INT NOT NULL,
-    usd NUMERIC,
+    usd NUMERIC, -- value of a normalized token (1 token = 10^decimals units)
     usd_update TIMESTAMP WITHOUT TIME ZONE
 );
 

--- a/node/node.go
+++ b/node/node.go
@@ -205,6 +205,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 			db,
 			cfg.Coordinator.L2DB.SafetyPeriod,
 			cfg.Coordinator.L2DB.MaxTxs,
+			cfg.Coordinator.L2DB.MinFeeUSD,
 			cfg.Coordinator.L2DB.TTL.Duration,
 			apiConnCon,
 		)

--- a/test/zkproof/flows_test.go
+++ b/test/zkproof/flows_test.go
@@ -75,7 +75,7 @@ func initTxSelector(t *testing.T, chainID uint16, hermezContractAddr ethCommon.A
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
-	l2DB := l2db.NewL2DB(db, 10, 100, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
 
 	dir, err := ioutil.TempDir("", "tmpSyncDB")
 	require.NoError(t, err)

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -29,7 +29,7 @@ func initTest(t *testing.T, chainID uint16, hermezContractAddr ethCommon.Address
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
-	l2DB := l2db.NewL2DB(db, 10, 100, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
 
 	dir, err := ioutil.TempDir("", "tmpdb")
 	require.NoError(t, err)


### PR DESCRIPTION
- Add config parameter `Coordinator.L2DB.MinPriceUSD` which allows rejecting
  txs to the pool that have a fee lower than the minimum.
- In pool tx insertion, checking the number of pending txs atomically with the
  insertion to avoid data races leading to more than MaxTxs pending txs in the
  pool.
Resolve #545 