### PR TITLE
Calculate ForgeBatch gasLimit with parametrized formula

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -104,6 +104,12 @@ GasPriceIncPerc = 10
 Path = "/tmp/iden3-test/hermez/ethkeystore"
 Password = "yourpasswordhere"
 
+[Coordinator.EthClient.ForgeBatchGasCost]
+Fixed = 500000
+L1UserTx = 8000
+L1CoordTx = 9000
+L2Tx = 1
+
 [Coordinator.API]
 Coordinator = true
 

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,15 @@ type ServerProof struct {
 	URL string `validate:"required"`
 }
 
+// ForgeBatchGasCost is the costs associated to a ForgeBatch transaction, split
+// into different parts to be used in a formula.
+type ForgeBatchGasCost struct {
+	Fixed     uint64 `validate:"required"`
+	L1UserTx  uint64 `validate:"required"`
+	L1CoordTx uint64 `validate:"required"`
+	L2Tx      uint64 `validate:"required"`
+}
+
 // Coordinator is the coordinator specific configuration.
 type Coordinator struct {
 	// ForgerAddress is the address under which this coordinator is forging
@@ -180,6 +189,9 @@ type Coordinator struct {
 			// Password used to decrypt the keys in the keystore
 			Password string `validate:"required"`
 		} `validate:"required"`
+		// ForgeBatchGasCost contains the cost of each action in the
+		// ForgeBatch transaction.
+		ForgeBatchGasCost ForgeBatchGasCost `validate:"required"`
 	} `validate:"required"`
 	API struct {
 		// Coordinator enables the coordinator API endpoints

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -11,6 +11,7 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-node/batchbuilder"
 	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/config"
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/eth"
@@ -115,7 +116,10 @@ type Config struct {
 	Purger         PurgerCfg
 	// VerifierIdx is the index of the verifier contract registered in the
 	// smart contract
-	VerifierIdx       uint8
+	VerifierIdx uint8
+	// ForgeBatchGasCost contains the cost of each action in the
+	// ForgeBatch transaction.
+	ForgeBatchGasCost config.ForgeBatchGasCost
 	TxProcessorConfig txprocessor.Config
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -336,6 +336,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 					PurgeBlockDelay:      cfg.Coordinator.L2DB.PurgeBlockDelay,
 					InvalidateBlockDelay: cfg.Coordinator.L2DB.InvalidateBlockDelay,
 				},
+				ForgeBatchGasCost: cfg.Coordinator.EthClient.ForgeBatchGasCost,
 				VerifierIdx:       uint8(verifierIdx),
 				TxProcessorConfig: txProcessorCfg,
 			},


### PR DESCRIPTION
Add the following config parameters at
`Coordinator.EthClient.ForgeBatchGasCost`:
- `Fixed`
- `L1UserTx`
- `L1CoordTx`
- `L2Tx`
Which are the costs associated to a ForgeBatch transaction, split
into different parts to be used in the formula to compute the gasLimit.

Resolve https://github.com/hermeznetwork/hermez-node/issues/460