### PR TITLE
Avoid SQL error when checking value of token without usd on tx insert

### DIFF
--- a/db/l2db/apiqueries.go
+++ b/db/l2db/apiqueries.go
@@ -50,7 +50,7 @@ func (l2db *L2DB) AddTxAPI(tx *PoolL2TxWrite) error {
 	defer l2db.apiConnCon.Release()
 
 	row := l2db.dbRead.QueryRow(`SELECT
-		($1::NUMERIC * token.usd * fee_percentage($2::NUMERIC)) /
+		($1::NUMERIC * COALESCE(token.usd, 0) * fee_percentage($2::NUMERIC)) /
 			(10.0 ^ token.decimals::NUMERIC)
 		FROM token WHERE token.token_id = $3;`,
 		tx.AmountFloat, tx.Fee, tx.TokenID)


### PR DESCRIPTION
When doing a `POST /transactions-pool`, if the token has no USD value set, it was returning a error hard to understand, now it will use 0 as USD value making the tx fail anyway, but because of not having enough value