### PR TITLE
Fix unforged L1UserTxs query in forgeBatch

### DIFF
--- a/coordinator/pipeline.go
+++ b/coordinator/pipeline.go
@@ -462,17 +462,18 @@ func (p *Pipeline) forgeBatch(batchNum common.BatchNum) (batchInfo *BatchInfo, e
 		noTxs := false
 		if len(l1UserTxsExtra) == 0 && len(l1CoordTxs) == 0 && len(poolL2Txs) == 0 {
 			if batchInfo.L1Batch {
-				// Query the L1UserTxs in the queue following
-				// the one we are trying to forge.
-				nextL1UserTxs, err := p.historyDB.GetUnforgedL1UserTxs(
-					p.state.lastForgeL1TxsNum + 1)
+				// Query the number of unforged L1UserTxs
+				// (either in a open queue or in a frozen
+				// not-yet-forged queue).
+				count, err := p.historyDB.GetUnforgedL1UserTxsCount()
 				if err != nil {
 					return nil, tracerr.Wrap(err)
 				}
 				// If there are future L1UserTxs, we forge a
-				// batch to advance the queues and forge the
-				// L1UserTxs in the future.  Otherwise, skip.
-				if len(nextL1UserTxs) == 0 {
+				// batch to advance the queues to be able to
+				// forge the L1UserTxs in the future.
+				// Otherwise, skip.
+				if count == 0 {
 					noTxs = true
 				}
 			} else {

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -763,6 +763,16 @@ func (hdb *HistoryDB) GetUnforgedL1UserTxs(toForgeL1TxsNum int64) ([]common.L1Tx
 	return db.SlicePtrsToSlice(txs).([]common.L1Tx), tracerr.Wrap(err)
 }
 
+// GetUnforgedL1UserTxsCount returns the count of unforged L1Txs (either in
+// open or frozen queues that are not yet forged)
+func (hdb *HistoryDB) GetUnforgedL1UserTxsCount() (int, error) {
+	row := hdb.dbRead.QueryRow(
+		`SELECT COUNT(*) FROM tx WHERE batch_num IS NULL;`,
+	)
+	var count int
+	return count, tracerr.Wrap(row.Scan(&count))
+}
+
 // TODO: Think about chaning all the queries that return a last value, to queries that return the next valid value.
 
 // GetLastTxsPosition for a given to_forge_l1_txs_num

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -720,6 +720,10 @@ func TestGetUnforgedL1UserTxs(t *testing.T) {
 	assert.Equal(t, 5, len(l1UserTxs))
 	assert.Equal(t, blocks[0].Rollup.L1UserTxs, l1UserTxs)
 
+	count, err := historyDB.GetUnforgedL1UserTxsCount()
+	require.NoError(t, err)
+	assert.Equal(t, 5, count)
+
 	// No l1UserTxs for this toForgeL1TxsNum
 	l1UserTxs, err = historyDB.GetUnforgedL1UserTxs(2)
 	require.NoError(t, err)


### PR DESCRIPTION
Previously the code was only querying the unforged L1UserTxs of a particular
queue, but this was incorrect because there are always two non-forged queues:
the frozen one and the open one.

Replace it by a query to all the unforged L1UserTxs via a new HistoryDB method.