### PR TITLE
fix possible runtime error

### DIFF
--- a/batchbuilder/batchbuilder.go
+++ b/batchbuilder/batchbuilder.go
@@ -64,7 +64,10 @@ func (bb *BatchBuilder) BuildBatch(coordIdxs []common.Idx, configBatch *ConfigBa
 	tp := txprocessor.NewTxProcessor(bbStateDB, configBatch.TxProcessorConfig)
 
 	ptOut, err := tp.ProcessTxs(coordIdxs, l1usertxs, l1coordinatortxs, pooll2txs)
-	return ptOut.ZKInputs, tracerr.Wrap(err)
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	return ptOut.ZKInputs, nil
 }
 
 // LocalStateDB returns the underlying LocalStateDB


### PR DESCRIPTION
### Bug description

possible runtime error: invalid memory address

### Steps to reproduce

Causing error in `tp.ProcessTxs(...)` function.

### Solution

Create an error check condition.



close https://github.com/hermeznetwork/hermez-node/issues/558
