### PR TITLE
Make API reject exits with amount 0

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -693,7 +693,7 @@ func TestTimeout(t *testing.T) {
 	err = json.Unmarshal(body, msg)
 	require.NoError(t, err)
 	// Check that the error was the expected down
-	require.Equal(t, errSQLTimeout, msg.Message)
+	require.Equal(t, ErrSQLTimeout, msg.Message)
 	finishWait <- nil
 
 	// Stop server

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,17 @@
+package api
+
+const (
+	// Public error messages (included in response objects)
+
+	// ErrDuplicatedKey error message returned when trying to insert an item with duplicated key
+	ErrDuplicatedKey = "Item already exists"
+	// ErrSQLTimeout error message returned when timeout due to SQL connection
+	ErrSQLTimeout = "The node is under heavy preasure, please try again later"
+	// ErrExitAmount0 error message returned when receiving (and rejecting) a tr of type exit with amount 0
+	ErrExitAmount0 = "Transaction rejected because an exit with amount 0 has no sense"
+
+	// Internal error messages (used for logs or handling errors returned from internal comopnents)
+
+	// errCtxTimeout error message received internally when context reaches timeout
+	errCtxTimeout = "context deadline exceeded"
+)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"database/sql"
-	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -29,20 +28,6 @@ const (
 
 	// 2^64 /2 -1
 	maxInt64 = 9223372036854775807
-
-	// Error for duplicated key
-	errDuplicatedKey = "Item already exists"
-
-	// Error for timeout due to SQL connection
-	errSQLTimeout = "The node is under heavy preasure, please try again later"
-
-	// Error message returned when context reaches timeout
-	errCtxTimeout = "context deadline exceeded"
-)
-
-var (
-	// ErrNilBidderAddr is used when a nil bidderAddr is received in the getCoordinator method
-	ErrNilBidderAddr = errors.New("biderAddr can not be nil")
 )
 
 func retSQLErr(err error, c *gin.Context) {
@@ -54,7 +39,7 @@ func retSQLErr(err error, c *gin.Context) {
 		// https://www.postgresql.org/docs/current/errcodes-appendix.html
 		if errCode == "23505" {
 			c.JSON(http.StatusConflict, errorMsg{
-				Message: errDuplicatedKey,
+				Message: ErrDuplicatedKey,
 			})
 		} else {
 			c.JSON(http.StatusInternalServerError, errorMsg{
@@ -64,7 +49,7 @@ func retSQLErr(err error, c *gin.Context) {
 	}
 	if errMsg == errCtxTimeout {
 		c.JSON(http.StatusServiceUnavailable, errorMsg{
-			Message: errSQLTimeout,
+			Message: ErrSQLTimeout,
 		})
 	} else if sqlErr, ok := tracerr.Unwrap(err).(*pq.Error); ok {
 		retDupKey(sqlErr.Code)

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -279,5 +279,13 @@ func (a *API) verifyPoolL2TxWrite(txw *l2db.PoolL2TxWrite) error {
 			))
 		}
 	}
+	// Extra sanity checks: those checks are valid as per the protocol, but are very likely to
+	// have unexpected side effects that could have a negative impact on users
+	switch poolTx.Type {
+	case common.TxTypeExit:
+		if poolTx.Amount.Cmp(big.NewInt(0)) <= 0 {
+			return tracerr.New(ErrExitAmount0)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #788

### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- API will reject transactions of type exit with amount 0
- Separated static API error messages into a dedicate file (`api/errors.go`). The idea is that is a first (tiny) step towards better error messages

### How to test?

<!-- What steps in order should someone run to test -->

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

