### PR TITLE
Feature/#729 gasprice etherscan

### DIFF
--- a/cli/node/cfg.buidler.toml
+++ b/cli/node/cfg.buidler.toml
@@ -143,6 +143,10 @@ BatchPath = "/tmp/iden3-test/hermez/batchesdebug"
 LightScrypt = true
 # RollupVerifierIndex = 0
 
+[Coordinator.Etherscan]
+URL = "https://api.etherscan.io"
+ApiKey = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+
 [RecommendedFeePolicy]
 # Strategy used to calculate the recommended fee that the API will expose.
 # Available options:

--- a/config/config.go
+++ b/config/config.go
@@ -237,6 +237,13 @@ type Coordinator struct {
 		// must match with the Circuit parameters.
 		RollupVerifierIndex *int
 	}
+	Etherscan struct {
+		// URL if set, specifies the etherscan endpoint to get
+		// the gas estimations for that momment.
+		URL string
+		// ApiKey allow access to etherscan services
+		ApiKey string
+	}
 }
 
 // PostgreSQL is the postgreSQL configuration parameters.  It's possible to use

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -241,7 +241,7 @@ func NewCoordinator(cfg Config,
 	ethClient eth.ClientInterface,
 	scConsts *common.SCConsts,
 	initSCVars *common.SCVariables,
-	etherscanClient etherscan.Client,
+	etherscanService *etherscan.Service,
 ) (*Coordinator, error) {
 	if cfg.DebugBatchPath != "" {
 		if err := os.MkdirAll(cfg.DebugBatchPath, 0744); err != nil {
@@ -286,7 +286,7 @@ func NewCoordinator(cfg Config,
 	ctxTimeout, ctxTimeoutCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer ctxTimeoutCancel()
 	txManager, err := NewTxManager(ctxTimeout, &cfg, ethClient, l2DB, &c,
-		scConsts, initSCVars, etherscanClient)
+		scConsts, initSCVars, etherscanService)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -55,6 +55,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/eth"
+	"github.com/hermeznetwork/hermez-node/etherscan"
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/hermez-node/prover"
 	"github.com/hermeznetwork/hermez-node/synchronizer"
@@ -240,6 +241,7 @@ func NewCoordinator(cfg Config,
 	ethClient eth.ClientInterface,
 	scConsts *common.SCConsts,
 	initSCVars *common.SCVariables,
+	etherscanClient etherscan.Client,
 ) (*Coordinator, error) {
 	if cfg.DebugBatchPath != "" {
 		if err := os.MkdirAll(cfg.DebugBatchPath, 0744); err != nil {
@@ -284,7 +286,7 @@ func NewCoordinator(cfg Config,
 	ctxTimeout, ctxTimeoutCancel := context.WithTimeout(ctx, 1*time.Second)
 	defer ctxTimeoutCancel()
 	txManager, err := NewTxManager(ctxTimeout, &cfg, ethClient, l2DB, &c,
-		scConsts, initSCVars)
+		scConsts, initSCVars, etherscanClient)
 	if err != nil {
 		return nil, tracerr.Wrap(err)
 	}

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -238,7 +238,7 @@ func TestCoordinatorFlow(t *testing.T) {
 	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
-	etherScanService, _ := etherscan.NewEtherscanService("")
+	etherScanService, _ := etherscan.NewEtherscanService("", "")
 	modules := newTestModules(t)
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 
@@ -335,7 +335,7 @@ func TestCoordinatorStartStop(t *testing.T) {
 	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
-	etherScanService, _ := etherscan.NewEtherscanService("")
+	etherScanService, _ := etherscan.NewEtherscanService("", "")
 	modules := newTestModules(t)
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	coord.Start()
@@ -351,7 +351,7 @@ func TestCoordCanForge(t *testing.T) {
 
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
-	etherScanService, _ := etherscan.NewEtherscanService("")
+	etherScanService, _ := etherscan.NewEtherscanService("", "")
 	modules := newTestModules(t)
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	_, err := ethClient.AuctionSetCoordinator(forger, "https://foo.bar")
@@ -432,7 +432,7 @@ func TestCoordHandleMsgSyncBlock(t *testing.T) {
 
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
-	etherScanService, _ := etherscan.NewEtherscanService("")
+	etherScanService, _ := etherscan.NewEtherscanService("", "")
 	modules := newTestModules(t)
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	_, err := ethClient.AuctionSetCoordinator(forger, "https://foo.bar")
@@ -532,7 +532,7 @@ func TestCoordinatorStress(t *testing.T) {
 	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
-	etherScanService, _ := etherscan.NewEtherscanService("")
+	etherScanService, _ := etherscan.NewEtherscanService("", "")
 	modules := newTestModules(t)
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	syn := newTestSynchronizer(t, ethClient, ethClientSetup, modules)

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/db/statedb"
 	"github.com/hermeznetwork/hermez-node/eth"
+	"github.com/hermeznetwork/hermez-node/etherscan"
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/hermez-node/prover"
 	"github.com/hermeznetwork/hermez-node/synchronizer"
@@ -159,7 +160,7 @@ var bidder = ethCommon.HexToAddress("0x6b175474e89094c44da98b954eedeac495271d0f"
 var forger = ethCommon.HexToAddress("0xc344E203a046Da13b0B4467EB7B3629D0C99F6E6")
 
 func newTestCoordinator(t *testing.T, forgerAddr ethCommon.Address, ethClient *test.Client,
-	ethClientSetup *test.ClientSetup, modules modules) *Coordinator {
+	ethClientSetup *test.ClientSetup, modules modules, 	etherscanClient etherscan.Client) *Coordinator {
 	debugBatchPath, err := ioutil.TempDir("", "tmpDebugBatch")
 	require.NoError(t, err)
 	deleteme = append(deleteme, debugBatchPath)
@@ -206,7 +207,7 @@ func newTestCoordinator(t *testing.T, forgerAddr ethCommon.Address, ethClient *t
 		WDelayer: *ethClientSetup.WDelayerVariables,
 	}
 	coord, err := NewCoordinator(conf, modules.historyDB, modules.l2DB, modules.txSelector,
-		modules.batchBuilder, serverProofs, ethClient, scConsts, initSCVars)
+		modules.batchBuilder, serverProofs, ethClient, scConsts, initSCVars, etherscanClient)
 	require.NoError(t, err)
 	return coord
 }
@@ -237,8 +238,9 @@ func TestCoordinatorFlow(t *testing.T) {
 	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
+	etherScanService, _ := etherscan.NewEtherscanService("")
 	modules := newTestModules(t)
-	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
+	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 
 	// Bid for slot 2 and 4
 	_, err := ethClient.AuctionSetCoordinator(forger, "https://foo.bar")
@@ -333,8 +335,9 @@ func TestCoordinatorStartStop(t *testing.T) {
 	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
+	etherScanService, _ := etherscan.NewEtherscanService("")
 	modules := newTestModules(t)
-	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
+	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	coord.Start()
 	coord.Stop()
 
@@ -348,8 +351,9 @@ func TestCoordCanForge(t *testing.T) {
 
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
+	etherScanService, _ := etherscan.NewEtherscanService("")
 	modules := newTestModules(t)
-	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
+	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	_, err := ethClient.AuctionSetCoordinator(forger, "https://foo.bar")
 	require.NoError(t, err)
 	bid, ok := new(big.Int).SetString("12000000000000000000", 10)
@@ -360,7 +364,7 @@ func TestCoordCanForge(t *testing.T) {
 	require.NoError(t, err)
 
 	modules2 := newTestModules(t)
-	bootCoord := newTestCoordinator(t, bootForger, ethClient, ethClientSetup, modules2)
+	bootCoord := newTestCoordinator(t, bootForger, ethClient, ethClientSetup, modules2, etherScanService)
 
 	assert.Equal(t, forger, coord.cfg.ForgerAddress)
 	assert.Equal(t, bootForger, bootCoord.cfg.ForgerAddress)
@@ -428,8 +432,9 @@ func TestCoordHandleMsgSyncBlock(t *testing.T) {
 
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
+	etherScanService, _ := etherscan.NewEtherscanService("")
 	modules := newTestModules(t)
-	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
+	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	_, err := ethClient.AuctionSetCoordinator(forger, "https://foo.bar")
 	require.NoError(t, err)
 	bid, ok := new(big.Int).SetString("11000000000000000000", 10)
@@ -527,8 +532,9 @@ func TestCoordinatorStress(t *testing.T) {
 	ethClientSetup.ChainID = big.NewInt(int64(chainID))
 	var timer timer
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
+	etherScanService, _ := etherscan.NewEtherscanService("")
 	modules := newTestModules(t)
-	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
+	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	syn := newTestSynchronizer(t, ethClient, ethClientSetup, modules)
 
 	coord.Start()

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -160,7 +160,7 @@ var bidder = ethCommon.HexToAddress("0x6b175474e89094c44da98b954eedeac495271d0f"
 var forger = ethCommon.HexToAddress("0xc344E203a046Da13b0B4467EB7B3629D0C99F6E6")
 
 func newTestCoordinator(t *testing.T, forgerAddr ethCommon.Address, ethClient *test.Client,
-	ethClientSetup *test.ClientSetup, modules modules, etherscanClient etherscan.Client) *Coordinator {
+	ethClientSetup *test.ClientSetup, modules modules, etherscanService *etherscan.Service) *Coordinator {
 	debugBatchPath, err := ioutil.TempDir("", "tmpDebugBatch")
 	require.NoError(t, err)
 	deleteme = append(deleteme, debugBatchPath)
@@ -207,7 +207,7 @@ func newTestCoordinator(t *testing.T, forgerAddr ethCommon.Address, ethClient *t
 		WDelayer: *ethClientSetup.WDelayerVariables,
 	}
 	coord, err := NewCoordinator(conf, modules.historyDB, modules.l2DB, modules.txSelector,
-		modules.batchBuilder, serverProofs, ethClient, scConsts, initSCVars, etherscanClient)
+		modules.batchBuilder, serverProofs, ethClient, scConsts, initSCVars, etherscanService)
 	require.NoError(t, err)
 	return coord
 }

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -160,7 +160,7 @@ var bidder = ethCommon.HexToAddress("0x6b175474e89094c44da98b954eedeac495271d0f"
 var forger = ethCommon.HexToAddress("0xc344E203a046Da13b0B4467EB7B3629D0C99F6E6")
 
 func newTestCoordinator(t *testing.T, forgerAddr ethCommon.Address, ethClient *test.Client,
-	ethClientSetup *test.ClientSetup, modules modules, 	etherscanClient etherscan.Client) *Coordinator {
+	ethClientSetup *test.ClientSetup, modules modules, etherscanClient etherscan.Client) *Coordinator {
 	debugBatchPath, err := ioutil.TempDir("", "tmpDebugBatch")
 	require.NoError(t, err)
 	deleteme = append(deleteme, debugBatchPath)

--- a/coordinator/pipeline_test.go
+++ b/coordinator/pipeline_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/historydb"
 	"github.com/hermeznetwork/hermez-node/db/statedb"
 	"github.com/hermeznetwork/hermez-node/eth"
+	"github.com/hermeznetwork/hermez-node/etherscan"
 	"github.com/hermeznetwork/hermez-node/prover"
 	"github.com/hermeznetwork/hermez-node/synchronizer"
 	"github.com/hermeznetwork/hermez-node/test"
@@ -40,9 +41,10 @@ func TestPipelineShouldL1L2Batch(t *testing.T) {
 	var timer timer
 	ctx := context.Background()
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
+	etherScanService, _ := etherscan.NewEtherscanService("")
 	modules := newTestModules(t)
 	var stats synchronizer.Stats
-	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
+	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	pipeline, err := coord.newPipeline(ctx)
 	require.NoError(t, err)
 	pipeline.vars = coord.vars
@@ -179,8 +181,9 @@ func TestPipelineForgeBatchWithTxs(t *testing.T) {
 	var timer timer
 	ctx := context.Background()
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
+	etherScanService, _ := etherscan.NewEtherscanService("")
 	modules := newTestModules(t)
-	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules)
+	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	sync := newTestSynchronizer(t, ethClient, ethClientSetup, modules)
 
 	// preload the synchronier (via the test ethClient) some tokens and

--- a/coordinator/pipeline_test.go
+++ b/coordinator/pipeline_test.go
@@ -41,7 +41,7 @@ func TestPipelineShouldL1L2Batch(t *testing.T) {
 	var timer timer
 	ctx := context.Background()
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
-	etherScanService, _ := etherscan.NewEtherscanService("")
+	etherScanService, _ := etherscan.NewEtherscanService("", "")
 	modules := newTestModules(t)
 	var stats synchronizer.Stats
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
@@ -181,7 +181,7 @@ func TestPipelineForgeBatchWithTxs(t *testing.T) {
 	var timer timer
 	ctx := context.Background()
 	ethClient := test.NewClient(true, &timer, &bidder, ethClientSetup)
-	etherScanService, _ := etherscan.NewEtherscanService("")
+	etherScanService, _ := etherscan.NewEtherscanService("", "")
 	modules := newTestModules(t)
 	coord := newTestCoordinator(t, forger, ethClient, ethClientSetup, modules, etherScanService)
 	sync := newTestSynchronizer(t, ethClient, ethClientSetup, modules)

--- a/coordinator/txmanager.go
+++ b/coordinator/txmanager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/eth"
+	"github.com/hermeznetwork/hermez-node/etherscan"
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/hermez-node/synchronizer"
 	"github.com/hermeznetwork/tracerr"
@@ -24,18 +25,19 @@ import (
 // call to forge, waits for transaction confirmation, and keeps checking them
 // until a number of confirmed blocks have passed.
 type TxManager struct {
-	cfg       Config
-	ethClient eth.ClientInterface
-	l2DB      *l2db.L2DB   // Used only to mark forged txs as forged in the L2DB
-	coord     *Coordinator // Used only to send messages to stop the pipeline
-	batchCh   chan *BatchInfo
-	chainID   *big.Int
-	account   accounts.Account
-	consts    common.SCConsts
+	cfg       			Config
+	ethClient 			eth.ClientInterface
+	etherscanClient 	etherscan.Client
+	l2DB      			*l2db.L2DB   // Used only to mark forged txs as forged in the L2DB
+	coord     			*Coordinator // Used only to send messages to stop the pipeline
+	batchCh   			chan *BatchInfo
+	chainID   			*big.Int
+	account   			accounts.Account
+	consts    			common.SCConsts
 
-	stats       synchronizer.Stats
-	vars        common.SCVariables
-	statsVarsCh chan statsVars
+	stats      			synchronizer.Stats
+	vars        		common.SCVariables
+	statsVarsCh 		chan statsVars
 
 	discardPipelineCh chan int // int refers to the pipelineNum
 
@@ -55,7 +57,7 @@ type TxManager struct {
 
 // NewTxManager creates a new TxManager
 func NewTxManager(ctx context.Context, cfg *Config, ethClient eth.ClientInterface, l2DB *l2db.L2DB,
-	coord *Coordinator, scConsts *common.SCConsts, initSCVars *common.SCVariables) (
+	coord *Coordinator, scConsts *common.SCConsts, initSCVars *common.SCVariables, etherscanClient etherscan.Client) (
 	*TxManager, error) {
 	chainID, err := ethClient.EthChainID()
 	if err != nil {
@@ -73,6 +75,7 @@ func NewTxManager(ctx context.Context, cfg *Config, ethClient eth.ClientInterfac
 	return &TxManager{
 		cfg:               *cfg,
 		ethClient:         ethClient,
+		etherscanClient:   etherscanClient,
 		l2DB:              l2DB,
 		coord:             coord,
 		batchCh:           make(chan *BatchInfo, queueLen),
@@ -126,9 +129,29 @@ func (t *TxManager) syncSCVars(vars common.SCVariablesPtr) {
 
 // NewAuth generates a new auth object for an ethereum transaction
 func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.TransactOpts, error) {
-	gasPrice, err := t.ethClient.EthSuggestGasPrice(ctx)
+	//First we try getting the gas price from etherscan. If it fails we get the gas price from the ethereum node.
+	var gasPrice *big.Int
+	etherscanGasPrice, err :=t.etherscanClient.GetGasPrice(ctx, "")
 	if err != nil {
-		return nil, tracerr.Wrap(err)
+		log.Warn("Error getting the gas price from etherscan. Trying another method")
+		var er error
+		gasPrice, er = t.ethClient.EthSuggestGasPrice(ctx)
+		if er != nil {
+			return nil, tracerr.Wrap(err)
+		}
+	} else {
+		eGasPrice := new(big.Int)
+		eGasPrice, ok := eGasPrice.SetString(etherscanGasPrice.ProposeGasPrice, 10)
+		if !ok {
+			log.Warn("invalid big int: \"%v\"", etherscanGasPrice.ProposeGasPrice, ". Trying another method to get gas price")
+			var er error
+			gasPrice, er = t.ethClient.EthSuggestGasPrice(ctx)
+			if er != nil {
+				return nil, tracerr.Wrap(err)
+			}
+		} else {
+			gasPrice = eGasPrice
+		}
 	}
 	if t.cfg.GasPriceIncPerc != 0 {
 		inc := new(big.Int).Set(gasPrice)

--- a/coordinator/txmanager.go
+++ b/coordinator/txmanager.go
@@ -25,19 +25,19 @@ import (
 // call to forge, waits for transaction confirmation, and keeps checking them
 // until a number of confirmed blocks have passed.
 type TxManager struct {
-	cfg       			Config
-	ethClient 			eth.ClientInterface
-	etherscanClient 	etherscan.Client
-	l2DB      			*l2db.L2DB   // Used only to mark forged txs as forged in the L2DB
-	coord     			*Coordinator // Used only to send messages to stop the pipeline
-	batchCh   			chan *BatchInfo
-	chainID   			*big.Int
-	account   			accounts.Account
-	consts    			common.SCConsts
+	cfg             Config
+	ethClient       eth.ClientInterface
+	etherscanClient etherscan.Client
+	l2DB            *l2db.L2DB   // Used only to mark forged txs as forged in the L2DB
+	coord           *Coordinator // Used only to send messages to stop the pipeline
+	batchCh         chan *BatchInfo
+	chainID         *big.Int
+	account         accounts.Account
+	consts          common.SCConsts
 
-	stats      			synchronizer.Stats
-	vars        		common.SCVariables
-	statsVarsCh 		chan statsVars
+	stats       synchronizer.Stats
+	vars        common.SCVariables
+	statsVarsCh chan statsVars
 
 	discardPipelineCh chan int // int refers to the pipelineNum
 
@@ -131,7 +131,7 @@ func (t *TxManager) syncSCVars(vars common.SCVariablesPtr) {
 func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.TransactOpts, error) {
 	//First we try getting the gas price from etherscan. If it fails we get the gas price from the ethereum node.
 	var gasPrice *big.Int
-	etherscanGasPrice, err :=t.etherscanClient.GetGasPrice(ctx, "")
+	etherscanGasPrice, err := t.etherscanClient.GetGasPrice(ctx, "")
 	if err != nil {
 		log.Warn("Error getting the gas price from etherscan. Trying another method")
 		var er error

--- a/coordinator/txmanager.go
+++ b/coordinator/txmanager.go
@@ -131,9 +131,9 @@ func (t *TxManager) syncSCVars(vars common.SCVariablesPtr) {
 func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.TransactOpts, error) {
 	//First we try getting the gas price from etherscan. If it fails we get the gas price from the ethereum node.
 	var gasPrice *big.Int
-	etherscanGasPrice, err := t.etherscanClient.GetGasPrice(ctx, "")
+	etherscanGasPrice, err := t.etherscanClient.GetGasPrice(ctx)
 	if err != nil {
-		log.Warn("Error getting the gas price from etherscan. Trying another method")
+		log.Warn("Error getting the gas price from etherscan. Trying another method. Error: ",err)
 		var er error
 		gasPrice, er = t.ethClient.EthSuggestGasPrice(ctx)
 		if er != nil {

--- a/etherscan/etherscan.go
+++ b/etherscan/etherscan.go
@@ -32,16 +32,17 @@ type GasPriceEtherscan struct {
 // EtherScanService definition
 type EtherScanService struct {
 	clientEtherscan *sling.Sling
+	apiKey string
 }
 
 // Client is the interface to a ServerProof that calculates zk proofs
 type Client interface {
 	// Blocking.  Returns the gas price.
-	GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error)
+	GetGasPrice(ctx context.Context) (*GasPriceEtherscan, error)
 }
 
 // NewEtherscanService is the constructor that creates an etherscanService
-func NewEtherscanService(etherscanURL string) (*EtherScanService, error) {
+func NewEtherscanService(etherscanURL string, apikey string) (*EtherScanService, error) {
 	// Init
 	tr := &http.Transport{
 		MaxIdleConns:       defaultMaxIdleConns,
@@ -51,13 +52,14 @@ func NewEtherscanService(etherscanURL string) (*EtherScanService, error) {
 	httpClient := &http.Client{Transport: tr}
 	return &EtherScanService{
 		clientEtherscan: sling.New().Base(etherscanURL).Client(httpClient),
+		apiKey: apikey,
 	}, nil
 }
 
 // GetGasPrice retrieves the gas price estimation from etherscan
-func (p *EtherScanService) GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error) {
+func (p *EtherScanService) GetGasPrice(ctx context.Context) (*GasPriceEtherscan, error) {
 	var resBody etherscanResponse
-	url := "/api?module=gastracker&action=gasoracle&apikey=" + apiKey
+	url := "/api?module=gastracker&action=gasoracle&apikey=" + p.apiKey
 	req, err := p.clientEtherscan.New().Get(url).Request()
 	if err != nil {
 		return nil, tracerr.Wrap(err)
@@ -77,7 +79,7 @@ type MockEtherscanClient struct {
 }
 
 // GetGasPrice retrieves the gas price estimation from etherscan
-func (p *MockEtherscanClient) GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error) {
+func (p *MockEtherscanClient) GetGasPrice(ctx context.Context) (*GasPriceEtherscan, error) {
 	return &GasPriceEtherscan{
 			LastBlock:       "0",
 			SafeGasPrice:    "90",

--- a/etherscan/etherscan.go
+++ b/etherscan/etherscan.go
@@ -1,0 +1,86 @@
+package etherscan
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dghubble/sling"
+	"github.com/hermeznetwork/tracerr"
+)
+
+const (
+	defaultMaxIdleConns    = 10
+	defaultIdleConnTimeout = 2 * time.Second
+)
+
+type EtherscanResponse struct {
+	Status		string    				`json:"status"`
+	Message		string 					`json:"message"`
+	Result		GasPriceEtherscan   	`json:"result"`
+}
+type GasPriceEtherscan struct {
+	LastBlock      		string    	`json:"LastBlock"`
+	SafeGasPrice     	string 		`json:"SafeGasPrice"`
+	ProposeGasPrice     string    	`json:"ProposeGasPrice"`
+	FastGasPrice      	string    	`json:"FastGasPrice"`
+}
+
+// EtherScanService definition
+type EtherScanService struct {
+	clientEtherscan   *sling.Sling
+}
+
+// Client is the interface to a ServerProof that calculates zk proofs
+type Client interface {
+	// Blocking.  Returns the gas price.
+	GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error)
+}
+
+// NewEtherscanService is the constructor that creates an etherscanService 
+func NewEtherscanService(etherscanURL string) (*EtherScanService, error) {
+	// Init
+	tr := &http.Transport{
+		MaxIdleConns:       defaultMaxIdleConns,
+		IdleConnTimeout:    defaultIdleConnTimeout,
+		DisableCompression: true,
+	}
+	httpClient := &http.Client{Transport: tr}
+	return &EtherScanService{
+		clientEtherscan:   sling.New().Base(etherscanURL).Client(httpClient),
+	}, nil
+}
+// GetgetGasPrice retrieves the gas price estimation from etherscan
+func (p *EtherScanService) GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error) {
+	var resBody EtherscanResponse
+	url := "/api?module=gastracker&action=gasoracle&apikey="+apiKey
+	req, err := p.clientEtherscan.New().Get(url).Request()
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	res, err := p.clientEtherscan.Do(req.WithContext(ctx), &resBody, nil)
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, tracerr.Wrap(fmt.Errorf("http response is not is %v", res.StatusCode))
+	}
+	return &resBody.Result, nil
+}
+
+// MockEtherscanClient is a mock EtherscanServer to be used in tests.  It doesn't calculate anything
+type MockEtherscanClient struct {
+}
+
+
+// GetGasPrice retrieves the gas price estimation from etherscan
+func (p *MockEtherscanClient) GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error) {
+	return &GasPriceEtherscan{
+			LastBlock: "0",
+			SafeGasPrice: "90",
+			ProposeGasPrice: "100",
+			FastGasPrice: "110",
+		},
+		nil
+}

--- a/etherscan/etherscan.go
+++ b/etherscan/etherscan.go
@@ -15,21 +15,23 @@ const (
 	defaultIdleConnTimeout = 2 * time.Second
 )
 
-type EtherscanResponse struct {
-	Status		string    				`json:"status"`
-	Message		string 					`json:"message"`
-	Result		GasPriceEtherscan   	`json:"result"`
+type etherscanResponse struct {
+	Status  string            `json:"status"`
+	Message string            `json:"message"`
+	Result  GasPriceEtherscan `json:"result"`
 }
+
+// GasPriceEtherscan definition
 type GasPriceEtherscan struct {
-	LastBlock      		string    	`json:"LastBlock"`
-	SafeGasPrice     	string 		`json:"SafeGasPrice"`
-	ProposeGasPrice     string    	`json:"ProposeGasPrice"`
-	FastGasPrice      	string    	`json:"FastGasPrice"`
+	LastBlock       string `json:"LastBlock"`
+	SafeGasPrice    string `json:"SafeGasPrice"`
+	ProposeGasPrice string `json:"ProposeGasPrice"`
+	FastGasPrice    string `json:"FastGasPrice"`
 }
 
 // EtherScanService definition
 type EtherScanService struct {
-	clientEtherscan   *sling.Sling
+	clientEtherscan *sling.Sling
 }
 
 // Client is the interface to a ServerProof that calculates zk proofs
@@ -38,7 +40,7 @@ type Client interface {
 	GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error)
 }
 
-// NewEtherscanService is the constructor that creates an etherscanService 
+// NewEtherscanService is the constructor that creates an etherscanService
 func NewEtherscanService(etherscanURL string) (*EtherScanService, error) {
 	// Init
 	tr := &http.Transport{
@@ -48,13 +50,14 @@ func NewEtherscanService(etherscanURL string) (*EtherScanService, error) {
 	}
 	httpClient := &http.Client{Transport: tr}
 	return &EtherScanService{
-		clientEtherscan:   sling.New().Base(etherscanURL).Client(httpClient),
+		clientEtherscan: sling.New().Base(etherscanURL).Client(httpClient),
 	}, nil
 }
-// GetgetGasPrice retrieves the gas price estimation from etherscan
+
+// GetGasPrice retrieves the gas price estimation from etherscan
 func (p *EtherScanService) GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error) {
-	var resBody EtherscanResponse
-	url := "/api?module=gastracker&action=gasoracle&apikey="+apiKey
+	var resBody etherscanResponse
+	url := "/api?module=gastracker&action=gasoracle&apikey=" + apiKey
 	req, err := p.clientEtherscan.New().Get(url).Request()
 	if err != nil {
 		return nil, tracerr.Wrap(err)
@@ -73,14 +76,13 @@ func (p *EtherScanService) GetGasPrice(ctx context.Context, apiKey string) (*Gas
 type MockEtherscanClient struct {
 }
 
-
 // GetGasPrice retrieves the gas price estimation from etherscan
 func (p *MockEtherscanClient) GetGasPrice(ctx context.Context, apiKey string) (*GasPriceEtherscan, error) {
 	return &GasPriceEtherscan{
-			LastBlock: "0",
-			SafeGasPrice: "90",
+			LastBlock:       "0",
+			SafeGasPrice:    "90",
 			ProposeGasPrice: "100",
-			FastGasPrice: "110",
+			FastGasPrice:    "110",
 		},
 		nil
 }

--- a/etherscan/etherscan_test.go
+++ b/etherscan/etherscan_test.go
@@ -1,0 +1,46 @@
+package etherscan
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var etherscanURL = "http://localhost:3000/api"
+
+var etherScanMockService *MockEtherscanClient
+var etherScanService *EtherScanService
+
+func TestMain(m *testing.M) {
+	exitVal := 0
+	_etherscanURL := os.Getenv("ETHERSCAN_API_URL")
+	if _etherscanURL != "" {
+		etherscanURL = _etherscanURL
+	}
+	var err error
+	etherScanService, err = NewEtherscanService(etherscanURL)
+	if err != nil {
+		panic(err)
+	}
+	exitVal = m.Run()
+	os.Exit(exitVal)
+}
+
+func TestEtherscanApiServer(t *testing.T) {
+	t.Run("testGetGasPrice", testGetGasPrice)
+}
+
+func testGetGasPrice(t *testing.T) {
+	fmt.Println("here",etherscanURL)
+	gasPrice, err := etherScanMockService.GetGasPrice(context.Background(), etherscanURL)
+	fmt.Println(gasPrice)
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, gasPrice.LastBlock)
+	assert.NotEqual(t, 90, gasPrice.SafeGasPrice)
+	assert.NotEqual(t, 100, gasPrice.ProposeGasPrice)
+	assert.NotEqual(t, 110, gasPrice.FastGasPrice)
+}

--- a/etherscan/etherscan_test.go
+++ b/etherscan/etherscan_test.go
@@ -2,7 +2,6 @@ package etherscan
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -35,9 +34,7 @@ func TestEtherscanApiServer(t *testing.T) {
 }
 
 func testGetGasPrice(t *testing.T) {
-	fmt.Println("here",etherscanURL)
 	gasPrice, err := etherScanMockService.GetGasPrice(context.Background(), etherscanURL)
-	fmt.Println(gasPrice)
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, gasPrice.LastBlock)
 	assert.NotEqual(t, 90, gasPrice.SafeGasPrice)

--- a/etherscan/etherscan_test.go
+++ b/etherscan/etherscan_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var etherscanURL = "http://localhost:3000/api"
+var apiKey = "FFFFFFFFFFFFFFFFFFF"
 
 var etherScanMockService *MockEtherscanClient
 var etherScanService *EtherScanService
@@ -20,8 +21,12 @@ func TestMain(m *testing.M) {
 	if _etherscanURL != "" {
 		etherscanURL = _etherscanURL
 	}
+	_apiKey := os.Getenv("ETHERSCAN_API_KEY")
+	if _apiKey != "" {
+		apiKey = _apiKey
+	}
 	var err error
-	etherScanService, err = NewEtherscanService(etherscanURL)
+	etherScanService, err = NewEtherscanService(etherscanURL, apiKey)
 	if err != nil {
 		panic(err)
 	}
@@ -34,7 +39,7 @@ func TestEtherscanApiServer(t *testing.T) {
 }
 
 func testGetGasPrice(t *testing.T) {
-	gasPrice, err := etherScanMockService.GetGasPrice(context.Background(), etherscanURL)
+	gasPrice, err := etherScanMockService.GetGasPrice(context.Background())
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, gasPrice.LastBlock)
 	assert.NotEqual(t, 90, gasPrice.SafeGasPrice)

--- a/node/node.go
+++ b/node/node.go
@@ -326,8 +326,15 @@ func NewNode(mode Mode, cfg *config.Node, version string) (*Node, error) {
 		if err != nil {
 			return nil, tracerr.Wrap(err)
 		}
-		etherScanService, _ := etherscan.NewEtherscanService(cfg.Coordinator.Etherscan.URL,
-			cfg.Coordinator.Etherscan.APIKey)
+		var etherScanService *etherscan.Service
+		if cfg.Coordinator.Etherscan.URL != "" && cfg.Coordinator.Etherscan.APIKey != "" {
+			log.Info("EtherScan method detected in cofiguration file")
+			etherScanService, _ = etherscan.NewEtherscanService(cfg.Coordinator.Etherscan.URL,
+				cfg.Coordinator.Etherscan.APIKey)
+		} else {
+			log.Info("EtherScan method not configured in config file")
+			etherScanService = nil
+		}
 		serverProofs := make([]prover.Client, len(cfg.Coordinator.ServerProofs))
 		for i, serverProofCfg := range cfg.Coordinator.ServerProofs {
 			serverProofs[i] = prover.NewProofServerClient(serverProofCfg.URL,

--- a/node/node.go
+++ b/node/node.go
@@ -326,7 +326,8 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		if err != nil {
 			return nil, tracerr.Wrap(err)
 		}
-		etherScanService, _ := etherscan.NewEtherscanService("")
+		etherScanService, _ := etherscan.NewEtherscanService(cfg.Coordinator.Etherscan.URL,
+			cfg.Coordinator.Etherscan.ApiKey)
 		serverProofs := make([]prover.Client, len(cfg.Coordinator.ServerProofs))
 		for i, serverProofCfg := range cfg.Coordinator.ServerProofs {
 			serverProofs[i] = prover.NewProofServerClient(serverProofCfg.URL,

--- a/node/node.go
+++ b/node/node.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/db/statedb"
 	"github.com/hermeznetwork/hermez-node/eth"
+	"github.com/hermeznetwork/hermez-node/etherscan"
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/hermez-node/priceupdater"
 	"github.com/hermeznetwork/hermez-node/prover"
@@ -325,6 +326,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 		if err != nil {
 			return nil, tracerr.Wrap(err)
 		}
+		etherScanService, _ := etherscan.NewEtherscanService("")
 		serverProofs := make([]prover.Client, len(cfg.Coordinator.ServerProofs))
 		for i, serverProofCfg := range cfg.Coordinator.ServerProofs {
 			serverProofs[i] = prover.NewProofServerClient(serverProofCfg.URL,
@@ -409,6 +411,7 @@ func NewNode(mode Mode, cfg *config.Node) (*Node, error) {
 			client,
 			&scConsts,
 			initSCVars,
+			etherScanService,
 		)
 		if err != nil {
 			return nil, tracerr.Wrap(err)


### PR DESCRIPTION
Closes #729

### What does this PR does?

This PR adds the ability to retrieve the gas price estimation from etherscan which is more accurate. If the endpoint is not operative then the node uses the old method as backup which is ask the gas price to geth.

There are four different situations:
1. EtherScan variables are empty or missing in config file: In this case the node will work only asking the gas price to geth.
2. EtherScan variables are wrong. In this case the node will try to use them. As the api call will fail, the node will use the geth method to retrieve the gas price.
3. EtherScan variables are correct but the endpoint is no available. In this situation the node will try to get the gas price from etherscan. Due to the endpoint unavailability, this call will fail and the node will try the geth method.
4. If Etherscan variables are correct and the endpoint is working, the node will retrieve the gas price info from etherscan.

This PR adds new configuration parameters:
- Coordinator.Etherscan.URL
- Coordinator.Etherscan.APIKey

### How to test?
Run the hermez node in coordinator mode and let the node ask for the gas price before send the ethereum transaction.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Include tests
- [X] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)
