### PR TITLE
Faster synchronization with less updates of Ethereum stats

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -60,7 +60,8 @@ URL = "http://localhost:8545"
 
 [Synchronizer]
 SyncLoopInterval = "1s"
-StatsRefreshPeriod = "1s"
+StatsUpdateBlockNumDiffThreshold = 100
+StatsUpdateFrequencyDivider = 100
 
 [SmartContracts]
 Rollup   = "0x8EEaea23686c319133a7cC110b840d1591d9AeE0"

--- a/config/config.go
+++ b/config/config.go
@@ -308,11 +308,19 @@ type Node struct {
 		// SyncLoopInterval is the interval between attempts to
 		// synchronize a new block from an ethereum node
 		SyncLoopInterval Duration `validate:"required"`
-		// StatsRefreshPeriod is the interval between updates of the
-		// synchronizer state Eth parameters (`Eth.LastBlock` and
-		// `Eth.LastBatch`).  This value only affects the reported % of
+		// StatsUpdateBlockNumDiffThreshold is a threshold of a number of
+		// Ethereum blocks left to synchronize, such that if there are more
+		// blocks to sync than the defined value synchronizer can aggressively
+		// skip calling UpdateEth to save network bandwidth and time.
+		// After reaching the threshold UpdateEth is called on each block.
+		// This value only affects the reported % of synchronization of
+		// blocks and batches, nothing else.
+		StatsUpdateBlockNumDiffThreshold uint16 `validate:"required"`
+		// StatsUpdateFrequencyDivider - While having more blocks to sync than
+		// updateEthBlockNumThreshold, UpdateEth will be called once in a
+		// defined number of blocks. This value only affects the reported % of
 		// synchronization of blocks and batches, nothing else.
-		StatsRefreshPeriod Duration `validate:"required"`
+		StatsUpdateFrequencyDivider uint16 `validate:"required"`
 	} `validate:"required"`
 	SmartContracts struct {
 		// Rollup is the address of the Hermez.sol smart contract
@@ -345,7 +353,7 @@ type Node struct {
 		// Maximum concurrent connections allowed between API and SQL
 		MaxSQLConnections int `validate:"required"`
 		// SQLConnectionTimeout is the maximum amount of time that an API request
-		// can wait to stablish a SQL connection
+		// can wait to establish a SQL connection
 		SQLConnectionTimeout Duration
 	} `validate:"required"`
 	RecommendedFeePolicy stateapiupdater.RecommendedFeePolicy `validate:"required"`
@@ -364,7 +372,7 @@ type APIServer struct {
 		// Maximum concurrent connections allowed between API and SQL
 		MaxSQLConnections int `validate:"required"`
 		// SQLConnectionTimeout is the maximum amount of time that an API request
-		// can wait to stablish a SQL connection
+		// can wait to establish a SQL connection
 		SQLConnectionTimeout Duration
 	} `validate:"required"`
 	PostgreSQL  PostgreSQL `validate:"required"`

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -209,7 +209,8 @@ func newTestSynchronizer(t *testing.T, ethClient *test.Client, ethClientSetup *t
 	modules modules) *synchronizer.Synchronizer {
 	sync, err := synchronizer.NewSynchronizer(ethClient, modules.historyDB, modules.l2DB, modules.stateDB,
 		synchronizer.Config{
-			StatsRefreshPeriod: 0 * time.Second,
+			StatsUpdateBlockNumDiffThreshold: 100,
+			StatsUpdateFrequencyDivider:      100,
 		})
 	require.NoError(t, err)
 	return sync

--- a/node/node.go
+++ b/node/node.go
@@ -251,9 +251,21 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		)
 	}
 
+	const safeBlockNumDiff = 32
+	if cfg.Synchronizer.StatsUpdateBlockNumDiffThreshold < safeBlockNumDiff {
+		return nil, tracerr.Wrap(fmt.Errorf("cfg.Synchronizer.StatsUpdateBlockNumDiffThreshold = %v < %v, which is unsafe",
+			cfg.Synchronizer.StatsUpdateBlockNumDiffThreshold, safeBlockNumDiff))
+	}
+	const safeFrequencyDivider = 1
+	if cfg.Synchronizer.StatsUpdateFrequencyDivider < safeFrequencyDivider {
+		return nil, tracerr.Wrap(fmt.Errorf("cfg.Synchronizer.StatsUpdateFrequencyDivider = %v < %v, which is unsafe",
+			cfg.Synchronizer.StatsUpdateFrequencyDivider, safeFrequencyDivider))
+	}
+
 	sync, err := synchronizer.NewSynchronizer(client, historyDB, l2DB, stateDB, synchronizer.Config{
-		StatsRefreshPeriod: cfg.Synchronizer.StatsRefreshPeriod.Duration,
-		ChainID:            chainIDU16,
+		StatsUpdateBlockNumDiffThreshold: cfg.Synchronizer.StatsUpdateBlockNumDiffThreshold,
+		StatsUpdateFrequencyDivider:      cfg.Synchronizer.StatsUpdateFrequencyDivider,
+		ChainID:                          chainIDU16,
 	})
 	if err != nil {
 		return nil, tracerr.Wrap(err)

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -352,7 +352,8 @@ func TestSyncGeneral(t *testing.T) {
 
 	// Create Synchronizer
 	s, err := NewSynchronizer(client, historyDB, l2DB, stateDB, Config{
-		StatsRefreshPeriod: 0 * time.Second,
+		StatsUpdateBlockNumDiffThreshold: 100,
+		StatsUpdateFrequencyDivider:      100,
 	})
 	require.NoError(t, err)
 
@@ -745,7 +746,8 @@ func TestSyncForgerCommitment(t *testing.T) {
 
 	// Create Synchronizer
 	s, err := NewSynchronizer(client, historyDB, l2DB, stateDB, Config{
-		StatsRefreshPeriod: 0 * time.Second,
+		StatsUpdateBlockNumDiffThreshold: 100,
+		StatsUpdateFrequencyDivider:      100,
 	})
 	require.NoError(t, err)
 
@@ -845,7 +847,8 @@ func TestSyncForgerCommitment(t *testing.T) {
 		syncCommitment[syncBlock.Block.Num] = stats.Sync.Auction.CurrentSlot.ForgerCommitment
 
 		s2, err := NewSynchronizer(client, historyDB, l2DB, stateDB, Config{
-			StatsRefreshPeriod: 0 * time.Second,
+			StatsUpdateBlockNumDiffThreshold: 100,
+			StatsUpdateFrequencyDivider:      100,
 		})
 		require.NoError(t, err)
 		stats = s2.Stats()


### PR DESCRIPTION
When doing initial synchronization we don't need to update Ethereum stats (fetching last Ethereum block mined and last batch forged) after each block (but not more that once in N second specified in config).

This change does this update only once in `cfg.Synchronizer.StatsUpdateFrequencyDivider` blocks synchronized. After reaching a threshold of `cfg.Synchronizer.StatsUpdateBlockNumDiffThreshold` blocks left to synchronize, node switches to regular checks on each block.

