### PR TITLE
Wipe StateDB in cli command wipesql

### DIFF
--- a/db/kvdb/kvdb.go
+++ b/db/kvdb/kvdb.go
@@ -544,10 +544,12 @@ func (k *KVDB) MakeCheckpointFromTo(fromBatchNum common.BatchNum, dest string) e
 	// synchronizer to the same batchNum
 	k.m.Lock()
 	defer k.m.Unlock()
-	return pebbleMakeCheckpoint(source, dest)
+	return PebbleMakeCheckpoint(source, dest)
 }
 
-func pebbleMakeCheckpoint(source, dest string) error {
+// PebbleMakeCheckpoint is a hepler function to make a pebble checkpoint from
+// source to dest.
+func PebbleMakeCheckpoint(source, dest string) error {
 	// Remove dest folder (if it exists) before doing the checkpoint
 	if _, err := os.Stat(dest); os.IsNotExist(err) {
 	} else if err != nil {


### PR DESCRIPTION
Also, in the cli commands `wipesql` and `discard`, always rebuild the current
checkpoint of the stateDBs to make sure it's in a consistent non-corrupted
state and do a reset afterwards.  These commands will allow reverting the
StateDB to a valid and consistent state in case a crash leaves the StateDB in a
corrupted state.

Resolve #598

~~Note: I leave this as a draft because I want to test it more~~