### PR TITLE
Bound the filter of init SC events by blocks

### DIFF
--- a/eth/auction.go
+++ b/eth/auction.go
@@ -260,7 +260,7 @@ type AuctionInterface interface {
 
 	AuctionConstants() (*common.AuctionConstants, error)
 	AuctionEventsByBlock(blockNum int64, blockHash *ethCommon.Hash) (*AuctionEvents, error)
-	AuctionEventInit() (*AuctionEventInitialize, int64, error)
+	AuctionEventInit(genesisBlockNum int64) (*AuctionEventInitialize, int64, error)
 }
 
 //
@@ -809,12 +809,14 @@ var (
 )
 
 // AuctionEventInit returns the initialize event with its corresponding block number
-func (c *AuctionClient) AuctionEventInit() (*AuctionEventInitialize, int64, error) {
+func (c *AuctionClient) AuctionEventInit(genesisBlockNum int64) (*AuctionEventInitialize, int64, error) {
 	query := ethereum.FilterQuery{
 		Addresses: []ethCommon.Address{
 			c.address,
 		},
-		Topics: [][]ethCommon.Hash{{logAuctionInitialize}},
+		FromBlock: big.NewInt(max(0, genesisBlockNum-blocksPerDay)),
+		ToBlock:   big.NewInt(genesisBlockNum),
+		Topics:    [][]ethCommon.Hash{{logAuctionInitialize}},
 	}
 	logs, err := c.client.client.FilterLogs(context.Background(), query)
 	if err != nil {

--- a/eth/auction_test.go
+++ b/eth/auction_test.go
@@ -28,7 +28,7 @@ func TestAuctionGetCurrentSlotNumber(t *testing.T) {
 }
 
 func TestAuctionEventInit(t *testing.T) {
-	auctionInit, blockNum, err := auctionClientTest.AuctionEventInit()
+	auctionInit, blockNum, err := auctionClientTest.AuctionEventInit(genesisBlock)
 	require.NoError(t, err)
 	assert.Equal(t, int64(18), blockNum)
 	assert.Equal(t, donationAddressConst, auctionInit.DonationAddress)

--- a/eth/client.go
+++ b/eth/client.go
@@ -12,6 +12,17 @@ import (
 
 var errTODO = fmt.Errorf("TODO: Not implemented yet")
 
+const (
+	blocksPerDay = (3600 * 24) / 15
+)
+
+func max(x, y int64) int64 {
+	if x > y {
+		return x
+	}
+	return y
+}
+
 // ClientInterface is the eth Client interface used by hermez-node modules to
 // interact with Ethereum Blockchain and smart contracts.
 type ClientInterface interface {

--- a/eth/rollup.go
+++ b/eth/rollup.go
@@ -273,7 +273,7 @@ type RollupInterface interface {
 	RollupConstants() (*common.RollupConstants, error)
 	RollupEventsByBlock(blockNum int64, blockHash *ethCommon.Hash) (*RollupEvents, error)
 	RollupForgeBatchArgs(ethCommon.Hash, uint16) (*RollupForgeBatchArgs, *ethCommon.Address, error)
-	RollupEventInit() (*RollupEventInitialize, int64, error)
+	RollupEventInit(genesisBlockNum int64) (*RollupEventInitialize, int64, error)
 }
 
 //
@@ -749,12 +749,14 @@ var (
 )
 
 // RollupEventInit returns the initialize event with its corresponding block number
-func (c *RollupClient) RollupEventInit() (*RollupEventInitialize, int64, error) {
+func (c *RollupClient) RollupEventInit(genesisBlockNum int64) (*RollupEventInitialize, int64, error) {
 	query := ethereum.FilterQuery{
 		Addresses: []ethCommon.Address{
 			c.address,
 		},
-		Topics: [][]ethCommon.Hash{{logHermezInitialize}},
+		FromBlock: big.NewInt(max(0, genesisBlockNum-blocksPerDay)),
+		ToBlock:   big.NewInt(genesisBlockNum),
+		Topics:    [][]ethCommon.Hash{{logHermezInitialize}},
 	}
 	logs, err := c.client.client.FilterLogs(context.Background(), query)
 	if err != nil {

--- a/eth/rollup_test.go
+++ b/eth/rollup_test.go
@@ -56,7 +56,7 @@ func genKeysBjj(i int64) *keys {
 }
 
 func TestRollupEventInit(t *testing.T) {
-	rollupInit, blockNum, err := rollupClient.RollupEventInit()
+	rollupInit, blockNum, err := rollupClient.RollupEventInit(genesisBlock)
 	require.NoError(t, err)
 	assert.Equal(t, int64(19), blockNum)
 	assert.Equal(t, uint8(10), rollupInit.ForgeL1L2BatchTimeout)

--- a/eth/wdelayer.go
+++ b/eth/wdelayer.go
@@ -137,7 +137,7 @@ type WDelayerInterface interface {
 
 	WDelayerEventsByBlock(blockNum int64, blockHash *ethCommon.Hash) (*WDelayerEvents, error)
 	WDelayerConstants() (*common.WDelayerConstants, error)
-	WDelayerEventInit() (*WDelayerEventInitialize, int64, error)
+	WDelayerEventInit(genesisBlockNum int64) (*WDelayerEventInitialize, int64, error)
 }
 
 //
@@ -415,12 +415,14 @@ var (
 )
 
 // WDelayerEventInit returns the initialize event with its corresponding block number
-func (c *WDelayerClient) WDelayerEventInit() (*WDelayerEventInitialize, int64, error) {
+func (c *WDelayerClient) WDelayerEventInit(genesisBlockNum int64) (*WDelayerEventInitialize, int64, error) {
 	query := ethereum.FilterQuery{
 		Addresses: []ethCommon.Address{
 			c.address,
 		},
-		Topics: [][]ethCommon.Hash{{logWDelayerInitialize}},
+		FromBlock: big.NewInt(max(0, genesisBlockNum-blocksPerDay)),
+		ToBlock:   big.NewInt(genesisBlockNum),
+		Topics:    [][]ethCommon.Hash{{logWDelayerInitialize}},
 	}
 	logs, err := c.client.client.FilterLogs(context.Background(), query)
 	if err != nil {

--- a/eth/wdelayer_test.go
+++ b/eth/wdelayer_test.go
@@ -18,7 +18,7 @@ var maxEmergencyModeTime = time.Hour * 24 * 7 * 26
 var maxWithdrawalDelay = time.Hour * 24 * 7 * 2
 
 func TestWDelayerInit(t *testing.T) {
-	wDelayerInit, blockNum, err := wdelayerClientTest.WDelayerEventInit()
+	wDelayerInit, blockNum, err := wdelayerClientTest.WDelayerEventInit(genesisBlock)
 	require.NoError(t, err)
 	assert.Equal(t, int64(16), blockNum)
 	assert.Equal(t, uint64(initWithdrawalDelay), wDelayerInit.InitialWithdrawalDelay)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -704,15 +704,15 @@ func (s *Synchronizer) reorg(uncleBlock *common.Block) (int64, error) {
 
 func getInitialVariables(ethClient eth.ClientInterface,
 	consts *common.SCConsts) (*common.SCVariables, *StartBlockNums, error) {
-	rollupInit, rollupInitBlock, err := ethClient.RollupEventInit()
+	rollupInit, rollupInitBlock, err := ethClient.RollupEventInit(consts.Auction.GenesisBlockNum)
 	if err != nil {
 		return nil, nil, tracerr.Wrap(fmt.Errorf("RollupEventInit: %w", err))
 	}
-	auctionInit, auctionInitBlock, err := ethClient.AuctionEventInit()
+	auctionInit, auctionInitBlock, err := ethClient.AuctionEventInit(consts.Auction.GenesisBlockNum)
 	if err != nil {
 		return nil, nil, tracerr.Wrap(fmt.Errorf("AuctionEventInit: %w", err))
 	}
-	wDelayerInit, wDelayerInitBlock, err := ethClient.WDelayerEventInit()
+	wDelayerInit, wDelayerInitBlock, err := ethClient.WDelayerEventInit(consts.Auction.GenesisBlockNum)
 	if err != nil {
 		return nil, nil, tracerr.Wrap(fmt.Errorf("WDelayerEventInit: %w", err))
 	}

--- a/test/ethclient.go
+++ b/test/ethclient.go
@@ -1152,7 +1152,7 @@ func (c *Client) RollupEventsByBlock(blockNum int64,
 }
 
 // RollupEventInit returns the initialize event with its corresponding block number
-func (c *Client) RollupEventInit() (*eth.RollupEventInitialize, int64, error) {
+func (c *Client) RollupEventInit(genesisBlockNum int64) (*eth.RollupEventInitialize, int64, error) {
 	vars := c.blocks[0].Rollup.Vars
 	return &eth.RollupEventInitialize{
 		ForgeL1L2BatchTimeout: uint8(vars.ForgeL1L2BatchTimeout),
@@ -1628,7 +1628,7 @@ func (c *Client) AuctionEventsByBlock(blockNum int64,
 }
 
 // AuctionEventInit returns the initialize event with its corresponding block number
-func (c *Client) AuctionEventInit() (*eth.AuctionEventInitialize, int64, error) {
+func (c *Client) AuctionEventInit(genesisBlockNum int64) (*eth.AuctionEventInitialize, int64, error) {
 	vars := c.blocks[0].Auction.Vars
 	return &eth.AuctionEventInitialize{
 		DonationAddress:        vars.DonationAddress,
@@ -1863,7 +1863,7 @@ func (c *Client) WDelayerConstants() (*common.WDelayerConstants, error) {
 }
 
 // WDelayerEventInit returns the initialize event with its corresponding block number
-func (c *Client) WDelayerEventInit() (*eth.WDelayerEventInitialize, int64, error) {
+func (c *Client) WDelayerEventInit(genesisBlockNum int64) (*eth.WDelayerEventInitialize, int64, error) {
 	vars := c.blocks[0].WDelayer.Vars
 	return &eth.WDelayerEventInitialize{
 		InitialWithdrawalDelay:         vars.WithdrawalDelay,


### PR DESCRIPTION
When querying the init event for each smart contract, bound the search from
block genesis-24h to block genesis.  Otherwise, this query in geth synced to
mainnet takes too long.