### PR TITLE
Feature/fastsync make checkpoint

### DIFF
--- a/batchbuilder/batchbuilder.go
+++ b/batchbuilder/batchbuilder.go
@@ -64,7 +64,7 @@ func (bb *BatchBuilder) BuildBatch(coordIdxs []common.Idx, configBatch *ConfigBa
 	bbStateDB := bb.localStateDB.StateDB
 	tp := txprocessor.NewTxProcessor(bbStateDB, configBatch.TxProcessorConfig)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1usertxs, l1coordinatortxs, pooll2txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1usertxs, l1coordinatortxs, pooll2txs, true)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -539,7 +539,7 @@ func TestCoordinatorStress(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		for {
-			blockData, _, err := syn.Sync(ctx, nil)
+			blockData, _, err := syn.Sync(ctx)
 			if ctx.Err() != nil {
 				wg.Done()
 				return

--- a/coordinator/pipeline_test.go
+++ b/coordinator/pipeline_test.go
@@ -150,7 +150,7 @@ func preloadSync(t *testing.T, ethClient *test.Client, sync *synchronizer.Synchr
 
 	ctx := context.Background()
 	for {
-		syncBlock, discards, err := sync.Sync(ctx, nil)
+		syncBlock, discards, err := sync.Sync(ctx)
 		require.NoError(t, err)
 		require.Nil(t, discards)
 		if syncBlock == nil {

--- a/db/kvdb/kvdb.go
+++ b/db/kvdb/kvdb.go
@@ -413,13 +413,14 @@ func (k *KVDB) SetCurrentIdx(idx common.Idx) error {
 	return nil
 }
 
-// MakeCheckpoint does a checkpoint at the given batchNum in the defined path.
-// Internally this advances & stores the current BatchNum, and then stores a
-// Checkpoint of the current state of the k.
-func (k *KVDB) MakeCheckpoint() error {
-	// advance currentBatch
+// AdvanceCurrentBatch advances the current BatchNum
+func (k *KVDB) AdvanceCurrentBatch() {
 	k.CurrentBatch++
+}
 
+// MakeCheckpoint does a checkpoint at the given batchNum in the defined path.
+// Stores a Checkpoint of the current state of the k.
+func (k *KVDB) MakeCheckpoint() error {
 	checkpointPath := path.Join(k.cfg.Path, fmt.Sprintf("%s%d", PathBatchNum, k.CurrentBatch))
 
 	if err := k.setCurrentBatch(); err != nil {
@@ -503,16 +504,6 @@ func (k *KVDB) ListCheckpoints() ([]int, error) {
 		}
 	}
 	sort.Ints(checkpoints)
-	if !k.cfg.NoGapsCheck && len(checkpoints) > 0 {
-		first := checkpoints[0]
-		for _, checkpoint := range checkpoints[1:] {
-			first++
-			if checkpoint != first {
-				log.Errorw("gap between checkpoints", "checkpoints", checkpoints)
-				return nil, tracerr.Wrap(fmt.Errorf("checkpoint gap at %v", checkpoint))
-			}
-		}
-	}
 	return checkpoints, nil
 }
 

--- a/db/kvdb/kvdb_test.go
+++ b/db/kvdb/kvdb_test.go
@@ -60,6 +60,7 @@ func TestCheckpoints(t *testing.T) {
 	}
 
 	// do checkpoints and check that currentBatch is correct
+	db.AdvanceCurrentBatch()
 	err = db.MakeCheckpoint()
 	require.NoError(t, err)
 	cb, err := db.GetCurrentBatch()
@@ -67,6 +68,7 @@ func TestCheckpoints(t *testing.T) {
 	assert.Equal(t, common.BatchNum(1), cb)
 
 	for i := 1; i < 10; i++ {
+		db.AdvanceCurrentBatch()
 		err = db.MakeCheckpoint()
 		require.NoError(t, err)
 
@@ -94,6 +96,7 @@ func TestCheckpoints(t *testing.T) {
 	assert.Equal(t, common.BatchNum(3), cb)
 
 	// advance one checkpoint and check that currentBatch is fine
+	db.AdvanceCurrentBatch()
 	err = db.MakeCheckpoint()
 	require.NoError(t, err)
 	cb, err = db.GetCurrentBatch()
@@ -124,6 +127,7 @@ func TestCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, common.BatchNum(4), cb)
 	// advance one checkpoint in ldb
+	ldb.AdvanceCurrentBatch()
 	err = ldb.MakeCheckpoint()
 	require.NoError(t, err)
 	cb, err = ldb.GetCurrentBatch()
@@ -145,6 +149,7 @@ func TestCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, common.BatchNum(4), cb)
 	// advance one checkpoint in ldb2
+	ldb2.AdvanceCurrentBatch()
 	err = ldb2.MakeCheckpoint()
 	require.NoError(t, err)
 	cb, err = ldb2.GetCurrentBatch()
@@ -174,6 +179,7 @@ func TestListCheckpoints(t *testing.T) {
 	numCheckpoints := 16
 	// do checkpoints
 	for i := 0; i < numCheckpoints; i++ {
+		db.AdvanceCurrentBatch()
 		err = db.MakeCheckpoint()
 		require.NoError(t, err)
 	}
@@ -208,6 +214,7 @@ func TestDeleteOldCheckpoints(t *testing.T) {
 	// do checkpoints and check that we never have more than `keep`
 	// checkpoints
 	for i := 0; i < numCheckpoints; i++ {
+		db.AdvanceCurrentBatch()
 		err = db.MakeCheckpoint()
 		require.NoError(t, err)
 		err = db.DeleteOldCheckpoints()
@@ -238,6 +245,7 @@ func TestConcurrentDeleteOldCheckpoints(t *testing.T) {
 	// checkpoints.
 	// 1 async DeleteOldCheckpoint after 1 MakeCheckpoint
 	for i := 0; i < numCheckpoints; i++ {
+		db.AdvanceCurrentBatch()
 		err = db.MakeCheckpoint()
 		require.NoError(t, err)
 		go func() {
@@ -257,6 +265,7 @@ func TestConcurrentDeleteOldCheckpoints(t *testing.T) {
 	// checkpoints
 	// 32 concurrent DeleteOldCheckpoint after 32 MakeCheckpoint
 	for i := 0; i < numCheckpoints; i++ {
+		db.AdvanceCurrentBatch()
 		err = db.MakeCheckpoint()
 		require.NoError(t, err)
 	}
@@ -297,6 +306,7 @@ func TestGetCurrentIdx(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, common.Idx(255), idx)
 
+	db.AdvanceCurrentBatch()
 	err = db.MakeCheckpoint()
 	require.NoError(t, err)
 

--- a/db/statedb/statedb.go
+++ b/db/statedb/statedb.go
@@ -219,11 +219,17 @@ func (s *StateDB) LastMTGetRoot() (*big.Int, error) {
 	return root, nil
 }
 
+// AdvanceCurrentBatch advances the current BatchNum
+func (s *StateDB) AdvanceCurrentBatch() {
+	log.Debugw("Advancing Current Batch Number", "batch", s.CurrentBatch()+1, "type", s.cfg.Type)
+	s.db.AdvanceCurrentBatch()
+}
+
 // MakeCheckpoint does a checkpoint at the given batchNum in the defined path.
 // Internally this advances & stores the current BatchNum, and then stores a
 // Checkpoint of the current state of the StateDB.
 func (s *StateDB) MakeCheckpoint() error {
-	log.Debugw("Making StateDB checkpoint", "batch", s.CurrentBatch()+1, "type", s.cfg.Type)
+	log.Debugw("Making StateDB checkpoint", "batch", s.CurrentBatch(), "type", s.cfg.Type)
 	return s.db.MakeCheckpoint()
 }
 

--- a/db/statedb/statedb_test.go
+++ b/db/statedb/statedb_test.go
@@ -131,6 +131,7 @@ func TestNewStateDBIntermediateState(t *testing.T) {
 	bn, err := sdb.getCurrentBatch()
 	require.NoError(t, err)
 	assert.Equal(t, common.BatchNum(0), bn)
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.NoError(t, err)
 	bn, err = sdb.getCurrentBatch()
@@ -333,6 +334,7 @@ func TestCheckpoints(t *testing.T) {
 	assert.Equal(t, db.ErrNotFound, tracerr.Unwrap(err))
 
 	// do checkpoints and check that currentBatch is correct
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.NoError(t, err)
 	cb, err := sdb.getCurrentBatch()
@@ -348,6 +350,7 @@ func TestCheckpoints(t *testing.T) {
 	assert.Equal(t, accCur, accLast)
 
 	for i := 1; i < 10; i++ {
+		sdb.AdvanceCurrentBatch()
 		err = sdb.MakeCheckpoint()
 		require.NoError(t, err)
 
@@ -373,6 +376,7 @@ func TestCheckpoints(t *testing.T) {
 	assert.Equal(t, common.BatchNum(3), cb)
 
 	// advance one checkpoint and check that currentBatch is fine
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.NoError(t, err)
 	cb, err = sdb.getCurrentBatch()
@@ -404,6 +408,7 @@ func TestCheckpoints(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, common.BatchNum(4), cb)
 	// advance one checkpoint in ldb
+	ldb.AdvanceCurrentBatch()
 	err = ldb.MakeCheckpoint()
 	require.NoError(t, err)
 	cb, err = ldb.getCurrentBatch()
@@ -425,6 +430,7 @@ func TestCheckpoints(t *testing.T) {
 	cb = ldb2.CurrentBatch()
 	assert.Equal(t, common.BatchNum(4), cb)
 	// advance one checkpoint in ldb2
+	ldb2.AdvanceCurrentBatch()
 	err = ldb2.MakeCheckpoint()
 	require.NoError(t, err)
 	cb = ldb2.CurrentBatch()
@@ -581,6 +587,7 @@ func TestListCheckpoints(t *testing.T) {
 	numCheckpoints := 16
 	// do checkpoints
 	for i := 0; i < numCheckpoints; i++ {
+		sdb.AdvanceCurrentBatch()
 		err = sdb.MakeCheckpoint()
 		require.NoError(t, err)
 	}
@@ -617,6 +624,7 @@ func TestDeleteOldCheckpoints(t *testing.T) {
 	// do checkpoints and check that we never have more than `keep`
 	// checkpoints
 	for i := 0; i < numCheckpoints; i++ {
+		sdb.AdvanceCurrentBatch()
 		err = sdb.MakeCheckpoint()
 		require.NoError(t, err)
 		err := sdb.DeleteOldCheckpoints()
@@ -644,6 +652,7 @@ func TestConcurrentDeleteOldCheckpoints(t *testing.T) {
 	// do checkpoints and check that we never have more than `keep`
 	// checkpoints
 	for i := 0; i < numCheckpoints; i++ {
+		sdb.AdvanceCurrentBatch()
 		err = sdb.MakeCheckpoint()
 		require.NoError(t, err)
 		wg := sync.WaitGroup{}
@@ -691,6 +700,7 @@ func TestCurrentIdx(t *testing.T) {
 	idx = sdb.CurrentIdx()
 	assert.Equal(t, common.Idx(255), idx)
 
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.NoError(t, err)
 
@@ -717,10 +727,13 @@ func TestResetFromBadCheckpoint(t *testing.T) {
 	sdb, err := NewStateDB(Config{Path: dir, Keep: keep, Type: TypeSynchronizer, NLevels: 32})
 	require.NoError(t, err)
 
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.NoError(t, err)
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.NoError(t, err)
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.NoError(t, err)
 

--- a/eth/auction.go
+++ b/eth/auction.go
@@ -871,122 +871,130 @@ func (c *AuctionClient) AuctionEventsByBlock(blockNum int64,
 				vLog.BlockHash.String())
 			return nil, tracerr.Wrap(ErrBlockHashMismatchEvent)
 		}
-		switch vLog.Topics[0] {
-		case logAuctionNewBid:
-			var auxNewBid struct {
-				Slot      *big.Int
-				BidAmount *big.Int
-				Address   ethCommon.Address
-			}
-			var newBid AuctionEventNewBid
-			if err := c.contractAbi.UnpackIntoInterface(&auxNewBid, "NewBid",
-				vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			newBid.BidAmount = auxNewBid.BidAmount
-			newBid.Slot = new(big.Int).SetBytes(vLog.Topics[1][:]).Int64()
-			newBid.Bidder = ethCommon.BytesToAddress(vLog.Topics[2].Bytes())
-			auctionEvents.NewBid = append(auctionEvents.NewBid, newBid)
-		case logAuctionNewSlotDeadline:
-			var newSlotDeadline AuctionEventNewSlotDeadline
-			if err := c.contractAbi.UnpackIntoInterface(&newSlotDeadline,
-				"NewSlotDeadline", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			auctionEvents.NewSlotDeadline = append(auctionEvents.NewSlotDeadline, newSlotDeadline)
-		case logAuctionNewClosedAuctionSlots:
-			var newClosedAuctionSlots AuctionEventNewClosedAuctionSlots
-			if err := c.contractAbi.UnpackIntoInterface(&newClosedAuctionSlots,
-				"NewClosedAuctionSlots", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			auctionEvents.NewClosedAuctionSlots =
-				append(auctionEvents.NewClosedAuctionSlots, newClosedAuctionSlots)
-		case logAuctionNewOutbidding:
-			var newOutbidding AuctionEventNewOutbidding
-			if err := c.contractAbi.UnpackIntoInterface(&newOutbidding, "NewOutbidding",
-				vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			auctionEvents.NewOutbidding = append(auctionEvents.NewOutbidding, newOutbidding)
-		case logAuctionNewDonationAddress:
-			var newDonationAddress AuctionEventNewDonationAddress
-			newDonationAddress.NewDonationAddress = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
-			auctionEvents.NewDonationAddress = append(auctionEvents.NewDonationAddress,
-				newDonationAddress)
-		case logAuctionNewBootCoordinator:
-			var newBootCoordinator AuctionEventNewBootCoordinator
-			if err := c.contractAbi.UnpackIntoInterface(&newBootCoordinator,
-				"NewBootCoordinator", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			newBootCoordinator.NewBootCoordinator = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
-			auctionEvents.NewBootCoordinator = append(auctionEvents.NewBootCoordinator,
-				newBootCoordinator)
-		case logAuctionNewOpenAuctionSlots:
-			var newOpenAuctionSlots AuctionEventNewOpenAuctionSlots
-			if err := c.contractAbi.UnpackIntoInterface(&newOpenAuctionSlots,
-				"NewOpenAuctionSlots", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			auctionEvents.NewOpenAuctionSlots =
-				append(auctionEvents.NewOpenAuctionSlots, newOpenAuctionSlots)
-		case logAuctionNewAllocationRatio:
-			var newAllocationRatio AuctionEventNewAllocationRatio
-			if err := c.contractAbi.UnpackIntoInterface(&newAllocationRatio,
-				"NewAllocationRatio", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			auctionEvents.NewAllocationRatio = append(auctionEvents.NewAllocationRatio,
-				newAllocationRatio)
-		case logAuctionSetCoordinator:
-			var setCoordinator AuctionEventSetCoordinator
-			if err := c.contractAbi.UnpackIntoInterface(&setCoordinator,
-				"SetCoordinator", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			setCoordinator.BidderAddress = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
-			setCoordinator.ForgerAddress = ethCommon.BytesToAddress(vLog.Topics[2].Bytes())
-			auctionEvents.SetCoordinator = append(auctionEvents.SetCoordinator, setCoordinator)
-		case logAuctionNewForgeAllocated:
-			var newForgeAllocated AuctionEventNewForgeAllocated
-			if err := c.contractAbi.UnpackIntoInterface(&newForgeAllocated,
-				"NewForgeAllocated", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			newForgeAllocated.Bidder = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
-			newForgeAllocated.Forger = ethCommon.BytesToAddress(vLog.Topics[2].Bytes())
-			newForgeAllocated.SlotToForge = new(big.Int).SetBytes(vLog.Topics[3][:]).Int64()
-			auctionEvents.NewForgeAllocated = append(auctionEvents.NewForgeAllocated,
-				newForgeAllocated)
-		case logAuctionNewDefaultSlotSetBid:
-			var auxNewDefaultSlotSetBid struct {
-				SlotSet          *big.Int
-				NewInitialMinBid *big.Int
-			}
-			var newDefaultSlotSetBid AuctionEventNewDefaultSlotSetBid
-			if err := c.contractAbi.UnpackIntoInterface(&auxNewDefaultSlotSetBid,
-				"NewDefaultSlotSetBid", vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			newDefaultSlotSetBid.NewInitialMinBid = auxNewDefaultSlotSetBid.NewInitialMinBid
-			newDefaultSlotSetBid.SlotSet = auxNewDefaultSlotSetBid.SlotSet.Int64()
-			auctionEvents.NewDefaultSlotSetBid =
-				append(auctionEvents.NewDefaultSlotSetBid, newDefaultSlotSetBid)
-		case logAuctionNewForge:
-			var newForge AuctionEventNewForge
-			newForge.Forger = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
-			newForge.SlotToForge = new(big.Int).SetBytes(vLog.Topics[2][:]).Int64()
-			auctionEvents.NewForge = append(auctionEvents.NewForge, newForge)
-		case logAuctionHEZClaimed:
-			var HEZClaimed AuctionEventHEZClaimed
-			if err := c.contractAbi.UnpackIntoInterface(&HEZClaimed, "HEZClaimed",
-				vLog.Data); err != nil {
-				return nil, tracerr.Wrap(err)
-			}
-			HEZClaimed.Owner = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
-			auctionEvents.HEZClaimed = append(auctionEvents.HEZClaimed, HEZClaimed)
+		err = c.processAuctionEvent(&vLog, &auctionEvents)
+		if err != nil {
+			return nil, tracerr.Wrap(err)
 		}
 	}
 	return &auctionEvents, nil
+}
+
+func (c *AuctionClient) processAuctionEvent(vLog *types.Log, auctionEvents *AuctionEvents) error {
+	switch vLog.Topics[0] {
+	case logAuctionNewBid:
+		var auxNewBid struct {
+			Slot      *big.Int
+			BidAmount *big.Int
+			Address   ethCommon.Address
+		}
+		var newBid AuctionEventNewBid
+		if err := c.contractAbi.UnpackIntoInterface(&auxNewBid, "NewBid",
+			vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		newBid.BidAmount = auxNewBid.BidAmount
+		newBid.Slot = new(big.Int).SetBytes(vLog.Topics[1][:]).Int64()
+		newBid.Bidder = ethCommon.BytesToAddress(vLog.Topics[2].Bytes())
+		auctionEvents.NewBid = append(auctionEvents.NewBid, newBid)
+	case logAuctionNewSlotDeadline:
+		var newSlotDeadline AuctionEventNewSlotDeadline
+		if err := c.contractAbi.UnpackIntoInterface(&newSlotDeadline,
+			"NewSlotDeadline", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		auctionEvents.NewSlotDeadline = append(auctionEvents.NewSlotDeadline, newSlotDeadline)
+	case logAuctionNewClosedAuctionSlots:
+		var newClosedAuctionSlots AuctionEventNewClosedAuctionSlots
+		if err := c.contractAbi.UnpackIntoInterface(&newClosedAuctionSlots,
+			"NewClosedAuctionSlots", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		auctionEvents.NewClosedAuctionSlots =
+			append(auctionEvents.NewClosedAuctionSlots, newClosedAuctionSlots)
+	case logAuctionNewOutbidding:
+		var newOutbidding AuctionEventNewOutbidding
+		if err := c.contractAbi.UnpackIntoInterface(&newOutbidding, "NewOutbidding",
+			vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		auctionEvents.NewOutbidding = append(auctionEvents.NewOutbidding, newOutbidding)
+	case logAuctionNewDonationAddress:
+		var newDonationAddress AuctionEventNewDonationAddress
+		newDonationAddress.NewDonationAddress = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
+		auctionEvents.NewDonationAddress = append(auctionEvents.NewDonationAddress,
+			newDonationAddress)
+	case logAuctionNewBootCoordinator:
+		var newBootCoordinator AuctionEventNewBootCoordinator
+		if err := c.contractAbi.UnpackIntoInterface(&newBootCoordinator,
+			"NewBootCoordinator", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		newBootCoordinator.NewBootCoordinator = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
+		auctionEvents.NewBootCoordinator = append(auctionEvents.NewBootCoordinator,
+			newBootCoordinator)
+	case logAuctionNewOpenAuctionSlots:
+		var newOpenAuctionSlots AuctionEventNewOpenAuctionSlots
+		if err := c.contractAbi.UnpackIntoInterface(&newOpenAuctionSlots,
+			"NewOpenAuctionSlots", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		auctionEvents.NewOpenAuctionSlots =
+			append(auctionEvents.NewOpenAuctionSlots, newOpenAuctionSlots)
+	case logAuctionNewAllocationRatio:
+		var newAllocationRatio AuctionEventNewAllocationRatio
+		if err := c.contractAbi.UnpackIntoInterface(&newAllocationRatio,
+			"NewAllocationRatio", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		auctionEvents.NewAllocationRatio = append(auctionEvents.NewAllocationRatio,
+			newAllocationRatio)
+	case logAuctionSetCoordinator:
+		var setCoordinator AuctionEventSetCoordinator
+		if err := c.contractAbi.UnpackIntoInterface(&setCoordinator,
+			"SetCoordinator", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		setCoordinator.BidderAddress = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
+		setCoordinator.ForgerAddress = ethCommon.BytesToAddress(vLog.Topics[2].Bytes())
+		auctionEvents.SetCoordinator = append(auctionEvents.SetCoordinator, setCoordinator)
+	case logAuctionNewForgeAllocated:
+		var newForgeAllocated AuctionEventNewForgeAllocated
+		if err := c.contractAbi.UnpackIntoInterface(&newForgeAllocated,
+			"NewForgeAllocated", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		newForgeAllocated.Bidder = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
+		newForgeAllocated.Forger = ethCommon.BytesToAddress(vLog.Topics[2].Bytes())
+		newForgeAllocated.SlotToForge = new(big.Int).SetBytes(vLog.Topics[3][:]).Int64()
+		auctionEvents.NewForgeAllocated = append(auctionEvents.NewForgeAllocated,
+			newForgeAllocated)
+	case logAuctionNewDefaultSlotSetBid:
+		var auxNewDefaultSlotSetBid struct {
+			SlotSet          *big.Int
+			NewInitialMinBid *big.Int
+		}
+		var newDefaultSlotSetBid AuctionEventNewDefaultSlotSetBid
+		if err := c.contractAbi.UnpackIntoInterface(&auxNewDefaultSlotSetBid,
+			"NewDefaultSlotSetBid", vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		newDefaultSlotSetBid.NewInitialMinBid = auxNewDefaultSlotSetBid.NewInitialMinBid
+		newDefaultSlotSetBid.SlotSet = auxNewDefaultSlotSetBid.SlotSet.Int64()
+		auctionEvents.NewDefaultSlotSetBid =
+			append(auctionEvents.NewDefaultSlotSetBid, newDefaultSlotSetBid)
+	case logAuctionNewForge:
+		var newForge AuctionEventNewForge
+		newForge.Forger = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
+		newForge.SlotToForge = new(big.Int).SetBytes(vLog.Topics[2][:]).Int64()
+		auctionEvents.NewForge = append(auctionEvents.NewForge, newForge)
+	case logAuctionHEZClaimed:
+		var HEZClaimed AuctionEventHEZClaimed
+		if err := c.contractAbi.UnpackIntoInterface(&HEZClaimed, "HEZClaimed",
+			vLog.Data); err != nil {
+			return tracerr.Wrap(err)
+		}
+		HEZClaimed.Owner = ethCommon.BytesToAddress(vLog.Topics[1].Bytes())
+		auctionEvents.HEZClaimed = append(auctionEvents.HEZClaimed, HEZClaimed)
+	}
+	return nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -696,23 +696,20 @@ func (n *Node) handleReorg(ctx context.Context, stats *synchronizer.Stats,
 	return nil
 }
 
-// TODO(Edu): Consider keeping the `lastBlock` inside synchronizer so that we
-// don't have to pass it around.
-func (n *Node) syncLoopFn(ctx context.Context, lastBlock *common.Block) (*common.Block,
-	time.Duration, error) {
-	blockData, discarded, err := n.sync.Sync(ctx, lastBlock)
+func (n *Node) syncLoopFn(ctx context.Context) (time.Duration, error) {
+	blockData, discarded, err := n.sync.Sync(ctx)
 	stats := n.sync.Stats()
 	if err != nil {
 		// case: error
-		return nil, n.cfg.Synchronizer.SyncLoopInterval.Duration, tracerr.Wrap(err)
+		return n.cfg.Synchronizer.SyncLoopInterval.Duration, tracerr.Wrap(err)
 	} else if discarded != nil {
 		// case: reorg
 		log.Infow("Synchronizer.Sync reorg", "discarded", *discarded)
 		vars := n.sync.SCVars()
 		if err := n.handleReorg(ctx, stats, vars); err != nil {
-			return nil, time.Duration(0), tracerr.Wrap(err)
+			return time.Duration(0), tracerr.Wrap(err)
 		}
-		return nil, time.Duration(0), nil
+		return time.Duration(0), nil
 	} else if blockData != nil {
 		// case: new block
 		vars := common.SCVariablesPtr{
@@ -721,12 +718,12 @@ func (n *Node) syncLoopFn(ctx context.Context, lastBlock *common.Block) (*common
 			WDelayer: blockData.WDelayer.Vars,
 		}
 		if err := n.handleNewBlock(ctx, stats, &vars, blockData.Rollup.Batches); err != nil {
-			return nil, time.Duration(0), tracerr.Wrap(err)
+			return time.Duration(0), tracerr.Wrap(err)
 		}
-		return &blockData.Block, time.Duration(0), nil
+		return time.Duration(0), nil
 	} else {
 		// case: no block
-		return lastBlock, n.cfg.Synchronizer.SyncLoopInterval.Duration, nil
+		return n.cfg.Synchronizer.SyncLoopInterval.Duration, nil
 	}
 }
 
@@ -748,7 +745,6 @@ func (n *Node) StartSynchronizer() {
 	n.wg.Add(1)
 	go func() {
 		var err error
-		var lastBlock *common.Block
 		waitDuration := time.Duration(0)
 		for {
 			select {
@@ -757,8 +753,7 @@ func (n *Node) StartSynchronizer() {
 				n.wg.Done()
 				return
 			case <-time.After(waitDuration):
-				if lastBlock, waitDuration, err = n.syncLoopFn(n.ctx,
-					lastBlock); err != nil {
+				if waitDuration, err = n.syncLoopFn(n.ctx); err != nil {
 					if n.ctx.Err() != nil {
 						continue
 					}

--- a/synchronizer/synchronizer_test.go
+++ b/synchronizer/synchronizer_test.go
@@ -370,7 +370,7 @@ func TestSyncGeneral(t *testing.T) {
 	assert.Equal(t, false, stats.Synced())
 
 	// Test Sync for rollup genesis block
-	syncBlock, discards, err := s.Sync(ctx, nil)
+	syncBlock, discards, err := s.Sync(ctx)
 	require.NoError(t, err)
 	require.Nil(t, discards)
 	require.NotNil(t, syncBlock)
@@ -393,7 +393,7 @@ func TestSyncGeneral(t *testing.T) {
 	assert.Equal(t, int64(1), dbBlocks[1].Num)
 
 	// Sync again and expect no new blocks
-	syncBlock, discards, err = s.Sync(ctx, nil)
+	syncBlock, discards, err = s.Sync(ctx)
 	require.NoError(t, err)
 	require.Nil(t, discards)
 	require.Nil(t, syncBlock)
@@ -490,7 +490,7 @@ func TestSyncGeneral(t *testing.T) {
 
 	// Block 2
 
-	syncBlock, discards, err = s.Sync(ctx, nil)
+	syncBlock, discards, err = s.Sync(ctx)
 	require.NoError(t, err)
 	require.Nil(t, discards)
 	require.NotNil(t, syncBlock)
@@ -507,7 +507,7 @@ func TestSyncGeneral(t *testing.T) {
 
 	// Block 3
 
-	syncBlock, discards, err = s.Sync(ctx, nil)
+	syncBlock, discards, err = s.Sync(ctx)
 	assert.NoError(t, err)
 	require.NoError(t, err)
 	require.Nil(t, discards)
@@ -533,7 +533,7 @@ func TestSyncGeneral(t *testing.T) {
 	require.NoError(t, err)
 	client.CtlMineBlock()
 
-	syncBlock, discards, err = s.Sync(ctx, nil)
+	syncBlock, discards, err = s.Sync(ctx)
 	require.NoError(t, err)
 	require.Nil(t, discards)
 	require.NotNil(t, syncBlock)
@@ -584,7 +584,7 @@ func TestSyncGeneral(t *testing.T) {
 
 	client.CtlMineBlock()
 
-	syncBlock, discards, err = s.Sync(ctx, nil)
+	syncBlock, discards, err = s.Sync(ctx)
 	require.NoError(t, err)
 	require.Nil(t, discards)
 	require.NotNil(t, syncBlock)
@@ -669,7 +669,7 @@ func TestSyncGeneral(t *testing.T) {
 	require.NoError(t, err)
 
 	// First sync detects the reorg and discards 4 blocks
-	syncBlock, discards, err = s.Sync(ctx, nil)
+	syncBlock, discards, err = s.Sync(ctx)
 	require.NoError(t, err)
 	expetedDiscards := int64(4)
 	require.Equal(t, &expetedDiscards, discards)
@@ -697,7 +697,7 @@ func TestSyncGeneral(t *testing.T) {
 
 	// Sync blocks 2-6
 	for i := 0; i < 5; i++ {
-		syncBlock, discards, err = s.Sync(ctx, nil)
+		syncBlock, discards, err = s.Sync(ctx)
 		require.NoError(t, err)
 		require.Nil(t, discards)
 		require.NotNil(t, syncBlock)
@@ -823,7 +823,7 @@ func TestSyncForgerCommitment(t *testing.T) {
 
 	// be in sync
 	for {
-		syncBlock, discards, err := s.Sync(ctx, nil)
+		syncBlock, discards, err := s.Sync(ctx)
 		require.NoError(t, err)
 		require.Nil(t, discards)
 		if syncBlock == nil {
@@ -842,7 +842,7 @@ func TestSyncForgerCommitment(t *testing.T) {
 		err = client.CtlAddBlocks([]common.BlockData{block})
 		require.NoError(t, err)
 
-		syncBlock, discards, err := s.Sync(ctx, nil)
+		syncBlock, discards, err := s.Sync(ctx)
 		require.NoError(t, err)
 		require.Nil(t, discards)
 		if syncBlock == nil {

--- a/test/debugapi/debugapi_test.go
+++ b/test/debugapi/debugapi_test.go
@@ -48,6 +48,7 @@ func TestDebugAPI(t *testing.T) {
 	sdb, err := statedb.NewStateDB(statedb.Config{Path: dir, Keep: 128,
 		Type: statedb.TypeSynchronizer, NLevels: 32})
 	require.Nil(t, err)
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint() // Make a checkpoint to increment the batchNum
 	require.Nil(t, err)
 
@@ -69,6 +70,7 @@ func TestDebugAPI(t *testing.T) {
 		require.Nil(t, err)
 	}
 	// Make a checkpoint (batchNum 2) to make the accounts available in Last
+	sdb.AdvanceCurrentBatch()
 	err = sdb.MakeCheckpoint()
 	require.Nil(t, err)
 

--- a/test/ethclient.go
+++ b/test/ethclient.go
@@ -1142,6 +1142,12 @@ func (c *Client) RollupEventsByBlock(blockNum int64,
 	return &block.Rollup.Events, nil
 }
 
+// RollupEventsByBlockRange returns the events in a block range that happened in the Rollup Smart Contract
+func (c *Client) RollupEventsByBlockRange(fromBlock int64, toBlock int64) (eth.RollupEventsByBlockNumMap, error) {
+	// TODO: return range!!!
+	return nil, tracerr.Wrap(fmt.Errorf("not implemented"))
+}
+
 // RollupEventInit returns the initialize event with its corresponding block number
 func (c *Client) RollupEventInit(genesisBlockNum int64) (*eth.RollupEventInitialize, int64, error) {
 	vars := c.blocks[0].Rollup.Vars
@@ -1618,6 +1624,12 @@ func (c *Client) AuctionEventsByBlock(blockNum int64,
 	return &block.Auction.Events, nil
 }
 
+// AuctionEventsByBlockRange returns the events in a block range that happened in the Auction Smart Contract
+func (c *Client) AuctionEventsByBlockRange(fromBlock int64, toBlock int64) (eth.AuctionEventsByBlockNumMap, error) {
+	// TODO: return range!!!
+	return nil, tracerr.Wrap(fmt.Errorf("not implemented"))
+}
+
 // AuctionEventInit returns the initialize event with its corresponding block number
 func (c *Client) AuctionEventInit(genesisBlockNum int64) (*eth.AuctionEventInitialize, int64, error) {
 	vars := c.blocks[0].Auction.Vars
@@ -1843,6 +1855,12 @@ func (c *Client) WDelayerEventsByBlock(blockNum int64,
 			blockHash, block.Eth.Hash))
 	}
 	return &block.WDelayer.Events, nil
+}
+
+// WDelayerEventsByBlockRange returns the events in a block range that happened in the WDelayer Contract
+func (c *Client) WDelayerEventsByBlockRange(fromBlock int64, toBlock int64) (eth.WDelayerEventsByBlockNumMap, error) {
+	// TODO: return range!!!
+	return nil, tracerr.Wrap(fmt.Errorf("not implemented"))
 }
 
 // WDelayerConstants returns the Constants of the WDelayer Contract

--- a/test/zkproof/zkproof_test.go
+++ b/test/zkproof/zkproof_test.go
@@ -92,21 +92,21 @@ func TestZKInputsEmpty(t *testing.T) {
 	l1UserTxs := []common.L1Tx{}
 	l1CoordTxs := []common.L1Tx{}
 	l2Txs := []common.PoolL2Tx{}
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs) // test empty batch ZKInputs
 
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs = txsets.GenerateTxsZKInputs0(t, ChainID)
 
-	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	coordIdxs = []common.Idx{}
 	l1UserTxs = []common.L1Tx{}
 	l1CoordTxs = []common.L1Tx{}
 	l2Txs = []common.PoolL2Tx{}
-	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 	sendProofAndCheckResp(t, ptOut.ZKInputs) // test empty batch ZKInputs after a non-empty batch
 
@@ -119,7 +119,7 @@ func TestZKInputs0(t *testing.T) {
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs := txsets.GenerateTxsZKInputs0(t, ChainID)
 
 	tp := txprocessor.NewTxProcessor(sdb, txprocConfig)
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -132,7 +132,7 @@ func TestZKInputs1(t *testing.T) {
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs := txsets.GenerateTxsZKInputs1(t, ChainID)
 
 	tp := txprocessor.NewTxProcessor(sdb, txprocConfig)
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -145,7 +145,7 @@ func TestZKInputs2(t *testing.T) {
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs := txsets.GenerateTxsZKInputs2(t, ChainID)
 
 	tp := txprocessor.NewTxProcessor(sdb, txprocConfig)
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -158,7 +158,7 @@ func TestZKInputs3(t *testing.T) {
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs := txsets.GenerateTxsZKInputs3(t, ChainID)
 
 	tp := txprocessor.NewTxProcessor(sdb, txprocConfig)
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -171,7 +171,7 @@ func TestZKInputs4(t *testing.T) {
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs := txsets.GenerateTxsZKInputs4(t, ChainID)
 
 	tp := txprocessor.NewTxProcessor(sdb, txprocConfig)
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -185,7 +185,7 @@ func TestZKInputs5(t *testing.T) {
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs := txsets.GenerateTxsZKInputs5(t, ChainID)
 
 	tp := txprocessor.NewTxProcessor(sdb, txprocConfig)
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -206,7 +206,7 @@ func TestZKInputs6(t *testing.T) {
 
 	tp := txprocessor.NewTxProcessor(sdb, txprocConfig)
 	// batch1
-	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil)
+	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -214,7 +214,7 @@ func TestZKInputs6(t *testing.T) {
 	// batch2
 	l1UserTxs := []common.L1Tx{}
 	l2Txs := common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -222,7 +222,7 @@ func TestZKInputs6(t *testing.T) {
 	// batch3
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[2].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[2].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -230,7 +230,7 @@ func TestZKInputs6(t *testing.T) {
 	// batch4
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[3].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[3].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -238,7 +238,7 @@ func TestZKInputs6(t *testing.T) {
 	// batch5
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[4].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[4].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[4].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[4].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -246,7 +246,7 @@ func TestZKInputs6(t *testing.T) {
 	// batch6
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[5].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[5].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[5].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[5].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -265,7 +265,7 @@ func TestZKInputs6(t *testing.T) {
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[6].Batch.ForgeL1TxsNum])
 	l2Txs = poolL2Txs
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[0].Rollup.Batches[6].L1CoordinatorTxs, l2Txs)
+		blocks[0].Rollup.Batches[6].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -284,7 +284,7 @@ func TestZKInputs6(t *testing.T) {
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[7].Batch.ForgeL1TxsNum])
 	l2Txs = poolL2Txs
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[0].Rollup.Batches[7].L1CoordinatorTxs, l2Txs)
+		blocks[0].Rollup.Batches[7].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -302,7 +302,7 @@ func TestZKInputs6(t *testing.T) {
 	l2Txs = poolL2Txs
 	coordIdxs = []common.Idx{262}
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs)
+		blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)
@@ -312,7 +312,7 @@ func TestZKInputs6(t *testing.T) {
 	l2Txs = []common.PoolL2Tx{}
 	coordIdxs = []common.Idx{}
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	sendProofAndCheckResp(t, ptOut.ZKInputs)

--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -185,10 +185,13 @@ func (tp *TxProcessor) resetZKInputs() {
 // And if TypeSynchronizer returns an array of common.Account with all the
 // created accounts.
 func (tp *TxProcessor) ProcessTxs(coordIdxs []common.Idx, l1usertxs, l1coordinatortxs []common.L1Tx,
-	l2txs []common.PoolL2Tx) (ptOut *ProcessTxOutput, err error) {
+	l2txs []common.PoolL2Tx, makeCheckpoint bool) (ptOut *ProcessTxOutput, err error) {
 	defer func() {
 		if err == nil {
-			err = tp.s.MakeCheckpoint()
+			tp.s.AdvanceCurrentBatch()
+			if makeCheckpoint {
+				err = tp.s.MakeCheckpoint()
+			}
 		}
 	}()
 

--- a/txprocessor/txprocessor_test.go
+++ b/txprocessor/txprocessor_test.go
@@ -77,7 +77,7 @@ func TestComputeEffectiveAmounts(t *testing.T) {
 		ChainID:  chainID,
 	}
 	tp := NewTxProcessor(sdb, config)
-	_, err = tp.ProcessTxs(nil, blocks[0].Rollup.L1UserTxs, nil, nil)
+	_, err = tp.ProcessTxs(nil, blocks[0].Rollup.L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 
 	tx := common.L1Tx{
@@ -248,21 +248,21 @@ func TestProcessTxsBalances(t *testing.T) {
 	tp := NewTxProcessor(sdb, config)
 
 	log.Debug("block:0 batch:1, only L1CoordinatorTxs")
-	_, err = tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil)
+	_, err = tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t, "0", tp.s.MT.Root().BigInt().String())
 
 	log.Debug("block:0 batch:2")
 	l1UserTxs := []common.L1Tx{}
 	l2Txs := common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
-	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t, "0", tp.s.MT.Root().BigInt().String())
 
 	log.Debug("block:0 batch:3")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[2].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[2].L2Txs)
-	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "A", 0, "500")
 	assert.Equal(t,
@@ -272,7 +272,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	log.Debug("block:0 batch:4")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[3].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[3].L2Txs)
-	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "A", 0, "500")
 	checkBalance(t, tc, sdb, "A", 1, "500")
@@ -283,7 +283,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	log.Debug("block:0 batch:5")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[4].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[4].L2Txs)
-	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[4].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[4].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "A", 0, "500")
 	checkBalance(t, tc, sdb, "A", 1, "500")
@@ -294,7 +294,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	log.Debug("block:0 batch:6")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[5].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[5].L2Txs)
-	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[5].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[5].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "A", 0, "600")
 	checkBalance(t, tc, sdb, "A", 1, "500")
@@ -307,7 +307,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	log.Debug("block:0 batch:7")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[6].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[6].L2Txs)
-	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[0].Rollup.Batches[6].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[0].Rollup.Batches[6].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "Coord", 0, "10")
 	checkBalance(t, tc, sdb, "Coord", 1, "20")
@@ -324,7 +324,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	log.Debug("block:0 batch:8")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[7].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[7].L2Txs)
-	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[0].Rollup.Batches[7].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[0].Rollup.Batches[7].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "Coord", 0, "35")
 	checkBalance(t, tc, sdb, "Coord", 1, "30")
@@ -343,7 +343,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	log.Debug("block:1 batch:1")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[1].Rollup.Batches[0].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[1].Rollup.Batches[0].L2Txs)
-	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "Coord", 1, "30")
 	checkBalance(t, tc, sdb, "Coord", 0, "35")
@@ -362,7 +362,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	log.Debug("block:1 batch:2")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[1].Rollup.Batches[1].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[1].Rollup.Batches[1].L2Txs)
-	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"20375835796927052406196249140510136992262283055544831070430919054949353249481",
@@ -372,7 +372,7 @@ func TestProcessTxsBalances(t *testing.T) {
 	poolL2Txs, err := tc.GeneratePoolL2Txs(txsets.SetPoolL2MinimumFlow1)
 	assert.NoError(t, err)
 
-	_, err = tp.ProcessTxs(coordIdxs, []common.L1Tx{}, []common.L1Tx{}, poolL2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, []common.L1Tx{}, []common.L1Tx{}, poolL2Txs, true)
 	require.NoError(t, err)
 	checkBalance(t, tc, sdb, "Coord", 1, "30")
 	checkBalance(t, tc, sdb, "Coord", 0, "35")
@@ -430,7 +430,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	// Process the 1st batch, which contains the L1CoordinatorTxs necessary
 	// to create the Coordinator accounts to receive the fees
 	log.Debug("block:0 batch:1, only L1CoordinatorTxs")
-	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil)
+	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t, 4, len(ptOut.CreatedAccounts))
 	assert.Equal(t, 0, len(ptOut.CollectedFees))
@@ -438,7 +438,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	log.Debug("block:0 batch:2")
 	l2Txs := common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
 	ptOut, err = tp.ProcessTxs(coordIdxs, blocks[0].Rollup.L1UserTxs,
-		blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+		blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(ptOut.ExitInfos))
 	assert.Equal(t, 31, len(ptOut.CreatedAccounts))
@@ -453,7 +453,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 
 	log.Debug("block:0 batch:3")
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[2].L2Txs)
-	ptOut, err = tp.ProcessTxs(coordIdxs, nil, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(coordIdxs, nil, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(ptOut.ExitInfos))
 	assert.Equal(t, 0, len(ptOut.CreatedAccounts))
@@ -473,7 +473,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	assert.Equal(t, common.Nonce(0), l2Txs[1].Nonce)
 	assert.Equal(t, common.Nonce(0), l2Txs[2].Nonce)
 
-	ptOut, err = tp.ProcessTxs(coordIdxs, nil, blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(coordIdxs, nil, blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// after processing expect l2Txs[0:2].Nonce!=0 and has expected value
@@ -495,7 +495,7 @@ func TestProcessTxsSynchronizer(t *testing.T) {
 	log.Debug("block:1 batch:2")
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[1].Rollup.Batches[1].L2Txs)
 	ptOut, err = tp.ProcessTxs(coordIdxs, blocks[1].Rollup.L1UserTxs,
-		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	// 1, as previous batch was without L1UserTxs, and has pending the
 	// 'ForceExit(1) A: 5', and the 2 exit transactions get grouped under 1
@@ -557,7 +557,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 	// Process the 1st batch, which contains the L1CoordinatorTxs necessary
 	// to create the Coordinator accounts to receive the fees
 	log.Debug("block:0 batch:1, only L1CoordinatorTxs")
-	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil)
+	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil, true)
 	require.NoError(t, err)
 	// expect 0 at CreatedAccount, as is only computed when StateDB.Type==TypeSynchronizer
 	assert.Equal(t, 0, len(ptOut.CreatedAccounts))
@@ -565,7 +565,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 	log.Debug("block:0 batch:2")
 	l2Txs := common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
 	ptOut, err = tp.ProcessTxs(coordIdxs, blocks[0].Rollup.L1UserTxs,
-		blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+		blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(ptOut.ExitInfos))
 	assert.Equal(t, 0, len(ptOut.CreatedAccounts))
@@ -575,7 +575,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 
 	log.Debug("block:0 batch:3")
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[2].L2Txs)
-	ptOut, err = tp.ProcessTxs(coordIdxs, nil, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(coordIdxs, nil, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(ptOut.ExitInfos))
 	assert.Equal(t, 0, len(ptOut.CreatedAccounts))
@@ -585,7 +585,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 
 	log.Debug("block:1 batch:1")
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[1].Rollup.Batches[0].L2Txs)
-	_, err = tp.ProcessTxs(coordIdxs, nil, blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, nil, blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	acc, err = sdb.GetAccount(idxA1)
 	require.NoError(t, err)
@@ -594,7 +594,7 @@ func TestProcessTxsBatchBuilder(t *testing.T) {
 	log.Debug("block:1 batch:2")
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[1].Rollup.Batches[1].L2Txs)
 	_, err = tp.ProcessTxs(coordIdxs, blocks[1].Rollup.L1UserTxs,
-		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	acc, err = sdb.GetAccount(idxA1)
 	assert.NoError(t, err)
@@ -669,7 +669,7 @@ func TestProcessTxsRootTestVectors(t *testing.T) {
 		ChainID:  chainID,
 	}
 	tp := NewTxProcessor(sdb, config)
-	_, err = tp.ProcessTxs(nil, l1Txs, nil, l2Txs)
+	_, err = tp.ProcessTxs(nil, l1Txs, nil, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"16181420716631932805604732887923905079487577323947343079740042260791593140221",
@@ -736,7 +736,7 @@ func TestCreateAccountDepositMaxValue(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	_, err = tp.ProcessTxs(nil, l1Txs, nil, nil)
+	_, err = tp.ProcessTxs(nil, l1Txs, nil, nil, true)
 	require.NoError(t, err)
 
 	// check balances
@@ -792,7 +792,7 @@ func initTestMultipleCoordIdxForTokenID(t *testing.T) (*TxProcessor, *til.Contex
 	}
 	tp := NewTxProcessor(sdb, config)
 	// batch1
-	_, err = tp.ProcessTxs(nil, nil, nil, nil) // to simulate the first batch from the Til set
+	_, err = tp.ProcessTxs(nil, nil, nil, nil, true) // to simulate the first batch from the Til set
 	require.NoError(t, err)
 
 	return tp, tc, blocks, sdb
@@ -808,7 +808,7 @@ func TestMultipleCoordIdxForTokenID(t *testing.T) {
 	l1CoordTxs := blocks[0].Rollup.Batches[1].L1CoordinatorTxs
 	l1CoordTxs = append(l1CoordTxs, l1CoordTxs[0]) // duplicate the CoordAccount for TokenID=0
 	l2Txs := common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
-	_, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	_, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	checkBalanceByIdx(t, tp.s, 256, "90")  // A
@@ -824,7 +824,7 @@ func TestMultipleCoordIdxForTokenID(t *testing.T) {
 	l1CoordTxs = blocks[0].Rollup.Batches[1].L1CoordinatorTxs
 	l1CoordTxs = append(l1CoordTxs, l1CoordTxs[0]) // duplicate the CoordAccount for TokenID=0
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
-	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	checkBalanceByIdx(t, tp.s, 256, "90")  // A
@@ -840,7 +840,7 @@ func TestMultipleCoordIdxForTokenID(t *testing.T) {
 	l1CoordTxs = blocks[0].Rollup.Batches[1].L1CoordinatorTxs
 	l1CoordTxs = append(l1CoordTxs, l1CoordTxs[0]) // duplicate the CoordAccount for TokenID=0
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
-	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	_, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	checkBalanceByIdx(t, tp.s, 256, "90")  // A
@@ -908,7 +908,7 @@ func testTwoExits(t *testing.T, stateDBType statedb.TypeStateDB) ([]*ProcessTxOu
 	ptOuts := []*ProcessTxOutput{}
 	for _, block := range blocks {
 		for _, batch := range block.Rollup.Batches {
-			ptOut, err := tp.ProcessTxs(nil, batch.L1UserTxs, nil, nil)
+			ptOut, err := tp.ProcessTxs(nil, batch.L1UserTxs, nil, nil, true)
 			require.NoError(t, err)
 			ptOuts = append(ptOuts, ptOut)
 		}
@@ -960,7 +960,7 @@ func testTwoExits(t *testing.T, stateDBType statedb.TypeStateDB) ([]*ProcessTxOu
 	ptOuts2 := []*ProcessTxOutput{}
 	for _, block := range blocks {
 		for _, batch := range block.Rollup.Batches {
-			ptOut, err := tp.ProcessTxs(nil, batch.L1UserTxs, nil, nil)
+			ptOut, err := tp.ProcessTxs(nil, batch.L1UserTxs, nil, nil, true)
 			require.NoError(t, err)
 			ptOuts2 = append(ptOuts2, ptOut)
 		}
@@ -1011,7 +1011,7 @@ func testTwoExits(t *testing.T, stateDBType statedb.TypeStateDB) ([]*ProcessTxOu
 	ptOuts3 := []*ProcessTxOutput{}
 	for _, block := range blocks {
 		for _, batch := range block.Rollup.Batches {
-			ptOut, err := tp.ProcessTxs(nil, batch.L1UserTxs, nil, nil)
+			ptOut, err := tp.ProcessTxs(nil, batch.L1UserTxs, nil, nil, true)
 			require.NoError(t, err)
 			ptOuts3 = append(ptOuts3, ptOut)
 		}
@@ -1104,10 +1104,10 @@ func TestExitOf0Amount(t *testing.T) {
 	// - Batch8, equivalent to Batches[7]
 
 	// process Batch2:
-	_, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil)
+	_, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	// process Batch4:
-	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[3].L1UserTxs, nil, nil)
+	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[3].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"17688031540912620894848983912708704736922099609001460827147265569563156468242",
@@ -1115,7 +1115,7 @@ func TestExitOf0Amount(t *testing.T) {
 	exitRootBatch4 := ptOut.ZKInputs.Metadata.NewExitRootRaw.BigInt().String()
 
 	// process Batch6:
-	ptOut, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[5].L1UserTxs, nil, nil)
+	ptOut, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[5].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"17688031540912620894848983912708704736922099609001460827147265569563156468242",
@@ -1128,7 +1128,7 @@ func TestExitOf0Amount(t *testing.T) {
 	// For the Batch8, as there is only 1 exit with Amount=0, the ExitRoot
 	// should be 0.
 	// process Batch8:
-	ptOut, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[7].L1UserTxs, nil, nil)
+	ptOut, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[7].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t, "0", ptOut.ZKInputs.Metadata.NewExitRootRaw.BigInt().String())
 
@@ -1200,7 +1200,7 @@ func TestUpdatedAccounts(t *testing.T) {
 	for _, batch := range blocks[0].Rollup.Batches {
 		l2Txs := common.L2TxsToPoolL2Txs(batch.L2Txs)
 		ptOut, err := tp.ProcessTxs(batch.Batch.FeeIdxsCoordinator, batch.L1UserTxs,
-			batch.L1CoordinatorTxs, l2Txs)
+			batch.L1CoordinatorTxs, l2Txs, true)
 		require.NoError(t, err)
 		switch batch.Batch.BatchNum {
 		case 1:

--- a/txprocessor/zkinputsgen_test.go
+++ b/txprocessor/zkinputsgen_test.go
@@ -58,7 +58,7 @@ func TestZKInputsHashTestVector0(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// check expected account keys values from tx inputs
@@ -113,7 +113,7 @@ func TestZKInputsHashTestVector1(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// check expected account keys values from tx inputs
@@ -182,7 +182,7 @@ func TestZKInputsEmpty(t *testing.T) {
 	l1CoordTxs := []common.L1Tx{}
 	l2Txs := []common.PoolL2Tx{}
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "0", sdb.MT.Root().BigInt().String())
@@ -217,7 +217,7 @@ func TestZKInputsEmpty(t *testing.T) {
 
 	_, coordIdxs, l1UserTxs, l1CoordTxs, l2Txs = txsets.GenerateTxsZKInputs0(t, chainID)
 
-	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	rootNonZero := sdb.MT.Root()
@@ -244,7 +244,7 @@ func TestZKInputsEmpty(t *testing.T) {
 	l1CoordTxs = []common.L1Tx{}
 	l2Txs = []common.PoolL2Tx{}
 
-	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, rootNonZero, sdb.MT.Root())
@@ -303,7 +303,7 @@ func TestZKInputs0(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// check expected account keys values from tx inputs
@@ -364,7 +364,7 @@ func TestZKInputs1(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// check expected account keys values from tx inputs
@@ -432,7 +432,7 @@ func TestZKInputs2(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// check expected account keys values from tx inputs
@@ -508,7 +508,7 @@ func TestZKInputs3(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// check expected account keys values from tx inputs
@@ -584,7 +584,7 @@ func TestZKInputs4(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	// check expected account keys values from tx inputs
@@ -660,7 +660,7 @@ func TestZKInputs5(t *testing.T) {
 	}
 	tp := NewTxProcessor(sdb, config)
 
-	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs)
+	ptOut, err := tp.ProcessTxs(coordIdxs, l1UserTxs, l1CoordTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	assert.Equal(t,
@@ -739,7 +739,7 @@ func TestZKInputs6(t *testing.T) {
 	tc.RestartNonces()
 
 	log.Debug("block:0 batch:1")
-	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil)
+	ptOut, err := tp.ProcessTxs(nil, nil, blocks[0].Rollup.Batches[0].L1CoordinatorTxs, nil, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "0", sdb.MT.Root().BigInt().String())
@@ -760,7 +760,7 @@ func TestZKInputs6(t *testing.T) {
 	log.Debug("block:0 batch:2")
 	l1UserTxs := []common.L1Tx{}
 	l2Txs := common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[1].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "0", sdb.MT.Root().BigInt().String())
@@ -781,7 +781,7 @@ func TestZKInputs6(t *testing.T) {
 	log.Debug("block:0 batch:3")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[2].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[2].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[2].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"10303926118213025243660668481827257778714122989909761705455084995854999537039",
@@ -802,7 +802,7 @@ func TestZKInputs6(t *testing.T) {
 	log.Debug("block:0 batch:4")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[3].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[3].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"8530501758307821623834726627056947648600328521261384179220598288701741436285",
@@ -823,7 +823,7 @@ func TestZKInputs6(t *testing.T) {
 	log.Debug("block:0 batch:5")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[4].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[4].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[4].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[4].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"8530501758307821623834726627056947648600328521261384179220598288701741436285",
@@ -844,7 +844,7 @@ func TestZKInputs6(t *testing.T) {
 	log.Debug("block:0 batch:6")
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[5].Batch.ForgeL1TxsNum])
 	l2Txs = common.L2TxsToPoolL2Txs(blocks[0].Rollup.Batches[5].L2Txs)
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[5].L1CoordinatorTxs, l2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[5].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"9061858435528794221929846392270405504056106238451760714188625065949729889651",
@@ -876,7 +876,7 @@ func TestZKInputs6(t *testing.T) {
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[6].Batch.ForgeL1TxsNum])
 	l2Txs = poolL2Txs
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[0].Rollup.Batches[6].L1CoordinatorTxs, l2Txs)
+		blocks[0].Rollup.Batches[6].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"4392049343656836675348565048374261353937130287163762821533580216441778455298",
@@ -908,7 +908,7 @@ func TestZKInputs6(t *testing.T) {
 	l1UserTxs = til.L1TxsToCommonL1Txs(tc.Queues[*blocks[0].Rollup.Batches[7].Batch.ForgeL1TxsNum])
 	l2Txs = poolL2Txs
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[0].Rollup.Batches[7].L1CoordinatorTxs, l2Txs)
+		blocks[0].Rollup.Batches[7].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"8905191229562583213069132470917469035834300549892959854483573322676101624713",
@@ -939,7 +939,7 @@ func TestZKInputs6(t *testing.T) {
 	l2Txs = poolL2Txs
 	coordIdxs = []common.Idx{263}
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs)
+		blocks[1].Rollup.Batches[0].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"20593679664586247774284790801579542411781976279024409415159440382607791042723",
@@ -962,7 +962,7 @@ func TestZKInputs6(t *testing.T) {
 	l2Txs = []common.PoolL2Tx{}
 	coordIdxs = []common.Idx{}
 	ptOut, err = tp.ProcessTxs(coordIdxs, l1UserTxs,
-		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs)
+		blocks[1].Rollup.Batches[1].L1CoordinatorTxs, l2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"7635139306183028888189957942287689775017794868718398189334978386355501406695",
@@ -1032,7 +1032,7 @@ func TestZKInputsForceExitNotEnoughBalance(t *testing.T) {
 	tp := NewTxProcessor(sdb, config)
 
 	// process Batch2:
-	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil)
+	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t, "0", ptOut.ZKInputs.Metadata.NewExitRootRaw.BigInt().String())
 	assert.Equal(t,
@@ -1048,7 +1048,7 @@ func TestZKInputsForceExitNotEnoughBalance(t *testing.T) {
 	// printZKInputs(t, ptOut.ZKInputs)
 
 	// process Batch4:
-	ptOut, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[3].L1UserTxs, nil, nil)
+	ptOut, err = tp.ProcessTxs(nil, blocks[0].Rollup.Batches[3].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"9817949306315488277882761441334442702413477797580483156608957607254414748724",
@@ -1168,7 +1168,7 @@ func TestZKInputsDepositTransferDifferentTokenIDs(t *testing.T) {
 	assert.Equal(t, "257", tc.Users["B"].Accounts[1].Idx.String())
 
 	// process Batch2:
-	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil)
+	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"15840908427090148754401850838287012766516231419678649885722313476293488046059",
@@ -1187,7 +1187,7 @@ func TestZKInputsDepositTransferDifferentTokenIDs(t *testing.T) {
 		Type:          common.TxTypeDepositTransfer,
 	}
 	l1UserTxs := []common.L1Tx{depositTransferTx}
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, nil, nil)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"14230709344017026161842015882701267639148413699586803973757674240329499158042",
@@ -1269,7 +1269,7 @@ func TestZKInputsL1CoordinatorTxsAfterL1Exit(t *testing.T) {
 	tp := NewTxProcessor(sdb, config)
 
 	// process Batch2:
-	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil)
+	ptOut, err := tp.ProcessTxs(nil, blocks[0].Rollup.Batches[1].L1UserTxs, nil, nil, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"13250144760662777978687264077050092444905467656476402514654550449973838329915",
@@ -1286,7 +1286,7 @@ func TestZKInputsL1CoordinatorTxsAfterL1Exit(t *testing.T) {
 
 	// process Batch4:
 	l1UserTxs := blocks[0].Rollup.Batches[3].L1UserTxs
-	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, poolL2Txs)
+	ptOut, err = tp.ProcessTxs(nil, l1UserTxs, blocks[0].Rollup.Batches[3].L1CoordinatorTxs, poolL2Txs, true)
 	require.NoError(t, err)
 	assert.Equal(t,
 		"2449079255569259710281173899922223113570673452636649748260745275814779988814",

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -218,6 +218,7 @@ func (txsel *TxSelector) getL1L2TxSelection(selectionConfig txprocessor.Config,
 				"Tx not selected due impossibility to be forged with the current state"
 			discardedL2Txs = append(discardedL2Txs, l2TxsNonForgable[i])
 		}
+		tp.StateDB().AdvanceCurrentBatch()
 		err = tp.StateDB().MakeCheckpoint()
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, tracerr.Wrap(err)
@@ -318,6 +319,7 @@ func (txsel *TxSelector) getL1L2TxSelection(selectionConfig txprocessor.Config,
 		}
 	}
 
+	tp.StateDB().AdvanceCurrentBatch()
 	err = tp.StateDB().MakeCheckpoint()
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, tracerr.Wrap(err)


### PR DESCRIPTION
### What does this PR does?

Changes how checkpointing is done in synchronization. Based on #747, when block range is synchronized calls MakeCheckpoint only once for the whole range and only if there were batches.

Changes storage consistency assumptions. Previously checkpoints were always done before writing to PostgreSQL, now - after in case of fast sync of block range.

### How to test?

Test performance by running node synchronization.
Test that node correctly shuts down on Ctrl+C and continues synchronization after that.

## Checklist

TODO:
- [ ] Check how node behaves on forced termination of it's process.

