### PR TITLE
check the forge address balance before starting the node

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -51,6 +51,7 @@ ForgerAddress = "0x05c23b938a85ab26A36E6314a0D02080E9ca6BeD" # Non-Boot Coordina
 # ForgerAddressPrivateKey = "0x30f5fddb34cd4166adb2c6003fa6b18f380fd2341376be42cf1c7937004ac7a3"
 # ForgerAddress = "0xb4124ceb3451635dacedd11767f004d8a28c6ee7" # Boot Coordinator
 # ForgerAddressPrivateKey = "0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563"
+MinimumForgeAddressBalance = 0
 ConfirmBlocks = 10
 L1BatchTimeoutPerc = 0.6
 StartSlotBlocksDelay = 2

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,10 @@ type ForgeBatchGasCost struct {
 type Coordinator struct {
 	// ForgerAddress is the address under which this coordinator is forging
 	ForgerAddress ethCommon.Address `validate:"required"`
+	// MinimumForgeAddressBalance is the minimum balance the forger address
+	// needs to start the coordinator in wei. Of set to 0, the coordinator
+	// will not check the balance before starting.
+	MinimumForgeAddressBalance *big.Int
 	// FeeAccount is the Hermez account that the coordinator uses to receive fees
 	FeeAccount struct {
 		// Address is the ethereum address of the account to receive fees


### PR DESCRIPTION
### What does this MR does?

Check the forge address balance before unlocking the wallet.

### Why we need it?

- Show the balances for the user coordinator
- If the config variable `MinimumForgeAddressBalance` is set, the forged address must have at least this amount.

### How to test?

- run node:
```
$ go run ./cli/node --mode coord --cfg cli/node/cfg.buidler.toml run
``` 

- set a high value to `MinimumForgeAddressBalance` and run again;