### PR TITLE
Generating automatically releases with Goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - main: ./cli/node/main.go
+    binary: node
+    id: node
+    goos:
+      - linux
+      - darwin
+      - windows
+    hooks:
+      pre: make migration-pack
+      post: make migration-clean
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # Project variables.
 PACKAGE := github.com/hermeznetwork/hermez-node
 VERSION := $(shell git describe --tags --always)
-BUILD := $(shell git rev-parse --short HEAD)
-BUILD_DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
+COMMIT := $(shell git rev-parse --short HEAD)
+DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
 PROJECT_NAME := $(shell basename "$(PWD)")
 
 # Go related variables.
@@ -23,7 +23,7 @@ CONFIG ?= $(GOBASE)/cli/node/cfg.buidler.toml
 POSTGRES_PASS ?= yourpasswordhere
 
 # Use linker flags to provide version/build settings.
-LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -X=main.Date=$(BUILD_DATE)"
+LDFLAGS=-ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 
 # PID file will keep the process id of the server.
 PID_PROOF_MOCK := /tmp/.$(PROJECT_NAME).proof.pid
@@ -94,11 +94,11 @@ install:
 	@echo "  >  Checking if there is any missing dependencies..."
 	$(GOENVVARS) go get $(GOCMD)/... $(get)
 
-## run: Run Hermez node.
-run:
+## run-node: Run Hermez node.
+run-node:
 	@bash -c "$(MAKE) clean build"
 	@echo "  >  Running $(PROJECT_NAME)"
-	@$(GOBIN)/$(GOBINARY) --mode $(MODE) --cfg $(CONFIG) run
+	@$(GOBIN)/$(GOBINARY) run --mode $(MODE) --cfg $(CONFIG)
 
 ## run-proof-mock: Run proof server mock API.
 run-proof-mock: stop-proof-mock

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ there are more information about the config file into [cli/node/README.md](cli/n
 After setting the config, you can build and run the Hermez Node as a synchronizer:
 
 ```shell
-$ make run
+$ make run-node
 ```
 
 Or build and run as a coordinator, and also passing the config file from other location:
 
 ```shell
-$ MODE=sync CONFIG=cli/node/cfg.buidler.toml make run
+$ MODE=sync CONFIG=cli/node/cfg.buidler.toml make run-node
 ```
 
 To check the useful make commands:

--- a/cli/node/main.go
+++ b/cli/node/main.go
@@ -35,18 +35,18 @@ const (
 )
 
 var (
-	// Version represents the program based on the git tag
-	Version = "v0.1.0"
-	// Build represents the program based on the git commit
-	Build = "dev"
-	// Date represents the date of application was built
-	Date = ""
+	// version represents the program based on the git tag
+	version = "v0.1.0"
+	// commit represents the program based on the git commit
+	commit = "dev"
+	// date represents the date of application was built
+	date = ""
 )
 
 func cmdVersion(c *cli.Context) error {
-	fmt.Printf("Version = \"%v\"\n", Version)
-	fmt.Printf("Build = \"%v\"\n", Build)
-	fmt.Printf("Date = \"%v\"\n", Date)
+	fmt.Printf("Version = \"%v\"\n", version)
+	fmt.Printf("Build = \"%v\"\n", commit)
+	fmt.Printf("Date = \"%v\"\n", date)
 	return nil
 }
 
@@ -420,7 +420,7 @@ func getConfigAPIServer(c *cli.Context) (*ConfigAPIServer, error) {
 func main() {
 	app := cli.NewApp()
 	app.Name = "hermez-node"
-	app.Version = Version
+	app.Version = version
 	flags := []cli.Flag{
 		&cli.StringFlag{
 			Name:     flagMode,


### PR DESCRIPTION
### What does this MR does?

Automatically generate binaries, checksum, and the changelog with [Goreleaser](https://goreleaser.com) and GitHub actions when I new tag is created.

### Why we need it?

For we have a better application distribution and versioning,

### How to test?

After merging this PR to the master, create a new version tag and check the [github release page] (https://github.com/hermeznetwork/hermez-node/releases). All binaries, checksum, and the changelog, must be generated automatically.

closes https://github.com/hermeznetwork/hermez-node/issues/632


**E.g:**
https://github.com/Pantani/tests/releases

![Screen Shot 2021-03-20 at 00 17 46](https://user-images.githubusercontent.com/2406457/111857665-bd669c80-8911-11eb-9efc-b99742356945.png)
