### PR TITLE
Fix Goreleaser migration pack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,24 +3,25 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-      -
-        name: Run GoReleaser
+      - name: Get packr
+        run: go get -u github.com/gobuffalo/packr/v2/packr2
+      - name: Prepare
+        run: git reset --hard
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,11 @@
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+
 before:
   hooks:
+    - go mod tidy
     - go mod download
-    - make migration-pack
 
 builds:
   - main: ./cli/node/main.go
@@ -12,14 +16,13 @@ builds:
       - darwin
     goarch:
       - amd64
-
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    hooks:
+      pre:
+        - cmd: bash -c "GOOS={{ .Os }} GOARCH={{ .Arch }} packr2"
+          dir: db
+      post:
+        - cmd: packr2 clean
+          dir: db
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
### What does this MR does?

Fix the migration pack for the binary release distribution

## Changes

- Download the packr as Github Action
- Add Go build env vars
- Specify the `GOARCH` and `GOOS` to `packr`

**Fully tested on a forked repository:**
https://github.com/Pantani/hermez-node/releases/tag/v1.3.3