### PR TITLE
Fix Synchronizer not setting slot.ForgerCommitment to true

### DIFF
--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -335,7 +335,7 @@ func (s *Synchronizer) updateCurrentSlot(slot *common.Slot, reset bool, hasBatch
 	// We want the next block because the current one is already mined
 	blockNum := s.stats.Sync.LastBlock.Num + 1
 	slotNum := s.consts.Auction.SlotNum(blockNum)
-	firstBatchBlockNum := s.stats.Sync.LastBlock.Num
+	syncLastBlockNum := s.stats.Sync.LastBlock.Num
 	if reset {
 		// Using this query only to know if there
 		dbFirstBatchBlockNum, err := s.historyDB.GetFirstBatchBlockNumBySlot(slotNum)
@@ -345,7 +345,7 @@ func (s *Synchronizer) updateCurrentSlot(slot *common.Slot, reset bool, hasBatch
 			hasBatch = false
 		} else {
 			hasBatch = true
-			firstBatchBlockNum = dbFirstBatchBlockNum
+			syncLastBlockNum = dbFirstBatchBlockNum
 		}
 		slot.ForgerCommitment = false
 	} else if slotNum > slot.SlotNum {
@@ -354,7 +354,7 @@ func (s *Synchronizer) updateCurrentSlot(slot *common.Slot, reset bool, hasBatch
 	}
 	slot.SlotNum = slotNum
 	slot.StartBlock, slot.EndBlock = s.consts.Auction.SlotBlocks(slot.SlotNum)
-	if hasBatch && s.consts.Auction.RelativeBlock(firstBatchBlockNum) < int64(s.vars.Auction.SlotDeadline) {
+	if hasBatch && s.consts.Auction.RelativeBlock(syncLastBlockNum) < int64(s.vars.Auction.SlotDeadline) {
 		slot.ForgerCommitment = true
 	}
 	// If Synced, update the current coordinator


### PR DESCRIPTION
Synchronizer was not setting `slot.ForgerCommitment` to `true` until fully synchronized, so if batch had been received just before becoming in sync - slot wasn't marked as having ForgerCommitment.

Also, after slot state reset (blockchain reorganization or node restart) `slot.ForgerCommitment` was reset to `false`, failing to check if there were batches previously because of not being in sync.

Resolves hermeznetwork/hermez-issues#47