### PR TITLE
Automatically fetch the smart contract addresses from the Rollup contract

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -65,8 +65,6 @@ StatsUpdateFrequencyDivider = 100
 
 [SmartContracts]
 Rollup   = "0x8EEaea23686c319133a7cC110b840d1591d9AeE0"
-Auction  = "0x317113D2593e3efF1FfAE0ba2fF7A61861Df7ae5"
-WDelayer = "0x5E0816F0f8bC560cB2B9e9C87187BeCac8c2021F"
 TokenHEZ = "0x5D94e3e7aeC542aB0F9129B9a7BAdeb5B3Ca0f77"
 TokenHEZName = "Hermez Network Token"
 

--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -65,8 +65,6 @@ StatsUpdateFrequencyDivider = 100
 
 [SmartContracts]
 Rollup   = "0x8EEaea23686c319133a7cC110b840d1591d9AeE0"
-TokenHEZ = "0x5D94e3e7aeC542aB0F9129B9a7BAdeb5B3Ca0f77"
-TokenHEZName = "Hermez Network Token"
 
 [Coordinator]
 ForgerAddress = "0x05c23b938a85ab26A36E6314a0D02080E9ca6BeD" # Non-Boot Coordinator

--- a/config/config.go
+++ b/config/config.go
@@ -325,12 +325,6 @@ type Node struct {
 	SmartContracts struct {
 		// Rollup is the address of the Hermez.sol smart contract
 		Rollup ethCommon.Address `validate:"required"`
-		// TokenHEZ is the address of the HEZTokenFull.sol smart
-		// contract
-		TokenHEZ ethCommon.Address `validate:"required"`
-		// TokenHEZName is the name of the HEZ token deployed at
-		// TokenHEZ address
-		TokenHEZName string `validate:"required"`
 	} `validate:"required"`
 	// API specifies the configuration parameters of the API
 	API struct {

--- a/config/config.go
+++ b/config/config.go
@@ -325,12 +325,6 @@ type Node struct {
 	SmartContracts struct {
 		// Rollup is the address of the Hermez.sol smart contract
 		Rollup ethCommon.Address `validate:"required"`
-		// Rollup is the address of the HermezAuctionProtocol.sol smart
-		// contract
-		Auction ethCommon.Address `validate:"required"`
-		// WDelayer is the address of the WithdrawalDelayer.sol smart
-		// contract
-		WDelayer ethCommon.Address `validate:"required"`
 		// TokenHEZ is the address of the HEZTokenFull.sol smart
 		// contract
 		TokenHEZ ethCommon.Address `validate:"required"`

--- a/coordinator/pipeline_test.go
+++ b/coordinator/pipeline_test.go
@@ -274,15 +274,9 @@ func TestEthRollupForgeBatch(t *testing.T) {
 		Rollup: eth.RollupConfig{
 			Address: rollupAddr,
 		},
-		Auction: eth.AuctionConfig{
+		TokenHEZ: eth.TokenConfig{
 			Address: ethCommon.Address{},
-			TokenHEZ: eth.TokenConfig{
-				Address: ethCommon.Address{},
-				Name:    "HEZ",
-			},
-		},
-		WDelayer: eth.WDelayerConfig{
-			Address: ethCommon.Address{},
+			Name:    "HEZ",
 		},
 	})
 	require.NoError(t, err)

--- a/coordinator/pipeline_test.go
+++ b/coordinator/pipeline_test.go
@@ -274,10 +274,6 @@ func TestEthRollupForgeBatch(t *testing.T) {
 		Rollup: eth.RollupConfig{
 			Address: rollupAddr,
 		},
-		TokenHEZ: eth.TokenConfig{
-			Address: ethCommon.Address{},
-			Name:    "HEZ",
-		},
 	})
 	require.NoError(t, err)
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -46,8 +46,8 @@ type Client struct {
 
 // TokenConfig is used to define the information about token
 type TokenConfig struct {
-	Address ethCommon.Address
 	Name    string
+	Address ethCommon.Address
 }
 
 // RollupConfig is the configuration for the Rollup smart contract interface
@@ -55,23 +55,11 @@ type RollupConfig struct {
 	Address ethCommon.Address
 }
 
-// AuctionConfig is the configuration for the Auction smart contract interface
-type AuctionConfig struct {
-	Address  ethCommon.Address
-	TokenHEZ TokenConfig
-}
-
-// WDelayerConfig is the configuration for the WDelayer smart contract interface
-type WDelayerConfig struct {
-	Address ethCommon.Address
-}
-
 // ClientConfig is the configuration of the Client
 type ClientConfig struct {
 	Ethereum EthereumConfig
 	Rollup   RollupConfig
-	Auction  AuctionConfig
-	WDelayer WDelayerConfig
+	TokenHEZ TokenConfig
 }
 
 // NewClient creates a new Client to interact with Ethereum and the Hermez smart contracts.
@@ -81,17 +69,19 @@ func NewClient(client *ethclient.Client, account *accounts.Account, ks *ethKeyst
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}
-	auctionClient, err := NewAuctionClient(ethereumClient, cfg.Auction.Address,
-		cfg.Auction.TokenHEZ)
-	if err != nil {
-		return nil, tracerr.Wrap(err)
-	}
 	rollupClient, err := NewRollupClient(ethereumClient, cfg.Rollup.Address,
-		cfg.Auction.TokenHEZ)
+		cfg.TokenHEZ)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}
-	wDelayerClient, err := NewWDelayerClient(ethereumClient, cfg.WDelayer.Address)
+	auctionClient, err := NewAuctionClient(ethereumClient,
+		rollupClient.consts.HermezAuctionContract,
+		cfg.TokenHEZ)
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	wDelayerClient, err := NewWDelayerClient(ethereumClient,
+		rollupClient.consts.WithdrawDelayerContract)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/eth/client.go
+++ b/eth/client.go
@@ -44,12 +44,6 @@ type Client struct {
 	WDelayerClient
 }
 
-// TokenConfig is used to define the information about token
-type TokenConfig struct {
-	Name    string
-	Address ethCommon.Address
-}
-
 // RollupConfig is the configuration for the Rollup smart contract interface
 type RollupConfig struct {
 	Address ethCommon.Address
@@ -59,7 +53,6 @@ type RollupConfig struct {
 type ClientConfig struct {
 	Ethereum EthereumConfig
 	Rollup   RollupConfig
-	TokenHEZ TokenConfig
 }
 
 // NewClient creates a new Client to interact with Ethereum and the Hermez smart contracts.
@@ -69,14 +62,13 @@ func NewClient(client *ethclient.Client, account *accounts.Account, ks *ethKeyst
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}
-	rollupClient, err := NewRollupClient(ethereumClient, cfg.Rollup.Address,
-		cfg.TokenHEZ)
+	rollupClient, err := NewRollupClient(ethereumClient, cfg.Rollup.Address)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}
 	auctionClient, err := NewAuctionClient(ethereumClient,
 		rollupClient.consts.HermezAuctionContract,
-		cfg.TokenHEZ)
+		rollupClient.consts.TokenHEZ)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/eth/main_test.go
+++ b/eth/main_test.go
@@ -58,7 +58,7 @@ var (
 	hermezRollupAddressConst ethCommon.Address
 	wdelayerAddressConst     ethCommon.Address
 	wdelayerTestAddressConst ethCommon.Address
-	tokenHEZ                 TokenConfig
+	tokenHEZ                 ethCommon.Address
 
 	donationAccount      *accounts.Account
 	donationAddressConst ethCommon.Address
@@ -124,10 +124,7 @@ func getEnvVariables() {
 	hermezRollupAddressConst = ethCommon.HexToAddress(hermezRollupAddressStr)
 	wdelayerAddressConst = ethCommon.HexToAddress(wdelayerAddressStr)
 	wdelayerTestAddressConst = ethCommon.HexToAddress(wdelayerTestAddressStr)
-	tokenHEZ = TokenConfig{
-		Address: tokenHEZAddressConst,
-		Name:    "Hermez Network Token",
-	}
+	tokenHEZ = tokenHEZAddressConst
 }
 
 func TestMain(m *testing.M) {
@@ -179,7 +176,7 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		rollupClient, err = NewRollupClient(ethereumClientGov, hermezRollupAddressConst, tokenHEZ)
+		rollupClient, err = NewRollupClient(ethereumClientGov, hermezRollupAddressConst)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/eth/rollup_test.go
+++ b/eth/rollup_test.go
@@ -292,7 +292,7 @@ func TestRollupUpdateTokenExchange(t *testing.T) {
 }
 
 func TestRollupL1UserTxETHCreateAccountDeposit(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst, tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	key := genKeysBjj(2)
 	fromIdxInt64 := int64(0)
@@ -327,8 +327,7 @@ func TestRollupL1UserTxETHCreateAccountDeposit(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20CreateAccountDeposit(t *testing.T) {
-	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst)
 	require.NoError(t, err)
 	key := genKeysBjj(1)
 	fromIdxInt64 := int64(0)
@@ -362,8 +361,7 @@ func TestRollupL1UserTxERC20CreateAccountDeposit(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20PermitCreateAccountDeposit(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	key := genKeysBjj(3)
 	fromIdxInt64 := int64(0)
@@ -397,8 +395,7 @@ func TestRollupL1UserTxERC20PermitCreateAccountDeposit(t *testing.T) {
 }
 
 func TestRollupL1UserTxETHDeposit(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(256)
 	toIdxInt64 := int64(0)
@@ -431,8 +428,7 @@ func TestRollupL1UserTxETHDeposit(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20Deposit(t *testing.T) {
-	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(257)
 	toIdxInt64 := int64(0)
@@ -464,8 +460,7 @@ func TestRollupL1UserTxERC20Deposit(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20PermitDeposit(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(258)
 	toIdxInt64 := int64(0)
@@ -496,8 +491,7 @@ func TestRollupL1UserTxERC20PermitDeposit(t *testing.T) {
 }
 
 func TestRollupL1UserTxETHDepositTransfer(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(256)
 	toIdxInt64 := int64(257)
@@ -530,8 +524,7 @@ func TestRollupL1UserTxETHDepositTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20DepositTransfer(t *testing.T) {
-	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(257)
 	toIdxInt64 := int64(258)
@@ -563,8 +556,7 @@ func TestRollupL1UserTxERC20DepositTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20PermitDepositTransfer(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(258)
 	toIdxInt64 := int64(259)
@@ -596,8 +588,7 @@ func TestRollupL1UserTxERC20PermitDepositTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxETHCreateAccountDepositTransfer(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(256)
 	toIdxInt64 := int64(257)
@@ -630,8 +621,7 @@ func TestRollupL1UserTxETHCreateAccountDepositTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20CreateAccountDepositTransfer(t *testing.T) {
-	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(257)
 	toIdxInt64 := int64(258)
@@ -663,8 +653,7 @@ func TestRollupL1UserTxERC20CreateAccountDepositTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20PermitCreateAccountDepositTransfer(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(258)
 	toIdxInt64 := int64(259)
@@ -696,8 +685,7 @@ func TestRollupL1UserTxERC20PermitCreateAccountDepositTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxETHForceTransfer(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(256)
 	toIdxInt64 := int64(257)
@@ -729,8 +717,7 @@ func TestRollupL1UserTxETHForceTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20ForceTransfer(t *testing.T) {
-	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(257)
 	toIdxInt64 := int64(258)
@@ -761,8 +748,7 @@ func TestRollupL1UserTxERC20ForceTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20PermitForceTransfer(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(259)
 	toIdxInt64 := int64(260)
@@ -793,8 +779,7 @@ func TestRollupL1UserTxERC20PermitForceTransfer(t *testing.T) {
 }
 
 func TestRollupL1UserTxETHForceExit(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(256)
 	toIdxInt64 := int64(1)
@@ -826,8 +811,7 @@ func TestRollupL1UserTxETHForceExit(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20ForceExit(t *testing.T) {
-	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux2, err := NewRollupClient(ethereumClientAux2, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(257)
 	toIdxInt64 := int64(1)
@@ -858,8 +842,7 @@ func TestRollupL1UserTxERC20ForceExit(t *testing.T) {
 }
 
 func TestRollupL1UserTxERC20PermitForceExit(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst,
-		tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 	fromIdxInt64 := int64(258)
 	toIdxInt64 := int64(1)
@@ -981,7 +964,7 @@ func TestRollupForgeBatchArgs2(t *testing.T) {
 }
 
 func TestRollupWithdrawMerkleProof(t *testing.T) {
-	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst, tokenHEZ)
+	rollupClientAux, err := NewRollupClient(ethereumClientAux, hermezRollupAddressConst)
 	require.NoError(t, err)
 
 	var pkComp babyjub.PublicKeyComp

--- a/eth/token.go
+++ b/eth/token.go
@@ -1,0 +1,37 @@
+package eth
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	HEZ "github.com/hermeznetwork/hermez-node/eth/contracts/tokenHEZ"
+	"github.com/hermeznetwork/tracerr"
+)
+
+// TokenClient is the implementation of the interface to the Hez Token Smart Contract in ethereum.
+type TokenClient struct {
+	client  *EthereumClient
+	hez     *HEZ.HEZ
+	address ethCommon.Address
+	name    string
+	opts    *bind.CallOpts
+}
+
+// NewTokenClient creates a new TokenClient
+func NewTokenClient(client *EthereumClient, address ethCommon.Address) (*TokenClient, error) {
+	hez, err := HEZ.NewHEZ(address, client.Client())
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	opts := newCallOpts()
+	name, err := hez.Name(opts)
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	return &TokenClient{
+		client:  client,
+		hez:     hez,
+		address: address,
+		name:    name,
+		opts:    opts,
+	}, nil
+}

--- a/node/node.go
+++ b/node/node.go
@@ -194,15 +194,8 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		Rollup: eth.RollupConfig{
 			Address: cfg.SmartContracts.Rollup,
 		},
-		Auction: eth.AuctionConfig{
-			Address: cfg.SmartContracts.Auction,
-			TokenHEZ: eth.TokenConfig{
-				Address: cfg.SmartContracts.TokenHEZ,
-				Name:    cfg.SmartContracts.TokenHEZName,
-			},
-		},
-		WDelayer: eth.WDelayerConfig{
-			Address: cfg.SmartContracts.WDelayer,
+		TokenHEZ: eth.TokenConfig{
+			Name: cfg.SmartContracts.TokenHEZName,
 		},
 	})
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -194,9 +194,6 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		Rollup: eth.RollupConfig{
 			Address: cfg.SmartContracts.Rollup,
 		},
-		TokenHEZ: eth.TokenConfig{
-			Name: cfg.SmartContracts.TokenHEZName,
-		},
 	})
 	if err != nil {
 		return nil, tracerr.Wrap(err)


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #717

### What does this PR does?

Automatically fetch the addresses of the auction, token, and the withdrawal delayer contracts from the Rollup smart contract, for we can avoid setting all in the config file

### How to test?

Run the node in the Rinkeby network

