### PR TITLE
API doesnt accept pool txs without to

### DIFF
--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -101,6 +101,8 @@ func (tx *PoolL2Tx) SetType() error {
 			tx.Type = TxTypeTransferToBJJ
 		} else if tx.ToEthAddr != FFAddr && tx.ToEthAddr != EmptyAddr {
 			tx.Type = TxTypeTransferToEthAddr
+		} else {
+			return tracerr.Wrap(errors.New("malformed transaction"))
 		}
 	} else {
 		return tracerr.Wrap(errors.New("malformed transaction"))


### PR DESCRIPTION
There was bug checking the tx type that allowed `api.receivedPoolTx` to be inserted in the pool when `ToIdx, ToEthAddr, ToBJ` were `nil`