### PR TITLE
Add greatestNonceInPool for GET /accounts

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -541,7 +541,7 @@ func TestMain(m *testing.M) {
 	testBatches, testFullBatches := genTestBatches(commonBlocks, commonBatches, testTxs)
 	poolTxsToSend, poolTxsToReceive := genTestPoolTxs(commonPoolTxs, testTokens, commonAccounts)
 	// Add balance and nonce to historyDB
-	accounts := genTestAccounts(commonAccounts, testTokens)
+	accounts := genTestAccounts(commonAccounts, testTokens, poolTxsToSend)
 	accUpdates := []common.AccountUpdate{}
 	for i := 0; i < len(accounts); i++ {
 		balance := new(big.Int)

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2369,7 +2369,16 @@ components:
         accountIndex:
           $ref: '#/components/schemas/AccountIndex'
         nonce:
-          $ref: '#/components/schemas/Nonce'      
+          $ref: '#/components/schemas/Nonce'
+        greatestNonceInPool:
+          type: number
+          description: | 
+            The greatest nonce of among all the transactions in the account from this account. 
+            `null` indicates that there are no transactions in the pool from this account.
+            Note that there is no guarantee that all transactions of the pool from the ssame accoun have consequtive nonces,
+            but the greatest will always be returned.
+          example: 3
+          nullable: true 
         balance:
           $ref: '#/components/schemas/BigInt'
         bjj:
@@ -2385,6 +2394,7 @@ components:
         hezEthereumAddress: hez:0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
         itemId: 4
         nonce: 0
+        greatestNonceInPool: 1
         token:
           USD: 500
           decimals: 18
@@ -2400,6 +2410,7 @@ components:
         - itemId
         - accountIndex
         - nonce
+        - greatestNonceInPool
         - balance
         - bjj
         - hezEthereumAddress

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -240,37 +240,39 @@ type CoordinatorAPI struct {
 // AccountAPI is a representation of a account with additional information
 // required by the API
 type AccountAPI struct {
-	ItemID           uint64              `meddler:"item_id"`
-	Idx              apitypes.HezIdx     `meddler:"idx"`
-	BatchNum         common.BatchNum     `meddler:"batch_num"`
-	PublicKey        apitypes.HezBJJ     `meddler:"bjj"`
-	EthAddr          apitypes.HezEthAddr `meddler:"eth_addr"`
-	Nonce            common.Nonce        `meddler:"nonce"`   // max of 40 bits used
-	Balance          *apitypes.BigIntStr `meddler:"balance"` // max of 192 bits used
-	TotalItems       uint64              `meddler:"total_items"`
-	FirstItem        uint64              `meddler:"first_item"`
-	LastItem         uint64              `meddler:"last_item"`
-	TokenID          common.TokenID      `meddler:"token_id"`
-	TokenItemID      int                 `meddler:"token_item_id"`
-	TokenEthBlockNum int64               `meddler:"token_block"`
-	TokenEthAddr     ethCommon.Address   `meddler:"token_eth_addr"`
-	TokenName        string              `meddler:"name"`
-	TokenSymbol      string              `meddler:"symbol"`
-	TokenDecimals    uint64              `meddler:"decimals"`
-	TokenUSD         *float64            `meddler:"usd"`
-	TokenUSDUpdate   *time.Time          `meddler:"usd_update"`
+	ItemID              uint64              `meddler:"item_id"`
+	Idx                 apitypes.HezIdx     `meddler:"idx"`
+	BatchNum            common.BatchNum     `meddler:"batch_num"`
+	PublicKey           apitypes.HezBJJ     `meddler:"bjj"`
+	EthAddr             apitypes.HezEthAddr `meddler:"eth_addr"`
+	Nonce               common.Nonce        `meddler:"nonce"` // max of 40 bits used
+	GreatestNonceInPool *common.Nonce       `meddler:"greatest_nonce"`
+	Balance             *apitypes.BigIntStr `meddler:"balance"` // max of 192 bits used
+	TotalItems          uint64              `meddler:"total_items"`
+	FirstItem           uint64              `meddler:"first_item"`
+	LastItem            uint64              `meddler:"last_item"`
+	TokenID             common.TokenID      `meddler:"token_id"`
+	TokenItemID         int                 `meddler:"token_item_id"`
+	TokenEthBlockNum    int64               `meddler:"token_block"`
+	TokenEthAddr        ethCommon.Address   `meddler:"token_eth_addr"`
+	TokenName           string              `meddler:"name"`
+	TokenSymbol         string              `meddler:"symbol"`
+	TokenDecimals       uint64              `meddler:"decimals"`
+	TokenUSD            *float64            `meddler:"usd"`
+	TokenUSDUpdate      *time.Time          `meddler:"usd_update"`
 }
 
 // MarshalJSON is used to neast some of the fields of AccountAPI
 // without the need of auxiliar structs
 func (account AccountAPI) MarshalJSON() ([]byte, error) {
 	jsonAccount := map[string]interface{}{
-		"itemId":             account.ItemID,
-		"accountIndex":       account.Idx,
-		"nonce":              account.Nonce,
-		"balance":            account.Balance,
-		"bjj":                account.PublicKey,
-		"hezEthereumAddress": account.EthAddr,
+		"itemId":              account.ItemID,
+		"accountIndex":        account.Idx,
+		"nonce":               account.Nonce,
+		"greatestNonceInPool": account.GreatestNonceInPool,
+		"balance":             account.Balance,
+		"bjj":                 account.PublicKey,
+		"hezEthereumAddress":  account.EthAddr,
 		"token": map[string]interface{}{
 			"id":               account.TokenID,
 			"itemId":           account.TokenItemID,


### PR DESCRIPTION
Return the greatest nonce in the pool for each account in the GET /accounts endpoint.

This will be useful for managing  sending transactions to the pool in scenarios where a user have multiple clients, or the cache of the client gets deleted.

Close #681 