### PR TITLE
Add configuration option to choose recommended fee strategy, and add …

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -522,11 +522,16 @@ func TestMain(m *testing.M) {
 		WithdrawalDelay: uint64(3000),
 	}
 
-	stateAPIUpdater = stateapiupdater.NewUpdater(hdb, nodeConfig, &common.SCVariables{
+	stateAPIUpdater, err = stateapiupdater.NewUpdater(hdb, nodeConfig, &common.SCVariables{
 		Rollup:   rollupVars,
 		Auction:  auctionVars,
 		WDelayer: wdelayerVars,
-	}, constants)
+	}, constants, &stateapiupdater.RecommendedFeePolicy{
+		PolicyType: stateapiupdater.RecommendedFeePolicyTypeAvgLastHour,
+	})
+	if err != nil {
+		panic(err)
+	}
 
 	// Generate test data, as expected to be received/sended from/to the API
 	testCoords := genTestCoordinators(commonCoords)

--- a/api/stateapiupdater/stateapiupdater.go
+++ b/api/stateapiupdater/stateapiupdater.go
@@ -2,10 +2,12 @@ package stateapiupdater
 
 import (
 	"database/sql"
+	"fmt"
 	"sync"
 
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/historydb"
+	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/tracerr"
 )
 
@@ -17,11 +19,45 @@ type Updater struct {
 	vars   common.SCVariablesPtr
 	consts historydb.Constants
 	rw     sync.RWMutex
+	rfp    *RecommendedFeePolicy
+}
+
+// RecommendedFeePolicy describes how the recommended fee is calculated
+type RecommendedFeePolicy struct {
+	PolicyType  RecommendedFeePolicyType `validate:"required"`
+	StaticValue float64
+}
+
+// RecommendedFeePolicyType describes the different available recommended fee strategies
+type RecommendedFeePolicyType string
+
+const (
+	// RecommendedFeePolicyTypeStatic always give the same StaticValue as recommended fee
+	RecommendedFeePolicyTypeStatic RecommendedFeePolicyType = "Static"
+	// RecommendedFeePolicyTypeAvgLastHour set the recommended fee using the average fee of the last hour
+	RecommendedFeePolicyTypeAvgLastHour RecommendedFeePolicyType = "AvgLastHour"
+)
+
+func (rfp *RecommendedFeePolicy) valid() bool {
+	switch rfp.PolicyType {
+	case RecommendedFeePolicyTypeStatic:
+		if rfp.StaticValue == 0 {
+			log.Warn("RcommendedFee is set to 0 USD, and the policy is static")
+		}
+		return true
+	case RecommendedFeePolicyTypeAvgLastHour:
+		return true
+	default:
+		return false
+	}
 }
 
 // NewUpdater creates a new Updater
 func NewUpdater(hdb *historydb.HistoryDB, config *historydb.NodeConfig, vars *common.SCVariables,
-	consts *historydb.Constants) *Updater {
+	consts *historydb.Constants, rfp *RecommendedFeePolicy) (*Updater, error) {
+	if ok := rfp.valid(); !ok {
+		return nil, tracerr.Wrap(fmt.Errorf("Invalid recommended fee policy: %v", rfp.PolicyType))
+	}
 	u := Updater{
 		hdb:    hdb,
 		config: *config,
@@ -31,9 +67,10 @@ func NewUpdater(hdb *historydb.HistoryDB, config *historydb.NodeConfig, vars *co
 				ForgeDelay: config.ForgeDelay,
 			},
 		},
+		rfp: rfp,
 	}
 	u.SetSCVars(vars.AsPtr())
-	return &u
+	return &u, nil
 }
 
 // Store the State in the HistoryDB
@@ -65,13 +102,27 @@ func (u *Updater) SetSCVars(vars *common.SCVariablesPtr) {
 
 // UpdateRecommendedFee update Status.RecommendedFee information
 func (u *Updater) UpdateRecommendedFee() error {
-	recommendedFee, err := u.hdb.GetRecommendedFee(u.config.MinFeeUSD, u.config.MaxFeeUSD)
-	if err != nil {
-		return tracerr.Wrap(err)
+	switch u.rfp.PolicyType {
+	case RecommendedFeePolicyTypeStatic:
+		u.rw.Lock()
+		u.state.RecommendedFee = common.RecommendedFee{
+			ExistingAccount:        u.rfp.StaticValue,
+			CreatesAccount:         u.rfp.StaticValue,
+			CreatesAccountInternal: u.rfp.StaticValue,
+		}
+		u.rw.Unlock()
+	case RecommendedFeePolicyTypeAvgLastHour:
+		recommendedFee, err := u.hdb.GetRecommendedFee(u.config.MinFeeUSD, u.config.MaxFeeUSD)
+		if err != nil {
+			return tracerr.Wrap(err)
+		}
+		u.rw.Lock()
+		u.state.RecommendedFee = *recommendedFee
+		u.rw.Unlock()
+	default:
+		return tracerr.New("Invalid recommende fee policy")
 	}
-	u.rw.Lock()
-	u.state.RecommendedFee = *recommendedFee
-	u.rw.Unlock()
+
 	return nil
 }
 

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -145,3 +145,11 @@ Coordinator = true
 BatchPath = "/tmp/iden3-test/hermez/batchesdebug"
 LightScrypt = true
 # RollupVerifierIndex = 0
+
+[RecommendedFeePolicy]
+# Strategy used to calculate the recommended fee that the API will expose.
+# Available options:
+# - Static: always return the same value (StaticValue) in USD
+# - AvgLastHour: calculate using the average fee of the forged transactions during the last hour
+PolicyType = "Static"
+StaticValue = 0.99

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/hermeznetwork/hermez-node/api/stateapiupdater"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/priceupdater"
 	"github.com/hermeznetwork/tracerr"
@@ -347,8 +348,9 @@ type Node struct {
 		// can wait to stablish a SQL connection
 		SQLConnectionTimeout Duration
 	} `validate:"required"`
-	Debug       NodeDebug   `validate:"required"`
-	Coordinator Coordinator `validate:"-"`
+	RecommendedFeePolicy stateapiupdater.RecommendedFeePolicy `validate:"required"`
+	Debug                NodeDebug                            `validate:"required"`
+	Coordinator          Coordinator                          `validate:"-"`
 }
 
 // APIServer is the api server configuration parameters

--- a/node/node.go
+++ b/node/node.go
@@ -288,7 +288,16 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		return nil, tracerr.Wrap(err)
 	}
 
-	stateAPIUpdater := stateapiupdater.NewUpdater(historyDB, &hdbNodeCfg, initSCVars, &hdbConsts)
+	stateAPIUpdater, err := stateapiupdater.NewUpdater(
+		historyDB,
+		&hdbNodeCfg,
+		initSCVars,
+		&hdbConsts,
+		&cfg.RecommendedFeePolicy,
+	)
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
 
 	var coord *coordinator.Coordinator
 	if mode == ModeCoordinator {


### PR DESCRIPTION
- Update configuration file to indicate which strategy is used to expose (via API) the recommended fee
- Add new strategy for recommended fee: static value

**Note:** I've tested (spin up the node) this locally and it works, however it doesn't fail parsing the configuration file if  `RecommendedFeePolicy` is not provided even when it's marked as `required`. If not provided the node will fail to start anyway as this is further validated when constructing the `StateAPIUpdater`.