### PR TITLE
Faster synchronization with asynchronous deletion of old checkpoints

### DIFF
--- a/db/kvdb/kvdb.go
+++ b/db/kvdb/kvdb.go
@@ -46,12 +46,12 @@ type KVDB struct {
 	cfg Config
 	db  *pebble.Storage
 	// CurrentIdx holds the current Idx that the BatchBuilder is using
-	CurrentIdx   common.Idx
-	CurrentBatch common.BatchNum
-	m            sync.Mutex
-	mutexDelOld  sync.Mutex
-	wg           sync.WaitGroup
-	last         *Last
+	CurrentIdx      common.Idx
+	CurrentBatch    common.BatchNum
+	mutexCheckpoint sync.Mutex
+	mutexDelOld     sync.Mutex
+	wg              sync.WaitGroup
+	last            *Last
 }
 
 // Last is a consistent view to the last batch of the stateDB that can
@@ -552,8 +552,8 @@ func (k *KVDB) MakeCheckpointFromTo(fromBatchNum common.BatchNum, dest string) e
 	// synchronizer to do a reset to a batchNum at the same time as the
 	// pipeline is doing a txSelector.Reset and batchBuilder.Reset from
 	// synchronizer to the same batchNum
-	k.m.Lock()
-	defer k.m.Unlock()
+	k.mutexCheckpoint.Lock()
+	defer k.mutexCheckpoint.Unlock()
 	return PebbleMakeCheckpoint(source, dest)
 }
 

--- a/db/statedb/statedb.go
+++ b/db/statedb/statedb.go
@@ -227,6 +227,12 @@ func (s *StateDB) MakeCheckpoint() error {
 	return s.db.MakeCheckpoint()
 }
 
+// DeleteOldCheckpoints deletes old checkpoints when there are more than
+// `cfg.keep` checkpoints
+func (s *StateDB) DeleteOldCheckpoints() error {
+	return s.db.DeleteOldCheckpoints()
+}
+
 // CurrentBatch returns the current in-memory CurrentBatch of the StateDB.db
 func (s *StateDB) CurrentBatch() common.BatchNum {
 	return s.db.CurrentBatch


### PR DESCRIPTION
After each checkpoint we were doing synchronous deletion of old checkpoints, which was taking a lot of time during synchronization. 
Fixed by making DeleteOldCheckpoints public method in KVDB and StateDB, removing it from MakeCheckpoint and adding async call in TxProcessor.
Added unit tests to check that possible concurrent deletion doesn't break anything.