### PR TITLE
In http servers, first listen, then serve

### DIFF
--- a/test/debugapi/debugapi.go
+++ b/test/debugapi/debugapi.go
@@ -2,6 +2,7 @@ package debugapi
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -118,16 +119,20 @@ func (a *DebugAPI) Run(ctx context.Context) error {
 	debugAPI.GET("sync/stats", a.handleSyncStats)
 
 	debugAPIServer := &http.Server{
-		Addr:    a.addr,
 		Handler: api,
-		// Use some hardcoded numberes that are suitable for testing
+		// Use some hardcoded numbers that are suitable for testing
 		ReadTimeout:    30 * time.Second, //nolint:gomnd
 		WriteTimeout:   30 * time.Second, //nolint:gomnd
 		MaxHeaderBytes: 1 << 20,          //nolint:gomnd
 	}
+	listener, err := net.Listen("tcp", a.addr)
+	if err != nil {
+		return tracerr.Wrap(err)
+	}
+	log.Infof("DebugAPI is ready at %v", a.addr)
 	go func() {
-		log.Infof("DebugAPI is ready at %v", a.addr)
-		if err := debugAPIServer.ListenAndServe(); err != nil && tracerr.Unwrap(err) != http.ErrServerClosed {
+		if err := debugAPIServer.Serve(listener); err != nil &&
+			tracerr.Unwrap(err) != http.ErrServerClosed {
 			log.Fatalf("Listen: %s\n", err)
 		}
 	}()


### PR DESCRIPTION
- In test, doing the `net.Listen` outside of the goroutine guarantees that we
  are listening, so we avoid a possible datarace consisting of doing an http
  request before listening.
- In packages that run an http server: doing the listen first allows
    - Checking for errors when opening the address for listening before
      starting the goroutine, so that if there's an error on listen we can
      terminate grafecully
    - Logging that we are listening when we are really listening, and not
      before.