### PR TITLE
remove max tx for remove by TTL

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,8 +149,8 @@ type Coordinator struct {
 		// order to be accepted into the pool.  Txs with greater than
 		// maximum fee will be rejected at the API level.
 		MaxFeeUSD float64 `validate:"required"`
-		// TTL is the Time To Live for L2Txs in the pool.  Once MaxTxs
-		// L2Txs is reached, L2Txs older than TTL will be deleted.
+		// TTL is the Time To Live for L2Txs in the pool. L2Txs older
+		// than TTL will be deleted.
 		TTL Duration `validate:"required"`
 		// PurgeBatchDelay is the delay between batches to purge
 		// outdated transactions. Outdated L2Txs are those that have

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -375,14 +375,12 @@ func (l2db *L2DB) Purge(currentBatchNum common.BatchNum) (err error) {
 		`DELETE FROM tx_pool WHERE (
 			batch_num < $1 AND (state = $2 OR state = $3)
 		) OR (
-			(SELECT count(*) FROM tx_pool WHERE state = $4) > $5 
-			AND timestamp < $6 AND state = $4
+			state = $4 AND timestamp < $5
 		);`,
 		currentBatchNum-l2db.safetyPeriod,
 		common.PoolL2TxStateForged,
 		common.PoolL2TxStateInvalid,
 		common.PoolL2TxStatePending,
-		l2db.maxTxs,
 		time.Unix(now-int64(l2db.ttl.Seconds()), 0),
 	)
 	return tracerr.Wrap(err)


### PR DESCRIPTION
### What does this MR does?

  Remove pending transactions that exceed TTL unconditionally, without the need to reach a max number of transactions.
 
## Changes

- Remove the length of the maximum transaction from the query to purge the pending transactions
 
 closes #701