### PR TITLE
Set gin debug mode via config

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -14,6 +14,7 @@ Type = "bitfinexV2"
 [Debug]
 APIAddress = "localhost:12345"
 MeddlerLogs = true
+GinDebugMode = true
 
 [StateDB]
 Path = "/tmp/iden3-test/hermez/statedb"

--- a/config/config.go
+++ b/config/config.go
@@ -294,6 +294,9 @@ type Node struct {
 		// MeddlerLogs enables meddler debug mode, where unused columns and struct
 		// fields will be logged
 		MeddlerLogs bool
+		// GinDebugMode sets Gin-Gonic (the web framework) to run in
+		// debug mode
+		GinDebugMode bool
 	}
 	Coordinator Coordinator `validate:"-"`
 }

--- a/node/node.go
+++ b/node/node.go
@@ -358,6 +358,11 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 	}
 	var nodeAPI *NodeAPI
 	if cfg.API.Address != "" {
+		if cfg.Debug.GinDebugMode {
+			gin.SetMode(gin.DebugMode)
+		} else {
+			gin.SetMode(gin.ReleaseMode)
+		}
 		if cfg.API.UpdateMetricsInterval.Duration == 0 {
 			return nil, tracerr.Wrap(fmt.Errorf("invalid cfg.API.UpdateMetricsInterval: %v",
 				cfg.API.UpdateMetricsInterval.Duration))


### PR DESCRIPTION
Add new config setting `Debug.GinDebugMode`.  When set to true, gin will run in
debug mode.  If not set, gin will run in release mode.  Before this change, gin
always ran in debug mode, so to keep the same behaviour as before, set this
parameter to true