### PR TITLE
Diferentiate SQL connections by read write

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -201,7 +201,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	apiConnCon := db.NewAPICnnectionController(1, time.Second)
-	hdb := historydb.NewHistoryDB(database, apiConnCon)
+	hdb := historydb.NewHistoryDB(database, database, apiConnCon)
 	if err != nil {
 		panic(err)
 	}
@@ -216,7 +216,7 @@ func TestMain(m *testing.M) {
 		}
 	}()
 	// L2DB
-	l2DB := l2db.NewL2DB(database, 10, 1000, 0.0, 24*time.Hour, apiConnCon)
+	l2DB := l2db.NewL2DB(database, database, 10, 1000, 0.0, 24*time.Hour, apiConnCon)
 	test.WipeDB(l2DB.DB()) // this will clean HistoryDB and L2DB
 	// Config (smart contract constants)
 	chainID := uint16(0)
@@ -591,10 +591,10 @@ func TestTimeout(t *testing.T) {
 	databaseTO, err := db.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
 	apiConnConTO := db.NewAPICnnectionController(1, 100*time.Millisecond)
-	hdbTO := historydb.NewHistoryDB(databaseTO, apiConnConTO)
+	hdbTO := historydb.NewHistoryDB(databaseTO, databaseTO, apiConnConTO)
 	require.NoError(t, err)
 	// L2DB
-	l2DBTO := l2db.NewL2DB(databaseTO, 10, 1000, 1.0, 24*time.Hour, apiConnConTO)
+	l2DBTO := l2db.NewL2DB(databaseTO, databaseTO, 10, 1000, 1.0, 24*time.Hour, apiConnConTO)
 
 	// API
 	apiGinTO := gin.Default()

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -20,11 +20,16 @@ Path = "/tmp/iden3-test/hermez/statedb"
 Keep = 256
 
 [PostgreSQL]
-Port     = 5432
-Host     = "localhost"
-User     = "hermez"
-Password = "yourpasswordhere"
-Name     = "hermez"
+PortWrite     = 5432
+HostWrite     = "localhost"
+UserWrite     = "hermez"
+PasswordWrite = "yourpasswordhere"
+NameWrite     = "hermez"
+# PortRead     = 5432
+# HostRead     = "localhost"
+# UserRead     = "hermez"
+# PasswordRead = "yourpasswordhere"
+# NameRead     = "hermez"
 
 [Web3]
 URL = "http://localhost:8545"

--- a/config/config.go
+++ b/config/config.go
@@ -215,17 +215,30 @@ type Node struct {
 		// Keep is the number of checkpoints to keep
 		Keep int `validate:"required"`
 	} `validate:"required"`
+	// It's possible to use diferentiated SQL connections for read/write.
+	// If the read configuration is not provided, the write one it's going to be used
+	// for both reads and writes
 	PostgreSQL struct {
-		// Port of the PostgreSQL server
-		Port int `validate:"required"`
-		// Host of the PostgreSQL server
-		Host string `validate:"required"`
-		// User of the PostgreSQL server
-		User string `validate:"required"`
-		// Password of the PostgreSQL server
-		Password string `validate:"required"`
-		// Name of the PostgreSQL server database
-		Name string `validate:"required"`
+		// Port of the PostgreSQL write server
+		PortWrite int `validate:"required"`
+		// Host of the PostgreSQL write server
+		HostWrite string `validate:"required"`
+		// User of the PostgreSQL write server
+		UserWrite string `validate:"required"`
+		// Password of the PostgreSQL write server
+		PasswordWrite string `validate:"required"`
+		// Name of the PostgreSQL write server database
+		NameWrite string `validate:"required"`
+		// Port of the PostgreSQL read server
+		PortRead int
+		// Host of the PostgreSQL read server
+		HostRead string
+		// User of the PostgreSQL read server
+		UserRead string
+		// Password of the PostgreSQL read server
+		PasswordRead string
+		// Name of the PostgreSQL read server database
+		NameRead string
 	} `validate:"required"`
 	Web3 struct {
 		// URL is the URL of the web3 ethereum-node RPC server

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -105,8 +105,8 @@ func newTestModules(t *testing.T) modules {
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
 	test.WipeDB(db)
-	l2DB := l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
-	historyDB := historydb.NewHistoryDB(db, nil)
+	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
+	historyDB := historydb.NewHistoryDB(db, db, nil)
 
 	txSelDBPath, err = ioutil.TempDir("", "tmpTxSelDB")
 	require.NoError(t, err)

--- a/coordinator/purger_test.go
+++ b/coordinator/purger_test.go
@@ -21,7 +21,7 @@ func newL2DB(t *testing.T) *l2db.L2DB {
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
 	test.WipeDB(db)
-	return l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
+	return l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
 }
 
 func newStateDB(t *testing.T) *statedb.LocalStateDB {

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -39,12 +39,12 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	historyDB = NewHistoryDB(db, nil)
+	historyDB = NewHistoryDB(db, db, nil)
 	if err != nil {
 		panic(err)
 	}
 	apiConnCon := dbUtils.NewAPICnnectionController(1, time.Second)
-	historyDBWithACC = NewHistoryDB(db, apiConnCon)
+	historyDBWithACC = NewHistoryDB(db, db, apiConnCon)
 	// Run tests
 	result := m.Run()
 	// Close DB
@@ -817,11 +817,11 @@ func TestSetExtraInfoForgedL1UserTxs(t *testing.T) {
 	}
 	// Add second batch to trigger the update of the batch_num,
 	// while avoiding the implicit call of setExtraInfoForgedL1UserTxs
-	err = historyDB.addBlock(historyDB.db, &blocks[1].Block)
+	err = historyDB.addBlock(historyDB.dbWrite, &blocks[1].Block)
 	require.NoError(t, err)
-	err = historyDB.addBatch(historyDB.db, &blocks[1].Rollup.Batches[0].Batch)
+	err = historyDB.addBatch(historyDB.dbWrite, &blocks[1].Rollup.Batches[0].Batch)
 	require.NoError(t, err)
-	err = historyDB.addAccounts(historyDB.db, blocks[1].Rollup.Batches[0].CreatedAccounts)
+	err = historyDB.addAccounts(historyDB.dbWrite, blocks[1].Rollup.Batches[0].CreatedAccounts)
 	require.NoError(t, err)
 
 	// Set the Effective{Amount,DepositAmount} of the L1UserTxs that are forged in the second block
@@ -831,7 +831,7 @@ func TestSetExtraInfoForgedL1UserTxs(t *testing.T) {
 	l1Txs[1].EffectiveAmount = big.NewInt(0)
 	l1Txs[2].EffectiveDepositAmount = big.NewInt(0)
 	l1Txs[2].EffectiveAmount = big.NewInt(0)
-	err = historyDB.setExtraInfoForgedL1UserTxs(historyDB.db, l1Txs)
+	err = historyDB.setExtraInfoForgedL1UserTxs(historyDB.dbWrite, l1Txs)
 	require.NoError(t, err)
 
 	dbL1Txs, err := historyDB.GetAllL1UserTxs()
@@ -918,10 +918,10 @@ func TestUpdateExitTree(t *testing.T) {
 		common.WithdrawInfo{Idx: 259, NumExitRoot: 3, InstantWithdraw: false,
 			Owner: tc.UsersByIdx[259].Addr, Token: tokenAddr},
 	)
-	err = historyDB.addBlock(historyDB.db, &block.Block)
+	err = historyDB.addBlock(historyDB.dbWrite, &block.Block)
 	require.NoError(t, err)
 
-	err = historyDB.updateExitTree(historyDB.db, block.Block.Num,
+	err = historyDB.updateExitTree(historyDB.dbWrite, block.Block.Num,
 		block.Rollup.Withdrawals, block.WDelayer.Withdrawals)
 	require.NoError(t, err)
 
@@ -951,10 +951,10 @@ func TestUpdateExitTree(t *testing.T) {
 			Token:  tokenAddr,
 			Amount: big.NewInt(80),
 		})
-	err = historyDB.addBlock(historyDB.db, &block.Block)
+	err = historyDB.addBlock(historyDB.dbWrite, &block.Block)
 	require.NoError(t, err)
 
-	err = historyDB.updateExitTree(historyDB.db, block.Block.Num,
+	err = historyDB.updateExitTree(historyDB.dbWrite, block.Block.Num,
 		block.Rollup.Withdrawals, block.WDelayer.Withdrawals)
 	require.NoError(t, err)
 
@@ -997,7 +997,7 @@ func TestGetBestBidCoordinator(t *testing.T) {
 			URL:         "bar",
 		},
 	}
-	err = historyDB.addCoordinators(historyDB.db, coords)
+	err = historyDB.addCoordinators(historyDB.dbWrite, coords)
 	require.NoError(t, err)
 
 	bids := []common.Bid{
@@ -1015,7 +1015,7 @@ func TestGetBestBidCoordinator(t *testing.T) {
 		},
 	}
 
-	err = historyDB.addBids(historyDB.db, bids)
+	err = historyDB.addBids(historyDB.dbWrite, bids)
 	require.NoError(t, err)
 
 	forger10, err := historyDB.GetBestBidCoordinator(10)
@@ -1053,7 +1053,7 @@ func TestAddBucketUpdates(t *testing.T) {
 			Withdrawals: big.NewInt(42),
 		},
 	}
-	err := historyDB.addBucketUpdates(historyDB.db, bucketUpdates)
+	err := historyDB.addBucketUpdates(historyDB.dbWrite, bucketUpdates)
 	require.NoError(t, err)
 	dbBucketUpdates, err := historyDB.GetAllBucketUpdates()
 	require.NoError(t, err)
@@ -1078,7 +1078,7 @@ func TestAddTokenExchanges(t *testing.T) {
 			ValueUSD:    67890,
 		},
 	}
-	err := historyDB.addTokenExchanges(historyDB.db, tokenExchanges)
+	err := historyDB.addTokenExchanges(historyDB.dbWrite, tokenExchanges)
 	require.NoError(t, err)
 	dbTokenExchanges, err := historyDB.GetAllTokenExchanges()
 	require.NoError(t, err)
@@ -1107,7 +1107,7 @@ func TestAddEscapeHatchWithdrawals(t *testing.T) {
 			Amount:      big.NewInt(20003),
 		},
 	}
-	err := historyDB.addEscapeHatchWithdrawals(historyDB.db, escapeHatchWithdrawals)
+	err := historyDB.addEscapeHatchWithdrawals(historyDB.dbWrite, escapeHatchWithdrawals)
 	require.NoError(t, err)
 	dbEscapeHatchWithdrawals, err := historyDB.GetAllEscapeHatchWithdrawals()
 	require.NoError(t, err)

--- a/priceupdater/priceupdater_test.go
+++ b/priceupdater/priceupdater_test.go
@@ -20,7 +20,7 @@ func TestPriceUpdater(t *testing.T) {
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	assert.NoError(t, err)
-	historyDB := historydb.NewHistoryDB(db, nil)
+	historyDB := historydb.NewHistoryDB(db, db, nil)
 	// Clean DB
 	test.WipeDB(historyDB.DB())
 	// Populate DB

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -315,7 +315,7 @@ func newTestModules(t *testing.T) (*statedb.StateDB, *historydb.HistoryDB) {
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
-	historyDB := historydb.NewHistoryDB(db, nil)
+	historyDB := historydb.NewHistoryDB(db, db, nil)
 	// Clear DB
 	test.WipeDB(historyDB.DB())
 

--- a/test/zkproof/flows_test.go
+++ b/test/zkproof/flows_test.go
@@ -38,7 +38,7 @@ func addTokens(t *testing.T, tc *til.Context, db *sqlx.DB) {
 		})
 	}
 
-	hdb := historydb.NewHistoryDB(db, nil)
+	hdb := historydb.NewHistoryDB(db, db, nil)
 	assert.NoError(t, hdb.AddBlock(&common.Block{
 		Num: 1,
 	}))
@@ -75,7 +75,7 @@ func initTxSelector(t *testing.T, chainID uint16, hermezContractAddr ethCommon.A
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
-	l2DB := l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
 
 	dir, err := ioutil.TempDir("", "tmpSyncDB")
 	require.NoError(t, err)

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -29,7 +29,7 @@ func initTest(t *testing.T, chainID uint16, hermezContractAddr ethCommon.Address
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
-	l2DB := l2db.NewL2DB(db, 10, 100, 0.0, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
 
 	dir, err := ioutil.TempDir("", "tmpdb")
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func addTokens(t *testing.T, tc *til.Context, db *sqlx.DB) {
 		})
 	}
 
-	hdb := historydb.NewHistoryDB(db, nil)
+	hdb := historydb.NewHistoryDB(db, db, nil)
 	assert.NoError(t, hdb.AddBlock(&common.Block{
 		Num: 1,
 	}))


### PR DESCRIPTION
# Edit by ed255:
Config update:
- Rename `PostgreSQL.Port` to `PostgreSQL.PortWrite`
- Rename `PostgreSQL.Host` to `PostgreSQL.HostWrite`
- Rename `PostgreSQL.User` to `PostgreSQL.UserWrite`
- Rename `PostgreSQL.Password` to `PostgreSQL.PasswordWrite`
- Rename `PostgreSQL.Name` to `PostgreSQL.NameWrite`
- Add `PostgreSQL.PortRead`
- Add `PostgreSQL.HostRead`
- Add `PostgreSQL.UserRead`
- Add `PostgreSQL.PasswordRead`
- Add `PostgreSQL.NameRead`