### PR TITLE
remove toethaddress and tobjjaddress checks

### DIFF
--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -93,7 +93,7 @@ func NewPoolL2Tx(tx *PoolL2Tx) (*PoolL2Tx, error) {
 // SetType sets the type of the transaction
 func (tx *PoolL2Tx) SetType() error {
 	isAddrEmpty := tx.ToBJJ == EmptyBJJComp && tx.ToEthAddr == EmptyAddr
-	if isAddrEmpty && tx.ToIdx >= IdxUserThreshold {
+	if tx.ToIdx >= IdxUserThreshold {
 		tx.Type = TxTypeTransfer
 	} else if isAddrEmpty && tx.ToIdx == 1 {
 		tx.Type = TxTypeExit

--- a/common/pooll2tx_test.go
+++ b/common/pooll2tx_test.go
@@ -327,18 +327,18 @@ func TestPoolL2Tx_SetType(t *testing.T) {
 		}, {
 			"Send to eth and bjj addresses and idx",
 			&PoolL2Tx{ToBJJ: bjjAddr, ToEthAddr: ethAddr, ToIdx: Idx(400)},
-			TxType(""),
-			true,
+			TxTypeTransfer,
+			false,
 		}, {
 			"Send to FFAddr eth and bjj addresses and idx",
 			&PoolL2Tx{ToBJJ: bjjAddr, ToEthAddr: FFAddr, ToIdx: Idx(400)},
-			TxType(""),
-			true,
+			TxTypeTransfer,
+			false,
 		}, {
 			"Send to FFAddr eth and bjj addresses",
-			&PoolL2Tx{ToBJJ: bjjAddr, ToEthAddr: ethAddr, ToIdx: Idx(0)},
-			TxType(""),
-			true,
+			&PoolL2Tx{ToBJJ: bjjAddr, ToEthAddr: FFAddr, ToIdx: Idx(0)},
+			TxTypeTransferToBJJ,
+			false,
 		}, {
 			"Send to eth and bjj addresses",
 			&PoolL2Tx{ToBJJ: bjjAddr, ToEthAddr: ethAddr, ToIdx: Idx(0)},

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -487,7 +487,7 @@ func (txsel *TxSelector) processL2Txs(tp *txprocessor.TxProcessor,
 				continue
 			}
 		} else if l2Txs[i].ToIdx >= common.IdxUserThreshold {
-			receiverAcc, err := txsel.localAccountsDB.GetAccount(l2Txs[i].ToIdx)
+			_, err := txsel.localAccountsDB.GetAccount(l2Txs[i].ToIdx)
 			if err != nil {
 				// tx not valid
 				log.Debugw("invalid L2Tx: ToIdx not found in StateDB",
@@ -498,38 +498,6 @@ func (txsel *TxSelector) processL2Txs(tp *txprocessor.TxProcessor,
 					"ToIdx: %d", l2Txs[i].ToIdx)
 				discardedL2Txs = append(discardedL2Txs, l2Txs[i])
 				continue
-			}
-			if l2Txs[i].ToEthAddr != common.EmptyAddr {
-				if l2Txs[i].ToEthAddr != receiverAcc.EthAddr {
-					log.Debugw("invalid L2Tx: ToEthAddr does not correspond to the Account.EthAddr",
-						"ToIdx", l2Txs[i].ToIdx, "tx.ToEthAddr",
-						l2Txs[i].ToEthAddr, "account.EthAddr", receiverAcc.EthAddr)
-					// Discard L2Tx, and update Info
-					// parameter of the tx, and add it to
-					// the discardedTxs array
-					l2Txs[i].Info = fmt.Sprintf("Tx not selected because ToEthAddr "+
-						"does not correspond to the Account.EthAddr. "+
-						"tx.ToIdx: %d, tx.ToEthAddr: %s, account.EthAddr: %s",
-						l2Txs[i].ToIdx, l2Txs[i].ToEthAddr, receiverAcc.EthAddr)
-					discardedL2Txs = append(discardedL2Txs, l2Txs[i])
-					continue
-				}
-			}
-			if l2Txs[i].ToBJJ != common.EmptyBJJComp {
-				if l2Txs[i].ToBJJ != receiverAcc.BJJ {
-					log.Debugw("invalid L2Tx: ToBJJ does not correspond to the Account.BJJ",
-						"ToIdx", l2Txs[i].ToIdx, "tx.ToEthAddr", l2Txs[i].ToBJJ,
-						"account.BJJ", receiverAcc.BJJ)
-					// Discard L2Tx, and update Info
-					// parameter of the tx, and add it to
-					// the discardedTxs array
-					l2Txs[i].Info = fmt.Sprintf("Tx not selected because tx.ToBJJ "+
-						"does not correspond to the Account.BJJ. "+
-						"tx.ToIdx: %d, tx.ToEthAddr: %s, tx.ToBJJ: %s, account.BJJ: %s",
-						l2Txs[i].ToIdx, l2Txs[i].ToEthAddr, l2Txs[i].ToBJJ, receiverAcc.BJJ)
-					discardedL2Txs = append(discardedL2Txs, l2Txs[i])
-					continue
-				}
 			}
 		}
 


### PR DESCRIPTION
Closes #749

### What does this PR does?

Remove api and txselector check restrictions to allow use random ethaddress and bjjaddress when a toIdx transfer is performed.

### How to test?

Send an L2 tx with a valid toIdx, and random etherAdddress and bjjAddress.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Include tests
- [X] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

