### PR TITLE
Fix swagger server URLs

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -59,9 +59,11 @@ externalDocs:
   description: Find out more about Hermez network.
   url: 'https://hermez.io'
 servers:
-  - description: Hosted mock up
-    url: https://apimock.hermez.network/v1
-  - description: Localhost mock Up
+  - description: Hermez node on Rinkeby
+    url: https://api.testnet.hermez.io/v1
+  - description: Hermez node on Mainnet
+    url: https://api.hermez.io/v1
+  - description: Localhost, usefull for testing changes locally and required for unit tests
     url: http://localhost:4010/v1
 tags:
   - name: Coordinator


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #810 

### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Change the server list of the swagger file to use deployed servers.
**NOTE:** this is a `hotfix` that will go straight to master! The rationale behind this: Our current deployed documentation https://apidoc.hermez.network/ is broken (the feature `Try it out`) and this commit will fix it 

### How to test?

<!-- What steps in order should someone run to test -->
`cd api && ./run.sh doc`

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

