### PR TITLE
Set the intermediary signal when exit TX is not inserted

### DIFF
--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -1268,6 +1268,7 @@ func (tp *TxProcessor) applyExit(coordIdxsMap map[common.TokenID]common.Idx,
 		}
 		tp.zki.OldKey2[tp.i] = p.OldKey.BigInt()
 		tp.zki.OldValue2[tp.i] = p.OldValue.BigInt()
+		tp.zki.ISExitRoot[tp.i] = exitTree.Root().BigInt()
 	}
 
 	return exitAccount, false, nil


### PR DESCRIPTION
In case 1b, The imtermediary Signal ExitRoot is was not set. It must be set with the new state of the exit tree.

This should fix Issue https://github.com/hermeznetwork/hermez-issues/issues/44