### PR TITLE
Synchronize the AccountCreationAuths from L1CoordinatorTxs

### DIFF
--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -206,7 +206,7 @@ func newTestCoordinator(t *testing.T, forgerAddr ethCommon.Address, ethClient *t
 
 func newTestSynchronizer(t *testing.T, ethClient *test.Client, ethClientSetup *test.ClientSetup,
 	modules modules) *synchronizer.Synchronizer {
-	sync, err := synchronizer.NewSynchronizer(ethClient, modules.historyDB, modules.stateDB,
+	sync, err := synchronizer.NewSynchronizer(ethClient, modules.historyDB, modules.l2DB, modules.stateDB,
 		synchronizer.Config{
 			StatsRefreshPeriod: 0 * time.Second,
 		})

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -74,6 +74,16 @@ func (l2db *L2DB) AddAccountCreationAuth(auth *common.AccountCreationAuth) error
 	return tracerr.Wrap(err)
 }
 
+// AddManyAccountCreationAuth inserts a batch of accounts creation authorization
+// if not exist into the DB
+func (l2db *L2DB) AddManyAccountCreationAuth(auths []common.AccountCreationAuth) error {
+	_, err := sqlx.NamedExec(l2db.dbWrite,
+		`INSERT INTO account_creation_auth (eth_addr, bjj, signature)
+				VALUES (:ethaddr, :bjj, :signature) 
+				ON CONFLICT (eth_addr) DO NOTHING`, auths)
+	return tracerr.Wrap(err)
+}
+
 // GetAccountCreationAuth returns an account creation authorization from the DB
 func (l2db *L2DB) GetAccountCreationAuth(addr ethCommon.Address) (*common.AccountCreationAuth, error) {
 	auth := new(common.AccountCreationAuth)

--- a/test/ethclient.go
+++ b/test/ethclient.go
@@ -1897,12 +1897,16 @@ func (c *Client) CtlAddBlocks(blocks []common.BlockData) (err error) {
 		}
 		c.CtlSetAddr(auction.Vars.BootCoordinator)
 		for _, batch := range block.Rollup.Batches {
+			auths := make([][]byte, len(batch.L1CoordinatorTxs))
+			for i := range auths {
+				auths[i] = make([]byte, 65)
+			}
 			if _, err := c.RollupForgeBatch(&eth.RollupForgeBatchArgs{
 				NewLastIdx:            batch.Batch.LastIdx,
 				NewStRoot:             batch.Batch.StateRoot,
 				NewExitRoot:           batch.Batch.ExitRoot,
 				L1CoordinatorTxs:      batch.L1CoordinatorTxs,
-				L1CoordinatorTxsAuths: [][]byte{}, // Intentionally empty
+				L1CoordinatorTxsAuths: auths,
 				L2TxsData:             batch.L2Txs,
 				FeeIdxCoordinator:     batch.Batch.FeeIdxsCoordinator,
 				// Circuit selector


### PR DESCRIPTION
### What does this MR does?

- Synchronize the new AccountCreationAuths from L1CoordinatorTxs coming from the rollup smart contract (_Only works as a coordinator_).
- Fix the error rollback handler (https://github.com/hermeznetwork/hermez-node/issues/606)

### Why we need it?

To sync new authorizations coming from other nodes.

### How to test?

- run the node:
```
$ go run ./cli/node --mode coord --cfg cli/node/cfg.buidler.toml run
``` 

- Make L1 transactions and wait for the node to sync the account creation auths into the L2DB;


closes https://github.com/hermeznetwork/hermez-node/issues/561
closes https://github.com/hermeznetwork/hermez-node/issues/606