### PR TITLE
tx manager: remove redundant error check

### DIFF
--- a/coordinator/txmanager.go
+++ b/coordinator/txmanager.go
@@ -231,7 +231,7 @@ func (t *TxManager) sendRollupForgeBatch(ctx context.Context, batchInfo *BatchIn
 				"err", err, "gasPrice", auth.GasPrice, "batchNum", batchInfo.BatchNum)
 			auth.GasPrice = addPerc(auth.GasPrice, 10)
 			attempt--
-		} else if err != nil {
+		} else {
 			log.Errorw("TxManager ethClient.RollupForgeBatch",
 				"attempt", attempt, "err", err, "block", t.stats.Eth.LastBlock.Num+1,
 				"batchNum", batchInfo.BatchNum)


### PR DESCRIPTION
### Bug description

Remove redundant error check condition for the tx manager.

### Steps to reproduce

N/A

### Solution

Keep only the first error condition:
https://github.com/hermeznetwork/hermez-node/blob/df0cc32eed0fcad9fe6c744efb8169476ff16334/coordinator/txmanager.go#L212-L214

close https://github.com/hermeznetwork/hermez-node/issues/559