### PR TITLE
Don't select extra columns in SQL, fix metrics query

### DIFF
--- a/db/historydb/apiqueries.go
+++ b/db/historydb/apiqueries.go
@@ -1010,7 +1010,8 @@ func (hdb *HistoryDB) GetMetricsAPI(lastBatchNum common.BatchNum) (*Metrics, err
 	}
 	err = meddler.QueryRow(
 		hdb.dbRead, metrics,
-		`SELECT COALESCE (AVG(EXTRACT(EPOCH FROM (forged.timestamp - added.timestamp))), 0) AS estimatedTimeToForgeL1 FROM tx
+		`SELECT COALESCE (AVG(EXTRACT(EPOCH FROM (forged.timestamp - added.timestamp))), 0)
+			AS estimated_time_to_forge_l1 FROM tx
 		INNER JOIN block AS added ON tx.eth_block_num = added.eth_block_num
 		INNER JOIN batch AS forged_batch ON tx.batch_num = forged_batch.batch_num
 		INNER JOIN block AS forged ON forged_batch.eth_block_num = forged.eth_block_num
@@ -1069,7 +1070,8 @@ func (hdb *HistoryDB) GetCommonAccountAPI(idx common.Idx) (*common.Account, erro
 	defer hdb.apiConnCon.Release()
 	account := &common.Account{}
 	err = meddler.QueryRow(
-		hdb.dbRead, account, `SELECT * FROM account WHERE idx = $1;`, idx,
+		hdb.dbRead, account, `SELECT idx, token_id, batch_num, bjj, eth_addr
+		FROM account WHERE idx = $1;`, idx,
 	)
 	return account, tracerr.Wrap(err)
 }

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -310,7 +310,7 @@ type Metrics struct {
 	TotalAccounts          int64   `json:"totalAccounts" meddler:"total_accounts"`
 	TotalBJJs              int64   `json:"totalBJJs" meddler:"total_bjjs"`
 	AvgTransactionFee      float64 `json:"avgTransactionFee"`
-	EstimatedTimeToForgeL1 float64 `json:"estimatedTimeToForgeL1" meddler:"estimatedTimeToForgeL1"`
+	EstimatedTimeToForgeL1 float64 `json:"estimatedTimeToForgeL1" meddler:"estimated_time_to_forge_l1"`
 }
 
 // MetricsTotals is used to get temporal information from HistoryDB


### PR DESCRIPTION
In the metrics query, the estimatedTimeToForgeL1 was probably not being read
from the SQL query because it contained upper case letters, and in PostgreSQL
when identifiers are not double quoted they are case insensitive:
https://stackoverflow.com/a/20880247

Resolve #592 