### PR TITLE
Add API metric for time to forge L1 tx

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1329,13 +1329,6 @@ components:
           type: string
           description: Moment in which the transaction was added to the pool.
           format: date-time
-        batchNum:
-          type: integer
-          description: Identifier of a batch. Every new forged batch increases by one the batchNum, starting at 0.
-          minimum: 0
-          maximum: 4294967295
-          nullable: true
-          example: null
         requestFromAccountIndex:
           type: string
           description: >-
@@ -1390,7 +1383,6 @@ components:
           $ref: '#/components/schemas/Token'
       example:
         amount: '100000000000000'
-        batchNum: 
         fee: 0
         fromAccountIndex: hez:SCC:256
         fromBJJ: hez:r_trOasVEk0zNaalOoS9aLedu6mO7jI5XTIPu_zGXoyn
@@ -1438,7 +1430,6 @@ components:
         - info
         - signature
         - timestamp
-        - batchNum
         - requestFromAccountIndex
         - requestToAccountIndex
         - requestToHezEthereumAddress
@@ -2812,6 +2803,10 @@ components:
           type: number
           description: Average fee percentage paid for L2 transactions in the last 24 hours.
           example: 1.54
+        estimatedTimeToForgeL1:
+          type: number
+          description: Estimated time needed to forge a L1 transaction, from the time it's added on the smart contract, until it's actualy forged. In seconds.
+          example: 193.4
       additionalProperties: false
       required:
         - transactionsPerBatch
@@ -2820,6 +2815,7 @@ components:
         - totalAccounts
         - totalBJJs
         - avgTransactionFee
+        - estimatedTimeToForgeL1
     PendingItems:
       type: integer
       description: Amount of items that will be returned in subsequent calls to the endpoint, as long as they are done with same filters. When the value is 0 it means that all items have been sent.

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -73,7 +73,7 @@ func NewPoolL2Tx(tx *PoolL2Tx) (*PoolL2Tx, error) {
 	// If original Type doesn't match the correct one, return error
 	if txTypeOld != "" && txTypeOld != tx.Type {
 		return nil, tracerr.Wrap(fmt.Errorf("L2Tx.Type: %s, should be: %s",
-			tx.Type, txTypeOld))
+			txTypeOld, tx.Type))
 	}
 
 	txIDOld := tx.TxID
@@ -83,7 +83,7 @@ func NewPoolL2Tx(tx *PoolL2Tx) (*PoolL2Tx, error) {
 	// If original TxID doesn't match the correct one, return error
 	if txIDOld != (TxID{}) && txIDOld != tx.TxID {
 		return tx, tracerr.Wrap(fmt.Errorf("PoolL2Tx.TxID: %s, should be: %s",
-			tx.TxID.String(), txIDOld.String()))
+			txIDOld.String(), tx.TxID.String()))
 	}
 
 	return tx, nil

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -304,12 +304,13 @@ type BatchAPI struct {
 
 // Metrics define metrics of the network
 type Metrics struct {
-	TransactionsPerBatch  float64 `json:"transactionsPerBatch"`
-	BatchFrequency        float64 `json:"batchFrequency"`
-	TransactionsPerSecond float64 `json:"transactionsPerSecond"`
-	TotalAccounts         int64   `json:"totalAccounts" meddler:"total_accounts"`
-	TotalBJJs             int64   `json:"totalBJJs" meddler:"total_bjjs"`
-	AvgTransactionFee     float64 `json:"avgTransactionFee"`
+	TransactionsPerBatch   float64 `json:"transactionsPerBatch"`
+	BatchFrequency         float64 `json:"batchFrequency"`
+	TransactionsPerSecond  float64 `json:"transactionsPerSecond"`
+	TotalAccounts          int64   `json:"totalAccounts" meddler:"total_accounts"`
+	TotalBJJs              int64   `json:"totalBJJs" meddler:"total_bjjs"`
+	AvgTransactionFee      float64 `json:"avgTransactionFee"`
+	EstimatedTimeToForgeL1 float64 `json:"estimatedTimeToForgeL1" meddler:"estimatedTimeToForgeL1"`
 }
 
 // MetricsTotals is used to get temporal information from HistoryDB

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -95,7 +95,6 @@ func (tx PoolTxAPI) MarshalJSON() ([]byte, error) {
 		"info":                        tx.Info,
 		"signature":                   tx.Signature,
 		"timestamp":                   tx.Timestamp,
-		"batchNum":                    tx.BatchNum,
 		"requestFromAccountIndex":     tx.RqFromIdx,
 		"requestToAccountIndex":       tx.RqToIdx,
 		"requestToHezEthereumAddress": tx.RqToEthAddr,


### PR DESCRIPTION
- Add a new metric to the API, `estimatedTimeToForgeL1`: average time in seconds that ti takes to forge a L1 tx (from added to the SC queue until forged). Close #576 
- Remove `batchNum` from the response of `GET /transactions-pool/{txid}` since it may be misleading, it's easy to understanf that the tx is forged in that batch, when in reality this is used internally to manage the state of the txs
- Fix error message for wrong ID and types in PoolL2Tx