### PR TITLE
Revert changes on the pool if forgeBatch fail

### DIFF
--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -356,7 +356,7 @@ func (l2db *L2DB) InvalidateOldNonces(updatedAccounts []common.IdxNonce, batchNu
 // The state of the affected txs can change form Forged -> Pending or from Invalid -> Pending
 func (l2db *L2DB) Reorg(lastValidBatch common.BatchNum) error {
 	_, err := l2db.dbWrite.Exec(
-		`UPDATE tx_pool SET batch_num = NULL, state = $1
+		`UPDATE tx_pool SET batch_num = NULL, state = $1, info = NULL
 		WHERE (state = $2 OR state = $3 OR state = $4) AND batch_num > $5`,
 		common.PoolL2TxStatePending,
 		common.PoolL2TxStateForging,


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #763 

### What does this PR does?

Reverts changes done to transaction pool made while trying to forge a batch if this fails.
NOTE: there are several possible points of failure that could lead to the bug that I'm trying to fix in this PR, and I may have missed some of them. Please refer to the linked issue for more details on the bug.

### How to test?

This one is tricky to test as the origin is not crystal clear. But overall the idea is that:

1. Set up a coordinator with some transactions in the pool and start forging
2. Intentionally make the process fail (for instance, stop the proof server)
3. Check that the transactions are marked as pending and with no `info`, as the pool should have the same state as before trying to forge.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [x] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

