### PR TITLE
Fix mock server

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -59,9 +59,9 @@ externalDocs:
   description: Find out more about Hermez network.
   url: 'https://hermez.io'
 servers:
-  - description: Hosted mock up
-    url: https://apimock.hermez.network/v1
-  - description: Localhost mock Up
+  - description: Testnet api, connected to Rinkeby deployment
+    url: https://api.testnet.hermez.io/v1
+  - description: Localhost usefull for testing/developing the api
     url: http://localhost:4010/v1
 tags:
   - name: Coordinator


### PR DESCRIPTION
Added `/v1` in swagger endpoints. This goes against the [OpenAPI spec](https://swagger.io/docs/specification/api-host-and-base-path/), however the mock server we're using doesn't support this (see this issue for more info #663).

IMO it's not bad to have the version added to the path in the description as this is actually part of the path and must be included, which is easy to miss if this i stetted only in the server URL. However not following a spec is a bad idea in general.

Anyway, as this is used publicly [here](https://apidoc.hermez.network/), we need a fix soon, and I've opted for this solution.
Note that my first attempt has been to try similar software, and for different reasons (problems with CORS, problems with the actual specification file, ...) non of them has worked.

After fixing the public mock server we should consider a more solid solution for this problem like adding a reverse proxy to manipulate the paths to be consistent with the OpenAPI spec, or just choose to ignore this.

EDIT: the original idea of this PR was to fix the mock server. Instead it switches to using the deployed API on testnet. After editing this comment the previously related issue won't get closed with the idea to fix the mock up server later on in order to give users the decision of using mocked data vs real (testnet) data