### PR TITLE
Not count txs marked as external_delete to reach MaxTxsPool

### DIFF
--- a/api/txspool.go
+++ b/api/txspool.go
@@ -179,7 +179,7 @@ func (a *API) verifyPoolL2TxWrite(txw *l2db.PoolL2TxWrite) error {
 	// Get public key
 	account, err := a.h.GetCommonAccountAPI(poolTx.FromIdx)
 	if err != nil {
-		return tracerr.Wrap(err)
+		return tracerr.Wrap(fmt.Errorf("Error getting from account: %w", err))
 	}
 	// Validate TokenID
 	if poolTx.TokenID != account.TokenID {

--- a/db/historydb/apiqueries.go
+++ b/db/historydb/apiqueries.go
@@ -1121,7 +1121,6 @@ func (hdb *HistoryDB) GetMetricsInternalAPI(lastBatchNum common.BatchNum) (*Metr
 		nBatches++
 	}
 	if (p.ToBatchNum - p.FromBatchNum) > 0 {
-		fmt.Printf("DBG ntxs: %v, nBatches: %v\n", nTxs, nBatches)
 		metrics.TransactionsPerBatch = float64(nTxs) /
 			float64(nBatches)
 	} else {

--- a/db/l2db/apiqueries.go
+++ b/db/l2db/apiqueries.go
@@ -80,7 +80,7 @@ func (l2db *L2DB) AddTxAPI(tx *PoolL2TxWrite) error {
 	q := fmt.Sprintf(
 		`INSERT INTO tx_pool (%s)
 		SELECT %s
-		WHERE (SELECT COUNT(*) FROM tx_pool WHERE state = $%v) < $%v;`,
+		WHERE (SELECT COUNT(*) FROM tx_pool WHERE state = $%v AND NOT external_delete) < $%v;`,
 		namesPart, valuesPart,
 		len(values)+1, len(values)+2) //nolint:gomnd
 	values = append(values, common.PoolL2TxStatePending, l2db.maxTxs)

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -204,7 +204,7 @@ func (l2db *L2DB) GetPendingTxs() ([]common.PoolL2Tx, error) {
 	var txs []*common.PoolL2Tx
 	err := meddler.QueryAll(
 		l2db.dbRead, &txs,
-		selectPoolTxCommon+"WHERE state = $1",
+		selectPoolTxCommon+"WHERE state = $1 AND NOT external_delete;",
 		common.PoolL2TxStatePending,
 	)
 	return db.SlicePtrsToSlice(txs).([]common.PoolL2Tx), tracerr.Wrap(err)


### PR DESCRIPTION
- Count txs that are pending and not marked as `external_delete` when it comes to decide if the pool is full or not
- Improved error message when the `from` of a `POST /transactions-pool` doesn't exist in the DB