### PR TITLE
node: remove redundant error check

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -247,9 +247,6 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		if err != nil {
 			return nil, tracerr.Wrap(err)
 		}
-		if err != nil {
-			return nil, tracerr.Wrap(err)
-		}
 		serverProofs := make([]prover.Client, len(cfg.Coordinator.ServerProofs))
 		for i, serverProofCfg := range cfg.Coordinator.ServerProofs {
 			serverProofs[i] = prover.NewProofServerClient(serverProofCfg.URL,


### PR DESCRIPTION
### Bug description

Remove redundant error check condition for the node creation

### Steps to reproduce

N/A

### Solution

Keep only the first one error condition:
https://github.com/hermeznetwork/hermez-node/blob/df0cc32eed0fcad9fe6c744efb8169476ff16334/node/node.go#L244-L251

close https://github.com/hermeznetwork/hermez-node/issues/560