### PR TITLE
Add config parameter  ForgeOncePerSlotIfTxs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,11 +112,17 @@ type Coordinator struct {
 	// MustForgeAtSlotDeadline enables the coordinator to forge slots if
 	// the empty slots reach the slot deadline.
 	MustForgeAtSlotDeadline bool
-	// IgnoreSlotCommitment IgnoreSlotCommitment disables forcing the
-	// coordinator to forge a slot immediately when the slot is not
-	// committed. If set to false, the coordinator will immediately forge
-	// a batch at the beginning of a slot if it's the slot winner.
+	// IgnoreSlotCommitment disables forcing the coordinator to forge a
+	// slot immediately when the slot is not committed. If set to false,
+	// the coordinator will immediately forge a batch at the beginning of a
+	// slot if it's the slot winner.
 	IgnoreSlotCommitment bool
+	// ForgeOncePerSlotIfTxs will make the coordinator forge at most one
+	// batch per slot, only if there are included txs in that batch, or
+	// pending l1UserTxs in the smart contract.  Setting this parameter
+	// overrides `ForgeDelay`, `ForgeNoTxsDelay`, `MustForgeAtSlotDeadline`
+	// and `IgnoreSlotCommitment`.
+	ForgeOncePerSlotIfTxs bool
 	// SyncRetryInterval is the waiting interval between calls to the main
 	// handler of a synced block after an error
 	SyncRetryInterval Duration `validate:"required"`

--- a/coordinator/batch.go
+++ b/coordinator/batch.go
@@ -85,7 +85,7 @@ type BatchInfo struct {
 	PublicInputs          []*big.Int
 	L1Batch               bool
 	VerifierIdx           uint8
-	L1UserTxsExtra        []common.L1Tx
+	L1UserTxs             []common.L1Tx
 	L1CoordTxs            []common.L1Tx
 	L1CoordinatorTxsAuths [][]byte
 	L2Txs                 []common.L2Tx

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -24,10 +24,8 @@ import (
 )
 
 var (
-	errLastL1BatchNotSynced  = fmt.Errorf("last L1Batch not synced yet")
-	errForgeNoTxsBeforeDelay = fmt.Errorf(
-		"no txs to forge and we haven't reached the forge no txs delay")
-	errForgeBeforeDelay = fmt.Errorf("we haven't reached the forge delay")
+	errLastL1BatchNotSynced = fmt.Errorf("last L1Batch not synced yet")
+	errSkipBatchByPolicy    = fmt.Errorf("skip batch by policy")
 )
 
 const (
@@ -92,6 +90,12 @@ type Config struct {
 	// the coordinator will immediately forge a batch at the beginning of
 	// a slot if it's the slot winner.
 	IgnoreSlotCommitment bool
+	// ForgeOncePerSlotIfTxs will make the coordinator forge at most one
+	// batch per slot, only if there are included txs in that batch, or
+	// pending l1UserTxs in the smart contract.  Setting this parameter
+	// overrides `ForgeDelay`, `ForgeNoTxsDelay`, `MustForgeAtSlotDeadline`
+	// and `IgnoreSlotCommitment`.
+	ForgeOncePerSlotIfTxs bool
 	// SyncRetryInterval is the waiting interval between calls to the main
 	// handler of a synced block after an error
 	SyncRetryInterval time.Duration

--- a/coordinator/pipeline_test.go
+++ b/coordinator/pipeline_test.go
@@ -224,12 +224,12 @@ PoolTransfer(0) User2-User3: 300 (126)
 
 	batchNum++
 
-	batchInfo, err := pipeline.forgeBatch(batchNum)
+	batchInfo, _, err := pipeline.forgeBatch(batchNum)
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(batchInfo.L2Txs))
 
 	batchNum++
-	batchInfo, err = pipeline.forgeBatch(batchNum)
+	batchInfo, _, err = pipeline.forgeBatch(batchNum)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(batchInfo.L2Txs))
 }

--- a/coordinator/txmanager.go
+++ b/coordinator/txmanager.go
@@ -147,7 +147,7 @@ func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.Tr
 	auth.Value = big.NewInt(0) // in wei
 
 	gasLimit := t.cfg.ForgeBatchGasCost.Fixed +
-		uint64(len(batchInfo.L1UserTxsExtra))*t.cfg.ForgeBatchGasCost.L1UserTx +
+		uint64(len(batchInfo.L1UserTxs))*t.cfg.ForgeBatchGasCost.L1UserTx +
 		uint64(len(batchInfo.L1CoordTxs))*t.cfg.ForgeBatchGasCost.L1CoordTx +
 		uint64(len(batchInfo.L2Txs))*t.cfg.ForgeBatchGasCost.L2Tx
 	auth.GasLimit = gasLimit

--- a/node/node.go
+++ b/node/node.go
@@ -367,6 +367,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 				ForgeDelay:              cfg.Coordinator.ForgeDelay.Duration,
 				MustForgeAtSlotDeadline: cfg.Coordinator.MustForgeAtSlotDeadline,
 				IgnoreSlotCommitment:    cfg.Coordinator.IgnoreSlotCommitment,
+				ForgeOncePerSlotIfTxs:   cfg.Coordinator.ForgeOncePerSlotIfTxs,
 				ForgeNoTxsDelay:         cfg.Coordinator.ForgeNoTxsDelay.Duration,
 				SyncRetryInterval:       cfg.Coordinator.SyncRetryInterval.Duration,
 				PurgeByExtDelInterval:   cfg.Coordinator.PurgeByExtDelInterval.Duration,


### PR DESCRIPTION
New configuration Coordinator configuration parameter `ForgeOncePerSlotIfTxs`:
ForgeOncePerSlotIfTxs will make the coordinator forge at most one batch per
slot, only if there are included txs in that batch, or pending l1UserTxs in the
smart contract.  Setting this parameter overrides `ForgeDelay`,
`ForgeNoTxsDelay`, `MustForgeAtSlotDeadline` and `IgnoreSlotCommitment`.

Also restructure a bit the functions that check policies to decide whether or
not to forge a batch.

Resolve #622 