### PR TITLE
API change names and add poolLoad, add maxFeeUSD

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -209,7 +209,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	// L2DB
-	l2DB := l2db.NewL2DB(database, database, 10, 1000, 0.0, 24*time.Hour, apiConnCon)
+	l2DB := l2db.NewL2DB(database, database, 10, 1000, 0.0, 1000.0, 24*time.Hour, apiConnCon)
 	test.WipeDB(l2DB.DB()) // this will clean HistoryDB and L2DB
 	// Config (smart contract constants)
 	chainID := uint16(0)
@@ -240,6 +240,7 @@ func TestMain(m *testing.M) {
 	nodeConfig := &historydb.NodeConfig{
 		MaxPoolTxs: 10,
 		MinFeeUSD:  0,
+		MaxFeeUSD:  10000000000,
 	}
 	if err := hdb.SetNodeConfig(nodeConfig); err != nil {
 		panic(err)
@@ -615,7 +616,7 @@ func TestTimeout(t *testing.T) {
 	hdbTO := historydb.NewHistoryDB(databaseTO, databaseTO, apiConnConTO)
 	require.NoError(t, err)
 	// L2DB
-	l2DBTO := l2db.NewL2DB(databaseTO, databaseTO, 10, 1000, 1.0, 24*time.Hour, apiConnConTO)
+	l2DBTO := l2db.NewL2DB(databaseTO, databaseTO, 10, 1000, 1.0, 1000.0, 24*time.Hour, apiConnConTO)
 
 	// API
 	apiGinTO := gin.Default()

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -145,8 +145,8 @@ func TestUpdateMetrics(t *testing.T) {
 	assert.Greater(t, ni.StateAPI.Metrics.TransactionsPerBatch, float64(0))
 	assert.Greater(t, ni.StateAPI.Metrics.BatchFrequency, float64(0))
 	assert.Greater(t, ni.StateAPI.Metrics.TransactionsPerSecond, float64(0))
-	assert.Greater(t, ni.StateAPI.Metrics.TotalAccounts, int64(0))
-	assert.Greater(t, ni.StateAPI.Metrics.TotalBJJs, int64(0))
+	assert.Greater(t, ni.StateAPI.Metrics.TokenAccounts, int64(0))
+	assert.Greater(t, ni.StateAPI.Metrics.Wallets, int64(0))
 	assert.Greater(t, ni.StateAPI.Metrics.AvgTransactionFee, float64(0))
 }
 
@@ -210,8 +210,8 @@ func TestGetState(t *testing.T) {
 	assert.Greater(t, status.Metrics.TransactionsPerBatch, float64(0))
 	assert.Greater(t, status.Metrics.BatchFrequency, float64(0))
 	assert.Greater(t, status.Metrics.TransactionsPerSecond, float64(0))
-	assert.Greater(t, status.Metrics.TotalAccounts, int64(0))
-	assert.Greater(t, status.Metrics.TotalBJJs, int64(0))
+	assert.Greater(t, status.Metrics.TokenAccounts, int64(0))
+	assert.Greater(t, status.Metrics.Wallets, int64(0))
 	assert.Greater(t, status.Metrics.AvgTransactionFee, float64(0))
 	// Recommended fee
 	// TODO: perform real asserts (not just greater than 0)

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2569,9 +2569,9 @@ components:
       description: List of next coordinators to forge.
       items: 
         $ref: '#/components/schemas/NextForger'
-    NodeConfig:
+    Node:
       type: object
-      description: Configuration of the coordinator node. Note that this is specific for each coordinator.
+      description: Configuration and metrics of the coordinator node. Note that this is specific for each coordinator.
       properties:
         forgeDelay:
           type: number
@@ -2581,9 +2581,14 @@ components:
             forge at the maximum rate. Note that this is a configuration parameter of a node,
             so each coordinator may have a different value.
           example: 193.4
+        poolLoad:
+          type: number
+          description: Number of pending transactions in the pool
+          example: 23201
       additionalProperties: false
       required: 
         - forgeDelay
+        - poolLoad
     State:
       type: object
       description: Gobal variables of the network
@@ -2600,8 +2605,8 @@ components:
           $ref: '#/components/schemas/StateWithdrawDelayer'
         recommendedFee:
           $ref: '#/components/schemas/RecommendedFee'
-        nodeConfig:
-          $ref: '#/components/schemas/NodeConfig'
+        node:
+          $ref: '#/components/schemas/Node'
       additionalProperties: false
       required: 
         - network
@@ -2610,7 +2615,7 @@ components:
         - auction
         - withdrawalDelayer
         - recommendedFee
-        - nodeConfig
+        - node
     StateNetwork:
       type: object
       description: Gobal statistics of the network
@@ -2809,11 +2814,11 @@ components:
           type: number
           description: Average transactions per second in the last 24 hours.
           example: 302.3
-        totalAccounts:
+        tokenAccounts:
           type: integer
           description: Number of created accounts.
           example: 90473
-        totalBJJs:
+        wallets:
           type: integer
           description: Number of different registered BJJs.
           example: 23067
@@ -2830,8 +2835,8 @@ components:
         - transactionsPerBatch
         - batchFrequency
         - transactionsPerSecond
-        - totalAccounts
-        - totalBJJs
+        - tokenAccounts
+        - wallets
         - avgTransactionFee
         - estimatedTimeToForgeL1
     PendingItems:

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -99,6 +99,7 @@ BJJ = "0x1b176232f78ba0d388ecc5f4896eca2d3b3d4f272092469f559247297f5c0c13"
 SafetyPeriod = 10
 MaxTxs       = 512
 MinFeeUSD    = 0.0
+MaxFeeUSD    = 50.0
 TTL          = "24h"
 PurgeBatchDelay = 10
 InvalidateBatchDelay = 20

--- a/cli/node/main.go
+++ b/cli/node/main.go
@@ -318,6 +318,7 @@ func cmdDiscard(c *cli.Context) error {
 		cfg.Coordinator.L2DB.SafetyPeriod,
 		cfg.Coordinator.L2DB.MaxTxs,
 		cfg.Coordinator.L2DB.MinFeeUSD,
+		cfg.Coordinator.L2DB.MaxFeeUSD,
 		cfg.Coordinator.L2DB.TTL.Duration,
 		nil,
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,10 @@ type Coordinator struct {
 		// order to be accepted into the pool.  Txs with lower than
 		// minimum fee will be rejected at the API level.
 		MinFeeUSD float64
+		// MaxFeeUSD is the maximum fee in USD that a tx must pay in
+		// order to be accepted into the pool.  Txs with greater than
+		// maximum fee will be rejected at the API level.
+		MaxFeeUSD float64 `validate:"required"`
 		// TTL is the Time To Live for L2Txs in the pool.  Once MaxTxs
 		// L2Txs is reached, L2Txs older than TTL will be deleted.
 		TTL Duration `validate:"required"`
@@ -376,6 +380,10 @@ type APIServer struct {
 			// order to be accepted into the pool.  Txs with lower than
 			// minimum fee will be rejected at the API level.
 			MinFeeUSD float64
+			// MaxFeeUSD is the maximum fee in USD that a tx must pay in
+			// order to be accepted into the pool.  Txs with greater than
+			// maximum fee will be rejected at the API level.
+			MaxFeeUSD float64 `validate:"required"`
 		} `validate:"required"`
 	}
 	Debug NodeDebug `validate:"required"`

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -105,7 +105,7 @@ func newTestModules(t *testing.T) modules {
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
 	test.WipeDB(db)
-	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 1000.0, 24*time.Hour, nil)
 	historyDB := historydb.NewHistoryDB(db, db, nil)
 
 	txSelDBPath, err = ioutil.TempDir("", "tmpTxSelDB")

--- a/coordinator/purger_test.go
+++ b/coordinator/purger_test.go
@@ -21,7 +21,7 @@ func newL2DB(t *testing.T) *l2db.L2DB {
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
 	test.WipeDB(db)
-	return l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
+	return l2db.NewL2DB(db, db, 10, 100, 0.0, 1000.0, 24*time.Hour, nil)
 }
 
 func newStateDB(t *testing.T) *statedb.LocalStateDB {

--- a/db/historydb/historydb.go
+++ b/db/historydb/historydb.go
@@ -1181,7 +1181,7 @@ const (
 )
 
 // GetRecommendedFee returns the RecommendedFee information
-func (hdb *HistoryDB) GetRecommendedFee(minFeeUSD float64) (*common.RecommendedFee, error) {
+func (hdb *HistoryDB) GetRecommendedFee(minFeeUSD, maxFeeUSD float64) (*common.RecommendedFee, error) {
 	var recommendedFee common.RecommendedFee
 	// Get total txs and the batch of the first selected tx of the last hour
 	type totalTxsSinceBatchNum struct {
@@ -1217,11 +1217,11 @@ func (hdb *HistoryDB) GetRecommendedFee(minFeeUSD float64) (*common.RecommendedF
 	} else {
 		avgTransactionFee = 0
 	}
-	recommendedFee.ExistingAccount =
-		math.Max(avgTransactionFee, minFeeUSD)
-	recommendedFee.CreatesAccount =
-		math.Max(CreateAccountExtraFeePercentage*avgTransactionFee, minFeeUSD)
-	recommendedFee.CreatesAccountInternal =
-		math.Max(CreateAccountInternalExtraFeePercentage*avgTransactionFee, minFeeUSD)
+	recommendedFee.ExistingAccount = math.Min(maxFeeUSD,
+		math.Max(avgTransactionFee, minFeeUSD))
+	recommendedFee.CreatesAccount = math.Min(maxFeeUSD,
+		math.Max(CreateAccountExtraFeePercentage*avgTransactionFee, minFeeUSD))
+	recommendedFee.CreatesAccountInternal = math.Min(maxFeeUSD,
+		math.Max(CreateAccountInternalExtraFeePercentage*avgTransactionFee, minFeeUSD))
 	return &recommendedFee, nil
 }

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -1177,7 +1177,7 @@ func TestGetMetricsAPI(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	res, err := historyDB.GetMetricsInternalAPI(common.BatchNum(numBatches))
+	res, _, err := historyDB.GetMetricsInternalAPI(common.BatchNum(numBatches))
 	assert.NoError(t, err)
 
 	assert.Equal(t, float64(numTx)/float64(numBatches), res.TransactionsPerBatch)
@@ -1186,8 +1186,8 @@ func TestGetMetricsAPI(t *testing.T) {
 	// There is a -2 as time for first and last batch is not taken into account
 	assert.InEpsilon(t, float64(frequency)*float64(numBatches-2)/float64(numBatches), res.BatchFrequency, 0.01)
 	assert.InEpsilon(t, float64(numTx)/float64(frequency*blockNum-frequency), res.TransactionsPerSecond, 0.01)
-	assert.Equal(t, int64(3), res.TotalAccounts)
-	assert.Equal(t, int64(3), res.TotalBJJs)
+	assert.Equal(t, int64(3), res.TokenAccounts)
+	assert.Equal(t, int64(3), res.Wallets)
 	// Til does not set fees
 	assert.Equal(t, float64(0), res.AvgTransactionFee)
 }
@@ -1255,22 +1255,22 @@ func TestGetMetricsAPIMoreThan24Hours(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	res, err := historyDBWithACC.GetMetricsInternalAPI(common.BatchNum(numBatches))
+	res, _, err := historyDBWithACC.GetMetricsInternalAPI(common.BatchNum(numBatches))
 	assert.NoError(t, err)
 
 	assert.InEpsilon(t, 1.0, res.TransactionsPerBatch, 0.1)
 
 	assert.InEpsilon(t, res.BatchFrequency, float64(blockTime/time.Second), 0.1)
 	assert.InEpsilon(t, 1.0/float64(blockTime/time.Second), res.TransactionsPerSecond, 0.1)
-	assert.Equal(t, int64(3), res.TotalAccounts)
-	assert.Equal(t, int64(3), res.TotalBJJs)
+	assert.Equal(t, int64(3), res.TokenAccounts)
+	assert.Equal(t, int64(3), res.Wallets)
 	// Til does not set fees
 	assert.Equal(t, float64(0), res.AvgTransactionFee)
 }
 
 func TestGetMetricsAPIEmpty(t *testing.T) {
 	test.WipeDB(historyDB.DB())
-	_, err := historyDBWithACC.GetMetricsInternalAPI(0)
+	_, _, err := historyDBWithACC.GetMetricsInternalAPI(0)
 	assert.NoError(t, err)
 }
 
@@ -1485,7 +1485,7 @@ func TestNodeInfo(t *testing.T) {
 	addr := ethCommon.HexToAddress("0x1234")
 	hash := ethCommon.HexToHash("0x5678")
 	stateAPI := &StateAPI{
-		NodePublicConfig: NodePublicConfig{
+		NodePublicInfo: NodePublicInfo{
 			ForgeDelay: 3.1,
 		},
 		Network: NetworkAPI{
@@ -1544,7 +1544,7 @@ func TestNodeInfo(t *testing.T) {
 		},
 		Metrics: MetricsAPI{
 			TransactionsPerBatch: 1.1,
-			TotalAccounts:        42,
+			TokenAccounts:        42,
 		},
 		Rollup:            *NewRollupVariablesAPI(clientSetup.RollupVariables),
 		Auction:           *NewAuctionVariablesAPI(clientSetup.AuctionVariables),

--- a/db/historydb/nodeinfo.go
+++ b/db/historydb/nodeinfo.go
@@ -34,16 +34,17 @@ type NetworkAPI struct {
 	NextForgers   []NextForgerAPI `json:"nextForgers"`
 }
 
-// NodePublicConfig is the configuration of the node that is exposed via API
-type NodePublicConfig struct {
+// NodePublicInfo is the configuration and metrics of the node that is exposed via API
+type NodePublicInfo struct {
 	// ForgeDelay in seconds
 	ForgeDelay float64 `json:"forgeDelay"`
+	// PoolLoad amount of transactions in the pool
+	PoolLoad int64 `json:"poolLoad"`
 }
 
 // StateAPI is an object representing the node and network state exposed via the API
 type StateAPI struct {
-	// NodePublicConfig is the configuration of the node that is exposed via API
-	NodePublicConfig  NodePublicConfig         `json:"nodeConfig"`
+	NodePublicInfo    NodePublicInfo           `json:"node"`
 	Network           NetworkAPI               `json:"network"`
 	Metrics           MetricsAPI               `json:"metrics"`
 	Rollup            RollupVariablesAPI       `json:"rollup"`
@@ -63,6 +64,7 @@ type Constants struct {
 type NodeConfig struct {
 	MaxPoolTxs uint32
 	MinFeeUSD  float64
+	MaxFeeUSD  float64
 	ForgeDelay float64
 }
 

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -314,8 +314,8 @@ type MetricsAPI struct {
 	TransactionsPerBatch   float64 `json:"transactionsPerBatch"`
 	BatchFrequency         float64 `json:"batchFrequency"`
 	TransactionsPerSecond  float64 `json:"transactionsPerSecond"`
-	TotalAccounts          int64   `json:"totalAccounts" meddler:"total_accounts"`
-	TotalBJJs              int64   `json:"totalBJJs" meddler:"total_bjjs"`
+	TokenAccounts          int64   `json:"tokenAccounts"`
+	Wallets                int64   `json:"wallets"`
 	AvgTransactionFee      float64 `json:"avgTransactionFee"`
 	EstimatedTimeToForgeL1 float64 `json:"estimatedTimeToForgeL1" meddler:"estimated_time_to_forge_l1"`
 }

--- a/db/l2db/apiqueries.go
+++ b/db/l2db/apiqueries.go
@@ -62,6 +62,10 @@ func (l2db *L2DB) AddTxAPI(tx *PoolL2TxWrite) error {
 		return tracerr.Wrap(fmt.Errorf("tx.feeUSD (%v) < minFeeUSD (%v)",
 			feeUSD, l2db.minFeeUSD))
 	}
+	if feeUSD > l2db.maxFeeUSD {
+		return tracerr.Wrap(fmt.Errorf("tx.feeUSD (%v) > maxFeeUSD (%v)",
+			feeUSD, l2db.maxFeeUSD))
+	}
 
 	// Prepare insert SQL query argument parameters
 	namesPart, err := meddler.Default.ColumnsQuoted(tx, false)

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -27,6 +27,7 @@ type L2DB struct {
 	ttl          time.Duration
 	maxTxs       uint32 // limit of txs that are accepted in the pool
 	minFeeUSD    float64
+	maxFeeUSD    float64
 	apiConnCon   *db.APIConnectionController
 }
 
@@ -38,6 +39,7 @@ func NewL2DB(
 	safetyPeriod common.BatchNum,
 	maxTxs uint32,
 	minFeeUSD float64,
+	maxFeeUSD float64,
 	TTL time.Duration,
 	apiConnCon *db.APIConnectionController,
 ) *L2DB {
@@ -48,6 +50,7 @@ func NewL2DB(
 		ttl:          TTL,
 		maxTxs:       maxTxs,
 		minFeeUSD:    minFeeUSD,
+		maxFeeUSD:    maxFeeUSD,
 		apiConnCon:   apiConnCon,
 	}
 }

--- a/db/l2db/l2db_test.go
+++ b/db/l2db/l2db_test.go
@@ -37,9 +37,9 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	l2DB = NewL2DB(db, db, 10, 1000, 0.0, 24*time.Hour, nil)
+	l2DB = NewL2DB(db, db, 10, 1000, 0.0, 1000.0, 24*time.Hour, nil)
 	apiConnCon := dbUtils.NewAPIConnectionController(1, time.Second)
-	l2DBWithACC = NewL2DB(db, db, 10, 1000, 0.0, 24*time.Hour, apiConnCon)
+	l2DBWithACC = NewL2DB(db, db, 10, 1000, 0.0, 1000.0, 24*time.Hour, apiConnCon)
 	test.WipeDB(l2DB.DB())
 	historyDB = historydb.NewHistoryDB(db, db, nil)
 	// Run tests

--- a/node/node.go
+++ b/node/node.go
@@ -230,6 +230,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 			cfg.Coordinator.L2DB.SafetyPeriod,
 			cfg.Coordinator.L2DB.MaxTxs,
 			cfg.Coordinator.L2DB.MinFeeUSD,
+			cfg.Coordinator.L2DB.MaxFeeUSD,
 			cfg.Coordinator.L2DB.TTL.Duration,
 			apiConnCon,
 		)
@@ -253,6 +254,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 	hdbNodeCfg := historydb.NodeConfig{
 		MaxPoolTxs: cfg.Coordinator.L2DB.MaxTxs,
 		MinFeeUSD:  cfg.Coordinator.L2DB.MinFeeUSD,
+		MaxFeeUSD:  cfg.Coordinator.L2DB.MaxFeeUSD,
 		ForgeDelay: cfg.Coordinator.ForgeDelay.Duration.Seconds(),
 	}
 	if err := historyDB.SetNodeConfig(&hdbNodeCfg); err != nil {
@@ -522,6 +524,7 @@ func NewAPIServer(mode Mode, cfg *config.APIServer) (*APIServer, error) {
 			0,
 			cfg.Coordinator.L2DB.MaxTxs,
 			cfg.Coordinator.L2DB.MinFeeUSD,
+			cfg.Coordinator.L2DB.MaxFeeUSD,
 			0,
 			apiConnCon,
 		)

--- a/stateapiupdater/stateapiupdater.go
+++ b/stateapiupdater/stateapiupdater.go
@@ -27,7 +27,7 @@ func NewUpdater(hdb *historydb.HistoryDB, config *historydb.NodeConfig, vars *co
 		config: *config,
 		consts: *consts,
 		state: historydb.StateAPI{
-			NodePublicConfig: historydb.NodePublicConfig{
+			NodePublicInfo: historydb.NodePublicInfo{
 				ForgeDelay: config.ForgeDelay,
 			},
 		},
@@ -65,7 +65,7 @@ func (u *Updater) SetSCVars(vars *common.SCVariablesPtr) {
 
 // UpdateRecommendedFee update Status.RecommendedFee information
 func (u *Updater) UpdateRecommendedFee() error {
-	recommendedFee, err := u.hdb.GetRecommendedFee(u.config.MinFeeUSD)
+	recommendedFee, err := u.hdb.GetRecommendedFee(u.config.MinFeeUSD, u.config.MaxFeeUSD)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
@@ -84,12 +84,13 @@ func (u *Updater) UpdateMetrics() error {
 		return nil
 	}
 	lastBatchNum := lastBatch.BatchNum
-	metrics, err := u.hdb.GetMetricsInternalAPI(lastBatchNum)
+	metrics, poolLoad, err := u.hdb.GetMetricsInternalAPI(lastBatchNum)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
 	u.rw.Lock()
 	u.state.Metrics = *metrics
+	u.state.NodePublicInfo.PoolLoad = poolLoad
 	u.rw.Unlock()
 	return nil
 }

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -323,7 +323,7 @@ func newTestModules(t *testing.T) (*statedb.StateDB, *historydb.HistoryDB, *l2db
 	test.WipeDB(historyDB.DB())
 
 	// Init L2 DB
-	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 1000.0, 24*time.Hour, nil)
 
 	return stateDB, historyDB, l2DB
 }

--- a/test/zkproof/flows_test.go
+++ b/test/zkproof/flows_test.go
@@ -77,7 +77,7 @@ func initTxSelector(t *testing.T, chainID uint16, hermezContractAddr ethCommon.A
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
-	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 1000.0, 24*time.Hour, nil)
 
 	dir, err := ioutil.TempDir("", "tmpSyncDB")
 	require.NoError(t, err)

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -30,7 +30,7 @@ func initTest(t *testing.T, chainID uint16, hermezContractAddr ethCommon.Address
 	pass := os.Getenv("POSTGRES_PASS")
 	db, err := dbUtils.InitSQLDB(5432, "localhost", "hermez", pass, "hermez")
 	require.NoError(t, err)
-	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 24*time.Hour, nil)
+	l2DB := l2db.NewL2DB(db, db, 10, 100, 0.0, 1000.0, 24*time.Hour, nil)
 
 	dir, err := ioutil.TempDir("", "tmpdb")
 	require.NoError(t, err)


### PR DESCRIPTION
- API changes (`GET /state` response):
    -  `nodeConfig` renamed to `node` as now it includes metrics as well as configuration
    - Added `poolLoad` under `node` (FKA as `nodeConfig`): amount of txs in the pool. 
    - Renamed  `totalBJJs` to `wallets`
    - Renamed `totalAccounts` to `tokenAccounts`
- Added (required) config option `MaxFeeUSD`, to limit the maximum fee that a L2 tx can have in order to be added to the pool.

Please ask before merging as we have to coordinate FE (breaking changes on the API)