### PR TITLE
Fix API /state collected fees unmarshal

### DIFF
--- a/apitypes/apitypes.go
+++ b/apitypes/apitypes.go
@@ -4,7 +4,6 @@ import (
 	"database/sql/driver"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -73,22 +72,16 @@ func (s *StrBigInt) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// CollectedFees is used to retrieve common.batch.CollectedFee from the DB
-type CollectedFees map[common.TokenID]BigIntStr
+// CollectedFeesAPI is send common.batch.CollectedFee through the API
+type CollectedFeesAPI map[common.TokenID]BigIntStr
 
-// UnmarshalJSON unmarshals a json representation of map[common.TokenID]*big.Int
-func (c *CollectedFees) UnmarshalJSON(text []byte) error {
-	bigIntMap := make(map[common.TokenID]*big.Int)
-	if err := json.Unmarshal(text, &bigIntMap); err != nil {
-		return tracerr.Wrap(err)
+// NewCollectedFeesAPI creates a new CollectedFeesAPI from a *big.Int map
+func NewCollectedFeesAPI(m map[common.TokenID]*big.Int) CollectedFeesAPI {
+	c := CollectedFeesAPI(make(map[common.TokenID]BigIntStr))
+	for k, v := range m {
+		c[k] = *NewBigIntStr(v)
 	}
-	*c = CollectedFees(make(map[common.TokenID]BigIntStr))
-	for k, v := range bigIntMap {
-		bStr := NewBigIntStr(v)
-		(CollectedFees(*c)[k]) = *bStr
-	}
-	// *c = CollectedFees(bStrMap)
-	return nil
+	return c
 }
 
 // HezEthAddr is used to scan/value Ethereum Address directly into strings that follow the Ethereum address hez format (^hez:0x[a-fA-F0-9]{40}$) from/to sql DBs.

--- a/db/historydb/nodeinfo.go
+++ b/db/historydb/nodeinfo.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/hermeznetwork/hermez-node/apitypes"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/tracerr"
 	"github.com/russross/meddler"
@@ -124,6 +125,10 @@ func (hdb *HistoryDB) getStateAPI(d meddler.DB) (*StateAPI, error) {
 
 // SetStateInternalAPI sets the StateAPI
 func (hdb *HistoryDB) SetStateInternalAPI(stateAPI *StateAPI) error {
+	if stateAPI.Network.LastBatch != nil {
+		stateAPI.Network.LastBatch.CollectedFeesAPI =
+			apitypes.NewCollectedFeesAPI(stateAPI.Network.LastBatch.CollectedFeesDB)
+	}
 	_stateAPI := struct {
 		StateAPI *StateAPI `meddler:"state,json"`
 	}{stateAPI}

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -289,23 +289,24 @@ func (account AccountAPI) MarshalJSON() ([]byte, error) {
 // BatchAPI is a representation of a batch with additional information
 // required by the API, and extracted by joining block table
 type BatchAPI struct {
-	ItemID        uint64                 `json:"itemId" meddler:"item_id"`
-	BatchNum      common.BatchNum        `json:"batchNum" meddler:"batch_num"`
-	EthBlockNum   int64                  `json:"ethereumBlockNum" meddler:"eth_block_num"`
-	EthBlockHash  ethCommon.Hash         `json:"ethereumBlockHash" meddler:"hash"`
-	Timestamp     time.Time              `json:"timestamp" meddler:"timestamp,utctime"`
-	ForgerAddr    ethCommon.Address      `json:"forgerAddr" meddler:"forger_addr"`
-	CollectedFees apitypes.CollectedFees `json:"collectedFees" meddler:"fees_collected,json"`
-	TotalFeesUSD  *float64               `json:"historicTotalCollectedFeesUSD" meddler:"total_fees_usd"`
-	StateRoot     apitypes.BigIntStr     `json:"stateRoot" meddler:"state_root"`
-	NumAccounts   int                    `json:"numAccounts" meddler:"num_accounts"`
-	ExitRoot      apitypes.BigIntStr     `json:"exitRoot" meddler:"exit_root"`
-	ForgeL1TxsNum *int64                 `json:"forgeL1TransactionsNum" meddler:"forge_l1_txs_num"`
-	SlotNum       int64                  `json:"slotNum" meddler:"slot_num"`
-	ForgedTxs     int                    `json:"forgedTransactions" meddler:"forged_txs"`
-	TotalItems    uint64                 `json:"-" meddler:"total_items"`
-	FirstItem     uint64                 `json:"-" meddler:"first_item"`
-	LastItem      uint64                 `json:"-" meddler:"last_item"`
+	ItemID           uint64                      `json:"itemId" meddler:"item_id"`
+	BatchNum         common.BatchNum             `json:"batchNum" meddler:"batch_num"`
+	EthBlockNum      int64                       `json:"ethereumBlockNum" meddler:"eth_block_num"`
+	EthBlockHash     ethCommon.Hash              `json:"ethereumBlockHash" meddler:"hash"`
+	Timestamp        time.Time                   `json:"timestamp" meddler:"timestamp,utctime"`
+	ForgerAddr       ethCommon.Address           `json:"forgerAddr" meddler:"forger_addr"`
+	CollectedFeesDB  map[common.TokenID]*big.Int `json:"-" meddler:"fees_collected,json"`
+	CollectedFeesAPI apitypes.CollectedFeesAPI   `json:"collectedFees" meddler:"-"`
+	TotalFeesUSD     *float64                    `json:"historicTotalCollectedFeesUSD" meddler:"total_fees_usd"`
+	StateRoot        apitypes.BigIntStr          `json:"stateRoot" meddler:"state_root"`
+	NumAccounts      int                         `json:"numAccounts" meddler:"num_accounts"`
+	ExitRoot         apitypes.BigIntStr          `json:"exitRoot" meddler:"exit_root"`
+	ForgeL1TxsNum    *int64                      `json:"forgeL1TransactionsNum" meddler:"forge_l1_txs_num"`
+	SlotNum          int64                       `json:"slotNum" meddler:"slot_num"`
+	ForgedTxs        int                         `json:"forgedTransactions" meddler:"forged_txs"`
+	TotalItems       uint64                      `json:"-" meddler:"total_items"`
+	FirstItem        uint64                      `json:"-" meddler:"first_item"`
+	LastItem         uint64                      `json:"-" meddler:"last_item"`
 }
 
 // MetricsAPI define metrics of the network


### PR DESCRIPTION
I've added two fields in the BatchAPI struct, one to interact with the DB, another to interact with the API.  This solves the problem that we want to marshal the collected fees in two different ways, one when marshaling for the DB, and when for marshaling for the API.

Resolve https://github.com/hermeznetwork/hermez-node/issues/642