### PR TITLE
fix the invalid goarch build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - go mod download
+    - make migration-pack
 
 builds:
   - main: ./cli/node/main.go
@@ -9,10 +10,8 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
-    hooks:
-      pre: make migration-pack
-      post: make migration-clean
+    goarch:
+      - amd64
 
 archives:
   - replacements:


### PR DESCRIPTION
### What does this MR does?

- Increase the build time avoiding call the migration-pack each build;
- Remove invalid architecture build to avoid int overlow error:
```
api/config.go:38:3: constant 4294967296 overflows int
api/config.go:46:3: constant 100000000000000 overflows int
```