### PR TITLE
Allow transferToBjj with toEth != 0xff...ff

### DIFF
--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -97,7 +97,7 @@ func (tx *PoolL2Tx) SetType() error {
 	} else if tx.ToIdx == 1 {
 		tx.Type = TxTypeExit
 	} else if tx.ToIdx == 0 {
-		if tx.ToBJJ != EmptyBJJComp && tx.ToEthAddr == FFAddr {
+		if tx.ToBJJ != EmptyBJJComp {
 			tx.Type = TxTypeTransferToBJJ
 		} else if tx.ToEthAddr != FFAddr && tx.ToEthAddr != EmptyAddr {
 			tx.Type = TxTypeTransferToEthAddr


### PR DESCRIPTION
- Edit the `func (tx *PoolL2Tx) SetType() error` to recognize a transfer as a `TxTypeTransferToBJJ` when `tx.ToBJJ != EmptyBJJComp`. Close #635 