### PR TITLE
Allow price update configuration to be specified per token

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -306,7 +306,7 @@ func TestMain(m *testing.M) {
 		USD:         &ethUSD,
 		USDUpdate:   &ethNow,
 	})
-	err = api.h.UpdateTokenValue(test.EthToken.Symbol, ethUSD)
+	err = api.h.UpdateTokenValue(common.EmptyAddr, ethUSD)
 	if err != nil {
 		panic(err)
 	}
@@ -333,7 +333,7 @@ func TestMain(m *testing.M) {
 			token.USD = &value
 			token.USDUpdate = &now
 			// Set value in DB
-			err = api.h.UpdateTokenValue(token.Symbol, value)
+			err = api.h.UpdateTokenValue(token.EthAddr, value)
 			if err != nil {
 				panic(err)
 			}

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -8,10 +8,31 @@ SQLConnectionTimeout = "2s"
 
 [PriceUpdater]
 Interval = "10s"
-URL = "https://api-pub.bitfinex.com/v2/"
-Type = "bitfinexV2"
-# URL = "https://api.coingecko.com/api/v3/"
-# Type = "coingeckoV3"
+URLBitfinexV2 = "https://api-pub.bitfinex.com/v2/"
+URLCoinGeckoV3 = "https://api.coingecko.com/api/v3/"
+# Available update methods:
+# - coingeckoV3 (recommended): get price by SC addr using coingecko API
+# - bitfinexV2: get price by token symbol using bitfinex API
+# - static (recommended for blacklisting tokens): use the given StaticValue to set the price (if not provided 0 will be used)
+# - ignore: don't update the price leave it as it is on the DB
+DefaultUpdateMethod = "coingeckoV3" # Update method used for all the tokens registered on the network, and not listed in [[PriceUpdater.TokensConfig]]
+[[PriceUpdater.TokensConfig]]
+UpdateMethod = "bitfinexV2"
+Symbol = "USDT"
+Addr = "0xdac17f958d2ee523a2206206994597c13d831ec7"
+[[PriceUpdater.TokensConfig]]
+UpdateMethod = "coingeckoV3"
+Symbol = "ETH"
+Addr = "0x0000000000000000000000000000000000000000"
+[[PriceUpdater.TokensConfig]]
+UpdateMethod = "static"
+Symbol = "UNI"
+Addr = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+StaticValue = 30.12
+[[PriceUpdater.TokensConfig]]
+UpdateMethod = "ignore"
+Symbol = "SUSHI"
+Addr = "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2"
 
 [Debug]
 APIAddress = "localhost:12345"

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/BurntSushi/toml"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/hermeznetwork/hermez-node/common"
+	"github.com/hermeznetwork/hermez-node/priceupdater"
 	"github.com/hermeznetwork/tracerr"
 	"github.com/iden3/go-iden3-crypto/babyjub"
 	"gopkg.in/go-playground/validator.v9"
@@ -219,11 +220,15 @@ type Coordinator struct {
 type Node struct {
 	PriceUpdater struct {
 		// Interval between price updater calls
-		Interval Duration `valudate:"required"`
-		// URL of the token prices provider
-		URL string `valudate:"required"`
-		// Type of the API of the token prices provider
-		Type string `valudate:"required"`
+		Interval Duration `validate:"required"`
+		// URLBitfinexV2 is the URL of bitfinex V2 API
+		URLBitfinexV2 string `validate:"required"`
+		// URLCoinGeckoV3 is the URL of coingecko V3 API
+		URLCoinGeckoV3 string `validate:"required"`
+		// DefaultUpdateMethod to get token prices
+		DefaultUpdateMethod priceupdater.UpdateMethodType `validate:"required"`
+		// TokensConfig to specify how each token get it's price updated
+		TokensConfig []priceupdater.TokenConfig
 	} `validate:"required"`
 	StateDB struct {
 		// Path where the synchronizer StateDB is stored

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -456,13 +456,10 @@ func (hdb *HistoryDB) addTokens(d meddler.DB, tokens []common.Token) error {
 
 // UpdateTokenValue updates the USD value of a token.  Value is the price in
 // USD of a normalized token (1 token = 10^decimals units)
-func (hdb *HistoryDB) UpdateTokenValue(tokenSymbol string, value float64) error {
-	// Sanitize symbol
-	tokenSymbol = strings.ToValidUTF8(tokenSymbol, " ")
-
+func (hdb *HistoryDB) UpdateTokenValue(tokenAddr ethCommon.Address, value float64) error {
 	_, err := hdb.dbWrite.Exec(
-		"UPDATE token SET usd = $1 WHERE symbol = $2;",
-		value, tokenSymbol,
+		"UPDATE token SET usd = $1 WHERE eth_addr = $2;",
+		value, tokenAddr,
 	)
 	return tracerr.Wrap(err)
 }
@@ -1161,7 +1158,7 @@ func (hdb *HistoryDB) GetTokensTest() ([]TokenWithUSD, error) {
 	tokens := []*TokenWithUSD{}
 	if err := meddler.QueryAll(
 		hdb.dbRead, &tokens,
-		"SELECT * FROM TOKEN",
+		"SELECT * FROM token ORDER BY token_id ASC",
 	); err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -166,7 +166,7 @@ func TestBatches(t *testing.T) {
 			if i%2 != 0 {
 				// Set value to the token
 				value := (float64(i) + 5) * 5.389329
-				assert.NoError(t, historyDB.UpdateTokenValue(token.Symbol, value))
+				assert.NoError(t, historyDB.UpdateTokenValue(token.EthAddr, value))
 				tokensValue[token.TokenID] = value / math.Pow(10, float64(token.Decimals))
 			}
 		}
@@ -276,7 +276,7 @@ func TestTokens(t *testing.T) {
 	// Update token value
 	for i, token := range tokens {
 		value := 1.01 * float64(i)
-		assert.NoError(t, historyDB.UpdateTokenValue(token.Symbol, value))
+		assert.NoError(t, historyDB.UpdateTokenValue(token.EthAddr, value))
 	}
 	// Fetch tokens
 	fetchedTokens, err = historyDB.GetTokensTest()
@@ -302,7 +302,7 @@ func TestTokensUTF8(t *testing.T) {
 	// Generate fake tokens
 	const nTokens = 5
 	tokens, ethToken := test.GenTokens(nTokens, blocks)
-	nonUTFTokens := make([]common.Token, len(tokens)+1)
+	nonUTFTokens := make([]common.Token, len(tokens))
 	// Force token.name and token.symbol to be non UTF-8 Strings
 	for i, token := range tokens {
 		token.Name = fmt.Sprint("NON-UTF8-NAME-\xc5-", i)
@@ -332,7 +332,7 @@ func TestTokensUTF8(t *testing.T) {
 	// Update token value
 	for i, token := range nonUTFTokens {
 		value := 1.01 * float64(i)
-		assert.NoError(t, historyDB.UpdateTokenValue(token.Symbol, value))
+		assert.NoError(t, historyDB.UpdateTokenValue(token.EthAddr, value))
 	}
 	// Fetch tokens
 	fetchedTokens, err = historyDB.GetTokensTest()

--- a/db/l2db/l2db_test.go
+++ b/db/l2db/l2db_test.go
@@ -121,7 +121,7 @@ func prepareHistoryDB(historyDB *historydb.HistoryDB) error {
 			}
 			tokens[token.TokenID] = readToken
 			// Set value to the tokens
-			err := historyDB.UpdateTokenValue(readToken.Symbol, *readToken.USD)
+			err := historyDB.UpdateTokenValue(readToken.EthAddr, *readToken.USD)
 			if err != nil {
 				return tracerr.Wrap(err)
 			}

--- a/node/node.go
+++ b/node/node.go
@@ -423,8 +423,13 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 	if cfg.Debug.APIAddress != "" {
 		debugAPI = debugapi.NewDebugAPI(cfg.Debug.APIAddress, stateDB, sync)
 	}
-	priceUpdater, err := priceupdater.NewPriceUpdater(cfg.PriceUpdater.URL,
-		priceupdater.APIType(cfg.PriceUpdater.Type), historyDB)
+	priceUpdater, err := priceupdater.NewPriceUpdater(
+		cfg.PriceUpdater.DefaultUpdateMethod,
+		cfg.PriceUpdater.TokensConfig,
+		historyDB,
+		cfg.PriceUpdater.URLBitfinexV2,
+		cfg.PriceUpdater.URLCoinGeckoV3,
+	)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}


### PR DESCRIPTION
- Each token can be configured differently in terms of how the price is updated
- Default option to update tokens that doesn't have a specified update mechanism

Possible update options are:

- coingeckoV3 (recommended): get price by SC addr using coingecko API
- bitfinexV2: get price by token symbol using bitfinex API
- static (recommended for blacklisting tokens): use the given StaticValue to set the price (if not provided 0 will be used)
- ignore: don't update the price leave it as it is on the DB