### PR TITLE
Feature/reafactor pooll2tx types

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -177,7 +177,7 @@ type testCommon struct {
 	accounts         []testAccount
 	txs              []testTx
 	exits            []testExit
-	poolTxsToSend    []testPoolTxSend
+	poolTxsToSend    []common.PoolL2Tx
 	poolTxsToReceive []testPoolTxReceive
 	auths            []testAuth
 	router           *swagger.Router

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -6,38 +6,33 @@ import (
 	"math/big"
 	"net/http"
 
-	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
-	"github.com/hermeznetwork/hermez-node/api/apitypes"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/tracerr"
-	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/yourbasic/graph"
 )
 
 func (a *API) postPoolTx(c *gin.Context) {
 	// Parse body
-	var receivedTx receivedPoolTx
+	var receivedTx common.PoolL2Tx
 	if err := c.ShouldBindJSON(&receivedTx); err != nil {
 		retBadReq(err, c)
 		return
 	}
-	// Transform from received to insert format and validate
-	writeTx := receivedTx.toPoolL2TxWrite()
-	if err := a.verifyPoolL2TxWrite(writeTx); err != nil {
+	// Check that tx is valid
+	if err := a.verifyPoolL2Tx(receivedTx); err != nil {
 		retBadReq(err, c)
 		return
 	}
-	writeTx.ClientIP = c.ClientIP()
+	receivedTx.ClientIP = c.ClientIP()
 	// Insert to DB
-	// note that fee in USD validation happens in this function
-	if err := a.l2.AddTxAPI(writeTx); err != nil {
+	if err := a.l2.AddTxAPI(&receivedTx); err != nil {
 		retSQLErr(err, c)
 		return
 	}
 	// Return TxID
-	c.JSON(http.StatusOK, writeTx.TxID.String())
+	c.JSON(http.StatusOK, receivedTx.TxID.String())
 }
 
 func (a *API) postAtomicPool(c *gin.Context) {
@@ -188,190 +183,68 @@ func (a *API) getPoolTxs(c *gin.Context) {
 	})
 }
 
-type receivedPoolTx struct {
-	TxID        common.TxID             `json:"id" binding:"required"`
-	Type        common.TxType           `json:"type" binding:"required"`
-	TokenID     common.TokenID          `json:"tokenId"`
-	FromIdx     apitypes.StrHezIdx      `json:"fromAccountIndex" binding:"required"`
-	ToIdx       *apitypes.StrHezIdx     `json:"toAccountIndex"`
-	ToEthAddr   *apitypes.StrHezEthAddr `json:"toHezEthereumAddress"`
-	ToBJJ       *apitypes.StrHezBJJ     `json:"toBjj"`
-	Amount      apitypes.StrBigInt      `json:"amount" binding:"required"`
-	Fee         common.FeeSelector      `json:"fee"`
-	Nonce       common.Nonce            `json:"nonce"`
-	Signature   babyjub.SignatureComp   `json:"signature" binding:"required"`
-	RqTxID      *common.TxID            `json:"requestId"`
-	RqFromIdx   *apitypes.StrHezIdx     `json:"requestFromAccountIndex"`
-	RqToIdx     *apitypes.StrHezIdx     `json:"requestToAccountIndex"`
-	RqToEthAddr *apitypes.StrHezEthAddr `json:"requestToHezEthereumAddress"`
-	RqToBJJ     *apitypes.StrHezBJJ     `json:"requestToBjj"`
-	RqTokenID   *common.TokenID         `json:"requestTokenId"`
-	RqAmount    *apitypes.StrBigInt     `json:"requestAmount"`
-	RqFee       *common.FeeSelector     `json:"requestFee"`
-	RqNonce     *common.Nonce           `json:"requestNonce"`
-}
-
-func (tx *receivedPoolTx) toPoolL2TxWrite() *l2db.PoolL2TxWrite {
-	f := new(big.Float).SetInt((*big.Int)(&tx.Amount))
-	amountF, _ := f.Float64()
-	return &l2db.PoolL2TxWrite{
-		TxID:        tx.TxID,
-		FromIdx:     common.Idx(tx.FromIdx),
-		ToIdx:       (*common.Idx)(tx.ToIdx),
-		ToEthAddr:   (*ethCommon.Address)(tx.ToEthAddr),
-		ToBJJ:       (*babyjub.PublicKeyComp)(tx.ToBJJ),
-		TokenID:     tx.TokenID,
-		Amount:      (*big.Int)(&tx.Amount),
-		AmountFloat: amountF,
-		Fee:         tx.Fee,
-		Nonce:       tx.Nonce,
-		State:       common.PoolL2TxStatePending,
-		Signature:   tx.Signature,
-		RqTxID:      (*common.TxID)(tx.RqTxID),
-		RqFromIdx:   (*common.Idx)(tx.RqFromIdx),
-		RqToIdx:     (*common.Idx)(tx.RqToIdx),
-		RqToEthAddr: (*ethCommon.Address)(tx.RqToEthAddr),
-		RqToBJJ:     (*babyjub.PublicKeyComp)(tx.RqToBJJ),
-		RqTokenID:   tx.RqTokenID,
-		RqAmount:    (*big.Int)(tx.RqAmount),
-		RqFee:       tx.RqFee,
-		RqNonce:     tx.RqNonce,
-		Type:        tx.Type,
-	}
-}
-
-func (a *API) verifyPoolL2TxWrite(txw *l2db.PoolL2TxWrite) error {
-	poolTx := common.PoolL2Tx{
-		TxID:    txw.TxID,
-		FromIdx: txw.FromIdx,
-		TokenID: txw.TokenID,
-		Amount:  txw.Amount,
-		Fee:     txw.Fee,
-		Nonce:   txw.Nonce,
-		// State:     txw.State,
-		Signature: txw.Signature,
-		RqAmount:  txw.RqAmount,
-		Type:      txw.Type,
-	}
-	// ToIdx
-	if txw.ToIdx != nil {
-		poolTx.ToIdx = *txw.ToIdx
-	}
-	// ToEthAddr
-	if txw.ToEthAddr == nil {
-		poolTx.ToEthAddr = common.EmptyAddr
-	} else {
-		poolTx.ToEthAddr = *txw.ToEthAddr
-	}
-	// ToBJJ
-	if txw.ToBJJ == nil {
-		poolTx.ToBJJ = common.EmptyBJJComp
-	} else {
-		poolTx.ToBJJ = *txw.ToBJJ
-	}
-	// Rq fields
-	txHasRq := false
-	// RqFromIdx
-	if txw.RqFromIdx != nil {
-		poolTx.RqFromIdx = *txw.RqFromIdx
-		txHasRq = true
-	}
-	// RqToIdx
-	if txw.RqToIdx != nil {
-		poolTx.RqToIdx = *txw.RqToIdx
-	}
-	// RqToEthAddr
-	if txw.RqToEthAddr == nil {
-		poolTx.RqToEthAddr = common.EmptyAddr
-	} else {
-		poolTx.RqToEthAddr = *txw.RqToEthAddr
-	}
-	// RqToBJJ
-	if txw.RqToBJJ == nil {
-		poolTx.RqToBJJ = common.EmptyBJJComp
-	} else {
-		poolTx.RqToBJJ = *txw.RqToBJJ
-	}
-	// RqTokenID
-	if txw.RqTokenID != nil {
-		poolTx.RqTokenID = *txw.RqTokenID
-	}
-	// RqFee
-	if txw.RqFee != nil {
-		poolTx.RqFee = *txw.RqFee
-	}
-	// RqNonce
-	if txw.RqNonce != nil {
-		poolTx.RqNonce = *txw.RqNonce
-	}
-	// RqTxID
-	if txw.RqTxID != nil {
-		poolTx.RqTxID = *txw.RqTxID
-	} else if txHasRq {
-		// If any Rq field is set RqTxID shouldn't be nil
-		return errors.New(ErrRqTxIDNotProvided)
-	}
-	// Check type, id and request id
-	_, err := common.NewPoolL2Tx(&poolTx)
+func (a *API) verifyPoolL2Tx(tx common.PoolL2Tx) error {
+	// Check type and id
+	_, err := common.NewPoolL2Tx(&tx)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
 	// Validate feeAmount
-	_, err = common.CalcFeeAmount(poolTx.Amount, poolTx.Fee)
+	_, err = common.CalcFeeAmount(tx.Amount, tx.Fee)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
 	// Get sender account information
-	account, err := a.h.GetCommonAccountAPI(poolTx.FromIdx)
+	account, err := a.h.GetCommonAccountAPI(tx.FromIdx)
 	if err != nil {
 		return tracerr.Wrap(fmt.Errorf("Error getting from account: %w", err))
 	}
 	// Validate sender:
 	// TokenID
-	if poolTx.TokenID != account.TokenID {
+	if tx.TokenID != account.TokenID {
 		return tracerr.Wrap(fmt.Errorf("tx.TokenID (%v) != account.TokenID (%v)",
-			poolTx.TokenID, account.TokenID))
+			tx.TokenID, account.TokenID))
 	}
 	// Nonce
-	if poolTx.Nonce < account.Nonce {
-		return tracerr.Wrap(fmt.Errorf("poolTx.Nonce (%v) < account.Nonce (%v)",
-			poolTx.Nonce, account.Nonce))
+	if tx.Nonce < account.Nonce {
+		return tracerr.Wrap(fmt.Errorf("tx.Nonce (%v) < account.Nonce (%v)",
+			tx.Nonce, account.Nonce))
 	}
 	// Check signature
-	if !poolTx.VerifySignature(a.cg.ChainID, account.BJJ) {
+	if !tx.VerifySignature(a.cg.ChainID, account.BJJ) {
 		return tracerr.Wrap(errors.New("wrong signature"))
 	}
 	// Check destinatary, note that transactions that are not transfers
 	// will always be valid in terms of destinatary (they use special ToIdx by protocol)
-	switch poolTx.Type {
+	switch tx.Type {
 	case common.TxTypeTransfer:
 		// ToIdx exists and match token
-		toAccount, err := a.h.GetCommonAccountAPI(poolTx.ToIdx)
+		toAccount, err := a.h.GetCommonAccountAPI(tx.ToIdx)
 		if err != nil {
 			return tracerr.Wrap(fmt.Errorf("Error getting to account: %w", err))
 		}
-		if poolTx.TokenID != toAccount.TokenID {
+		if tx.TokenID != toAccount.TokenID {
 			return tracerr.Wrap(fmt.Errorf("tx.TokenID (%v) != toAccount.TokenID (%v)",
-				poolTx.TokenID, toAccount.TokenID))
+				tx.TokenID, toAccount.TokenID))
 		}
 	case common.TxTypeTransferToEthAddr:
 		// ToEthAddr has account created with matching token ID or authorization
-		ok, err := a.h.CanSendToEthAddr(poolTx.ToEthAddr, poolTx.TokenID)
+		ok, err := a.h.CanSendToEthAddr(tx.ToEthAddr, tx.TokenID)
 		if err != nil {
 			return err
 		}
 		if !ok {
 			return tracerr.Wrap(fmt.Errorf(
 				"Destination eth addr (%v) has not a valid account created nor authorization",
-				poolTx.ToEthAddr,
+				tx.ToEthAddr,
 			))
 		}
 	}
 	// Extra sanity checks: those checks are valid as per the protocol, but are very likely to
 	// have unexpected side effects that could have a negative impact on users
-	switch poolTx.Type {
+	switch tx.Type {
 	case common.TxTypeExit:
-		if poolTx.Amount.Cmp(big.NewInt(0)) <= 0 {
+		if tx.Amount.Cmp(big.NewInt(0)) <= 0 {
 			return tracerr.New(ErrExitAmount0)
 		}
 	}

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -37,7 +37,7 @@ func (a *API) postPoolTx(c *gin.Context) {
 
 func (a *API) postAtomicPool(c *gin.Context) {
 	// Parse body
-	var receivedTxs []receivedPoolTx
+	var receivedTxs []common.PoolL2Tx
 	if err := c.ShouldBindJSON(&receivedTxs); err != nil {
 		retBadReq(err, c)
 		return
@@ -47,27 +47,24 @@ func (a *API) postAtomicPool(c *gin.Context) {
 		retBadReq(errors.New(ErrSingleTxInAtomicEndpoint), c)
 		return
 	}
-	// Transform from received to insert format and validate (individually)
-	writeTxs := make([]l2db.PoolL2TxWrite, nTxs) // used for DB insert
-	txIDStrings := make([]string, nTxs)          // used for successful response
+	// Validate txs individually
+	txIDStrings := make([]string, nTxs) // used for successful response
 	clientIP := c.ClientIP()
 	for i, tx := range receivedTxs {
-		writeTx := tx.toPoolL2TxWrite()
-		if err := a.verifyPoolL2TxWrite(writeTx); err != nil {
+		if err := a.verifyPoolL2Tx(tx); err != nil {
 			retBadReq(err, c)
 			return
 		}
-		writeTx.ClientIP = clientIP
-		writeTxs[i] = *writeTx
-		txIDStrings[i] = writeTx.TxID.String()
+		receivedTxs[i].ClientIP = clientIP
+		txIDStrings[i] = tx.TxID.String()
 	}
 	// Validate that all txs in the payload represent an atomic group
-	if !isAtomicGroup(writeTxs) {
+	if !isAtomicGroup(receivedTxs) {
 		retBadReq(errors.New(ErrTxsNotAtomic), c)
 		return
 	}
 	// Insert to DB
-	if err := a.l2.AddAtomicTxsAPI(writeTxs); err != nil {
+	if err := a.l2.AddAtomicTxsAPI(receivedTxs); err != nil {
 		retSQLErr(err, c)
 		return
 	}
@@ -77,7 +74,7 @@ func (a *API) postAtomicPool(c *gin.Context) {
 
 // isAtomicGroup returns true if all the txs are needed to be forged
 // (all txs will be forged in the same batch or non of them will be forged)
-func isAtomicGroup(txs []l2db.PoolL2TxWrite) bool {
+func isAtomicGroup(txs []common.PoolL2Tx) bool {
 	// Create a graph from the given txs to represent requests between transactions
 	g := graph.New(len(txs))
 	idToPos := make(map[common.TxID]int, len(txs))
@@ -87,12 +84,12 @@ func isAtomicGroup(txs []l2db.PoolL2TxWrite) bool {
 	}
 	// Create vertices that connect nodes of the graph (txs) using RqTxID
 	for i, tx := range txs {
-		if tx.RqTxID == nil {
+		if tx.RqTxID == common.EmptyTxID {
 			// if just one tx doesn't request any other tx, this tx could be forged alone
 			// making the hole group not atomic
 			return false
 		}
-		if rqTxPos, ok := idToPos[*tx.RqTxID]; ok {
+		if rqTxPos, ok := idToPos[tx.RqTxID]; ok {
 			g.Add(i, rqTxPos)
 		} else {
 			// tx is requesting a tx that is not provided in the payload

--- a/api/txspool_test.go
+++ b/api/txspool_test.go
@@ -74,51 +74,24 @@ func (t testPoolTxsResponse) Len() int {
 
 func (t testPoolTxsResponse) New() Pendinger { return &testPoolTxsResponse{} }
 
-// testPoolTxSend is a struct to be used as a JSON body
-// when testing POST /transactions-pool
-type testPoolTxSend struct {
-	TxID        common.TxID           `json:"id" binding:"required"`
-	Type        common.TxType         `json:"type" binding:"required"`
-	TokenID     common.TokenID        `json:"tokenId"`
-	FromIdx     string                `json:"fromAccountIndex" binding:"required"`
-	ToIdx       *string               `json:"toAccountIndex"`
-	ToEthAddr   *string               `json:"toHezEthereumAddress"`
-	ToBJJ       *string               `json:"toBjj"`
-	Amount      string                `json:"amount" binding:"required"`
-	Fee         common.FeeSelector    `json:"fee"`
-	Nonce       common.Nonce          `json:"nonce"`
-	Signature   babyjub.SignatureComp `json:"signature" binding:"required"`
-	RqTxID      *common.TxID          `json:"requestId" binding:"required"`
-	RqFromIdx   *string               `json:"requestFromAccountIndex"`
-	RqToIdx     *string               `json:"requestToAccountIndex"`
-	RqToEthAddr *string               `json:"requestToHezEthereumAddress"`
-	RqToBJJ     *string               `json:"requestToBjj"`
-	RqTokenID   *common.TokenID       `json:"requestTokenId"`
-	RqAmount    *string               `json:"requestAmount"`
-	RqFee       *common.FeeSelector   `json:"requestFee"`
-	RqNonce     *common.Nonce         `json:"requestNonce"`
-}
-
 func genTestPoolTxs(
 	poolTxs []common.PoolL2Tx,
 	tokens []historydb.TokenWithUSD,
 	accs []common.Account,
-) (poolTxsToSend []testPoolTxSend, poolTxsToReceive []testPoolTxReceive) {
-	poolTxsToSend = []testPoolTxSend{}
+) (poolTxsToSend []common.PoolL2Tx, poolTxsToReceive []testPoolTxReceive) {
+	poolTxsToSend = []common.PoolL2Tx{}
 	poolTxsToReceive = []testPoolTxReceive{}
 	for _, poolTx := range poolTxs {
-		// common.PoolL2Tx ==> testPoolTxSend
+		// common.PoolL2Tx ==> poolTxsToSend (add token symbols for proper marshaling)
 		token := getTokenByID(poolTx.TokenID, tokens)
-		genSendTx := testPoolTxSend{
-			TxID:      poolTx.TxID,
-			Type:      poolTx.Type,
-			TokenID:   poolTx.TokenID,
-			FromIdx:   idxToHez(poolTx.FromIdx, token.Symbol),
-			Amount:    poolTx.Amount.String(),
-			Fee:       poolTx.Fee,
-			Nonce:     poolTx.Nonce,
-			Signature: poolTx.Signature,
+		txToSend := poolTx
+		txToSend.TokenSymbol = token.Symbol
+		var rqToken historydb.TokenWithUSD
+		if poolTx.RqToIdx != 0 {
+			rqToken = getTokenByID(poolTx.RqTokenID, tokens)
+			txToSend.RqTokenSymbol = rqToken.Symbol
 		}
+		poolTxsToSend = append(poolTxsToSend, txToSend)
 		// common.PoolL2Tx ==> testPoolTxReceive
 		genReceiveTx := testPoolTxReceive{
 			TxID:      poolTx.TxID,
@@ -130,22 +103,17 @@ func genTestPoolTxs(
 			State:     poolTx.State,
 			Signature: poolTx.Signature,
 			Timestamp: poolTx.Timestamp,
-			// BatchNum:    poolTx.BatchNum,
-			Token: token,
+			Token:     token,
 		}
 		fromAcc := getAccountByIdx(poolTx.FromIdx, accs)
 		fromAddr := ethAddrToHez(fromAcc.EthAddr)
 		genReceiveTx.FromEthAddr = &fromAddr
 		fromBjj := bjjToString(fromAcc.BJJ)
 		genReceiveTx.FromBJJ = &fromBjj
-		if poolTx.ToIdx != 0 {
-			toIdx := idxToHez(poolTx.ToIdx, token.Symbol)
-			genSendTx.ToIdx = &toIdx
-			genReceiveTx.ToIdx = &toIdx
-		}
+		toIdx := idxToHez(poolTx.ToIdx, token.Symbol)
+		genReceiveTx.ToIdx = &toIdx
 		if poolTx.ToEthAddr != common.EmptyAddr {
 			toEth := ethAddrToHez(poolTx.ToEthAddr)
-			genSendTx.ToEthAddr = &toEth
 			genReceiveTx.ToEthAddr = &toEth
 		} else if poolTx.ToIdx > 255 {
 			acc := getAccountByIdx(poolTx.ToIdx, accs)
@@ -154,7 +122,6 @@ func genTestPoolTxs(
 		}
 		if poolTx.ToBJJ != common.EmptyBJJComp {
 			toBJJ := bjjToString(poolTx.ToBJJ)
-			genSendTx.ToBJJ = &toBJJ
 			genReceiveTx.ToBJJ = &toBJJ
 		} else if poolTx.ToIdx > 255 {
 			acc := getAccountByIdx(poolTx.ToIdx, accs)
@@ -162,6 +129,7 @@ func genTestPoolTxs(
 			genReceiveTx.ToBJJ = &bjj
 		}
 		if poolTx.RqFromIdx != 0 {
+<<<<<<< HEAD
 			rqFromIdx := idxToHez(poolTx.RqFromIdx, token.Symbol)
 			rqTxID := poolTx.RqTxID
 			rqFee := poolTx.RqFee
@@ -173,31 +141,30 @@ func genTestPoolTxs(
 			genSendTx.RqNonce = &rqNonce
 			genReceiveTx.RqNonce = &rqNonce
 			genSendTx.RqFromIdx = &rqFromIdx
+=======
+			rqFromIdx := idxToHez(poolTx.RqFromIdx, rqToken.Symbol)
+>>>>>>> Merge api.receivedPoolTx, api.testPoolTxSend and l2db.PoolL2TxWrite into common.PoolL2Tx
 			genReceiveTx.RqFromIdx = &rqFromIdx
-			genSendTx.RqTokenID = &token.TokenID
-			genReceiveTx.RqTokenID = &token.TokenID
+			genReceiveTx.RqTokenID = &rqToken.TokenID
 			rqAmount := poolTx.RqAmount.String()
-			genSendTx.RqAmount = &rqAmount
 			genReceiveTx.RqAmount = &rqAmount
+			genReceiveTx.RqFee = &poolTx.RqFee
+			genReceiveTx.RqNonce = &poolTx.RqNonce
 
 			if poolTx.RqToIdx != 0 {
-				rqToIdx := idxToHez(poolTx.RqToIdx, token.Symbol)
-				genSendTx.RqToIdx = &rqToIdx
+				rqToIdx := idxToHez(poolTx.RqToIdx, rqToken.Symbol)
 				genReceiveTx.RqToIdx = &rqToIdx
 			}
 			if poolTx.RqToEthAddr != common.EmptyAddr {
 				rqToEth := ethAddrToHez(poolTx.RqToEthAddr)
-				genSendTx.RqToEthAddr = &rqToEth
 				genReceiveTx.RqToEthAddr = &rqToEth
 			}
 			if poolTx.RqToBJJ != common.EmptyBJJComp {
 				rqToBJJ := bjjToString(poolTx.RqToBJJ)
-				genSendTx.RqToBJJ = &rqToBJJ
 				genReceiveTx.RqToBJJ = &rqToBJJ
 			}
 		}
 
-		poolTxsToSend = append(poolTxsToSend, genSendTx)
 		poolTxsToReceive = append(poolTxsToReceive, genReceiveTx)
 	}
 	return poolTxsToSend, poolTxsToReceive
@@ -223,7 +190,7 @@ func TestPoolTxs(t *testing.T) {
 	// 400
 	// Wrong fee
 	badTx := tc.poolTxsToSend[0]
-	badTx.Amount = "99950000000000000"
+	badTx.Amount = big.NewInt(99950000000000000)
 	badTx.Fee = 255
 	jsonTxBytes, err := json.Marshal(badTx)
 	require.NoError(t, err)
@@ -232,7 +199,7 @@ func TestPoolTxs(t *testing.T) {
 	require.NoError(t, err)
 	// Wrong signature
 	badTx = tc.poolTxsToSend[0]
-	badTx.FromIdx = "hez:foo:1000"
+	badTx.FromIdx = 1000
 	jsonTxBytes, err = json.Marshal(badTx)
 	require.NoError(t, err)
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
@@ -240,9 +207,8 @@ func TestPoolTxs(t *testing.T) {
 	require.NoError(t, err)
 	// Wrong to
 	badTx = tc.poolTxsToSend[0]
-	ethAddr := "hez:0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-	badTx.ToEthAddr = &ethAddr
-	badTx.ToIdx = nil
+	badTx.ToEthAddr = common.FFAddr
+	badTx.ToIdx = 0
 	jsonTxBytes, err = json.Marshal(badTx)
 	require.NoError(t, err)
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
@@ -250,8 +216,8 @@ func TestPoolTxs(t *testing.T) {
 	require.NoError(t, err)
 	// Wrong rq
 	badTx = tc.poolTxsToSend[0]
-	rqFromIdx := "hez:foo:30"
-	badTx.RqFromIdx = &rqFromIdx
+	badTx.RqFromIdx = 30
+	badTx.RqTokenSymbol = "FOO"
 	jsonTxBytes, err = json.Marshal(badTx)
 	require.NoError(t, err)
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
@@ -535,19 +501,10 @@ func TestAllTosNull(t *testing.T) {
 	assert.NoError(t, err)
 	sig := sk.SignPoseidon(toSign)
 	tx.Signature = sig.Compress()
-	// Transform common.PoolL2Tx ==> testPoolTxSend
-	txToSend := testPoolTxSend{
-		TxID:      tx.TxID,
-		Type:      tx.Type,
-		TokenID:   tx.TokenID,
-		FromIdx:   idxToHez(tx.FromIdx, "ETH"),
-		Amount:    tx.Amount.String(),
-		Fee:       tx.Fee,
-		Nonce:     tx.Nonce,
-		Signature: tx.Signature,
-	}
+	// Add token symbol for mashaling
+	tx.TokenSymbol = "ETH"
 	// Send tx to the API
-	jsonTxBytes, err := json.Marshal(txToSend)
+	jsonTxBytes, err := json.Marshal(tx)
 	require.NoError(t, err)
 	jsonTxReader := bytes.NewReader(jsonTxBytes)
 	err = doBadReq("POST", apiURL+"transactions-pool", jsonTxReader, 400)

--- a/api/txspool_test.go
+++ b/api/txspool_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db"
 	"github.com/hermeznetwork/hermez-node/db/historydb"
-	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/iden3/go-iden3-crypto/babyjub"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
@@ -81,86 +80,73 @@ func genTestPoolTxs(
 ) (poolTxsToSend []common.PoolL2Tx, poolTxsToReceive []testPoolTxReceive) {
 	poolTxsToSend = []common.PoolL2Tx{}
 	poolTxsToReceive = []testPoolTxReceive{}
-	for _, poolTx := range poolTxs {
+	for i := range poolTxs {
 		// common.PoolL2Tx ==> poolTxsToSend (add token symbols for proper marshaling)
-		token := getTokenByID(poolTx.TokenID, tokens)
-		txToSend := poolTx
+		token := getTokenByID(poolTxs[i].TokenID, tokens)
+		txToSend := poolTxs[i]
 		txToSend.TokenSymbol = token.Symbol
 		var rqToken historydb.TokenWithUSD
-		if poolTx.RqToIdx != 0 {
-			rqToken = getTokenByID(poolTx.RqTokenID, tokens)
+		if poolTxs[i].RqToIdx != 0 {
+			rqToken = getTokenByID(poolTxs[i].RqTokenID, tokens)
 			txToSend.RqTokenSymbol = rqToken.Symbol
 		}
 		poolTxsToSend = append(poolTxsToSend, txToSend)
 		// common.PoolL2Tx ==> testPoolTxReceive
 		genReceiveTx := testPoolTxReceive{
-			TxID:      poolTx.TxID,
-			Type:      poolTx.Type,
-			FromIdx:   idxToHez(poolTx.FromIdx, token.Symbol),
-			Amount:    poolTx.Amount.String(),
-			Fee:       poolTx.Fee,
-			Nonce:     poolTx.Nonce,
-			State:     poolTx.State,
-			Signature: poolTx.Signature,
-			Timestamp: poolTx.Timestamp,
+			TxID:      poolTxs[i].TxID,
+			Type:      poolTxs[i].Type,
+			FromIdx:   idxToHez(poolTxs[i].FromIdx, token.Symbol),
+			Amount:    poolTxs[i].Amount.String(),
+			Fee:       poolTxs[i].Fee,
+			Nonce:     poolTxs[i].Nonce,
+			State:     poolTxs[i].State,
+			Signature: poolTxs[i].Signature,
+			Timestamp: poolTxs[i].Timestamp,
 			Token:     token,
 		}
-		fromAcc := getAccountByIdx(poolTx.FromIdx, accs)
+		fromAcc := getAccountByIdx(poolTxs[i].FromIdx, accs)
 		fromAddr := ethAddrToHez(fromAcc.EthAddr)
 		genReceiveTx.FromEthAddr = &fromAddr
 		fromBjj := bjjToString(fromAcc.BJJ)
 		genReceiveTx.FromBJJ = &fromBjj
-		toIdx := idxToHez(poolTx.ToIdx, token.Symbol)
+		toIdx := idxToHez(poolTxs[i].ToIdx, token.Symbol)
 		genReceiveTx.ToIdx = &toIdx
-		if poolTx.ToEthAddr != common.EmptyAddr {
-			toEth := ethAddrToHez(poolTx.ToEthAddr)
+		if poolTxs[i].ToEthAddr != common.EmptyAddr {
+			toEth := ethAddrToHez(poolTxs[i].ToEthAddr)
 			genReceiveTx.ToEthAddr = &toEth
-		} else if poolTx.ToIdx > 255 {
-			acc := getAccountByIdx(poolTx.ToIdx, accs)
+		} else if poolTxs[i].ToIdx > 255 {
+			acc := getAccountByIdx(poolTxs[i].ToIdx, accs)
 			addr := ethAddrToHez(acc.EthAddr)
 			genReceiveTx.ToEthAddr = &addr
 		}
-		if poolTx.ToBJJ != common.EmptyBJJComp {
-			toBJJ := bjjToString(poolTx.ToBJJ)
+		if poolTxs[i].ToBJJ != common.EmptyBJJComp {
+			toBJJ := bjjToString(poolTxs[i].ToBJJ)
 			genReceiveTx.ToBJJ = &toBJJ
-		} else if poolTx.ToIdx > 255 {
-			acc := getAccountByIdx(poolTx.ToIdx, accs)
+		} else if poolTxs[i].ToIdx > 255 {
+			acc := getAccountByIdx(poolTxs[i].ToIdx, accs)
 			bjj := bjjToString(acc.BJJ)
 			genReceiveTx.ToBJJ = &bjj
 		}
-		if poolTx.RqFromIdx != 0 {
-<<<<<<< HEAD
-			rqFromIdx := idxToHez(poolTx.RqFromIdx, token.Symbol)
-			rqTxID := poolTx.RqTxID
-			rqFee := poolTx.RqFee
-			rqNonce := poolTx.RqNonce
-			genSendTx.RqTxID = &rqTxID
-			genReceiveTx.RqTxID = &rqTxID
-			genSendTx.RqFee = &rqFee
-			genReceiveTx.RqFee = &rqFee
-			genSendTx.RqNonce = &rqNonce
-			genReceiveTx.RqNonce = &rqNonce
-			genSendTx.RqFromIdx = &rqFromIdx
-=======
-			rqFromIdx := idxToHez(poolTx.RqFromIdx, rqToken.Symbol)
->>>>>>> Merge api.receivedPoolTx, api.testPoolTxSend and l2db.PoolL2TxWrite into common.PoolL2Tx
+		if poolTxs[i].RqFromIdx != 0 {
+			rqFromIdx := idxToHez(poolTxs[i].RqFromIdx, rqToken.Symbol)
 			genReceiveTx.RqFromIdx = &rqFromIdx
+			genReceiveTx.RqTxID = &poolTxs[i].RqTxID
 			genReceiveTx.RqTokenID = &rqToken.TokenID
-			rqAmount := poolTx.RqAmount.String()
+			rqAmount := poolTxs[i].RqAmount.String()
 			genReceiveTx.RqAmount = &rqAmount
-			genReceiveTx.RqFee = &poolTx.RqFee
-			genReceiveTx.RqNonce = &poolTx.RqNonce
+			genReceiveTx.RqFee = &poolTxs[i].RqFee
+			genReceiveTx.RqNonce = &poolTxs[i].RqNonce
 
-			if poolTx.RqToIdx != 0 {
-				rqToIdx := idxToHez(poolTx.RqToIdx, rqToken.Symbol)
+			if poolTxs[i].RqToIdx != 0 {
+				rqToIdx := idxToHez(poolTxs[i].RqToIdx, rqToken.Symbol)
 				genReceiveTx.RqToIdx = &rqToIdx
 			}
-			if poolTx.RqToEthAddr != common.EmptyAddr {
-				rqToEth := ethAddrToHez(poolTx.RqToEthAddr)
+			if poolTxs[i].RqToEthAddr != common.EmptyAddr {
+				rqToEth := ethAddrToHez(poolTxs[i].RqToEthAddr)
 				genReceiveTx.RqToEthAddr = &rqToEth
 			}
-			if poolTx.RqToBJJ != common.EmptyBJJComp {
-				rqToBJJ := bjjToString(poolTx.RqToBJJ)
+			if poolTxs[i].RqToBJJ != common.EmptyBJJComp {
+				rqToBJJ := bjjToString(poolTxs[i].RqToBJJ)
 				genReceiveTx.RqToBJJ = &rqToBJJ
 			}
 		}
@@ -551,7 +537,7 @@ func TestAtomicPool(t *testing.T) {
 	err = api.h.AddAccountUpdates(accountUpdates)
 	assert.NoError(t, err)
 
-	signAndTransformTxs := func(txs []common.PoolL2Tx) ([]testPoolTxSend, []testPoolTxReceive) {
+	signAndTransformTxs := func(txs []common.PoolL2Tx) ([]common.PoolL2Tx, []testPoolTxReceive) {
 		for i := 0; i < len(txs); i++ {
 			// Set TxID and type
 			_, err := common.NewPoolL2Tx(&txs[i])
@@ -762,7 +748,7 @@ func TestAtomicPool(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test send only one tx
-	jsonTxBytes, err = json.Marshal([]testPoolTxSend{tc.poolTxsToSend[0]})
+	jsonTxBytes, err = json.Marshal([]common.PoolL2Tx{tc.poolTxsToSend[0]})
 	require.NoError(t, err)
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
 	err = doBadReq("POST", path, jsonTxReader, 400)
@@ -794,42 +780,42 @@ func generateKeys(random int) (ethCommon.Address, babyjub.PrivateKey) {
 func TestIsAtomic(t *testing.T) {
 	// NOT atomic cases
 	// Empty group
-	txs := []l2db.PoolL2TxWrite{}
+	txs := []common.PoolL2Tx{}
 	assert.False(t, isAtomicGroup(txs))
 
 	// Case missing tx: 1 ==> 2 ==> 3 ==> (4: not provided)
-	txs = []l2db.PoolL2TxWrite{
-		{TxID: common.TxID{1}, RqTxID: &common.TxID{2}},
-		{TxID: common.TxID{2}, RqTxID: &common.TxID{3}},
-		{TxID: common.TxID{3}, RqTxID: &common.TxID{4}},
+	txs = []common.PoolL2Tx{
+		{TxID: common.TxID{1}, RqTxID: common.TxID{2}},
+		{TxID: common.TxID{2}, RqTxID: common.TxID{3}},
+		{TxID: common.TxID{3}, RqTxID: common.TxID{4}},
 	}
 	assert.False(t, isAtomicGroup(txs))
 
 	// Case loneley tx: 1 ==> 2 ==> 3 ==> 1 <== (4: no buddy references 4th tx)
-	txs = []l2db.PoolL2TxWrite{
-		{TxID: common.TxID{1}, RqTxID: &common.TxID{2}},
-		{TxID: common.TxID{2}, RqTxID: &common.TxID{3}},
-		{TxID: common.TxID{3}, RqTxID: &common.TxID{1}},
-		{TxID: common.TxID{4}, RqTxID: &common.TxID{1}},
+	txs = []common.PoolL2Tx{
+		{TxID: common.TxID{1}, RqTxID: common.TxID{2}},
+		{TxID: common.TxID{2}, RqTxID: common.TxID{3}},
+		{TxID: common.TxID{3}, RqTxID: common.TxID{1}},
+		{TxID: common.TxID{4}, RqTxID: common.TxID{1}},
 	}
 	assert.False(t, isAtomicGroup(txs))
 
 	// Case two groups: 1 <==> 2  3 <==> 4
-	txs = []l2db.PoolL2TxWrite{
-		{TxID: common.TxID{1}, RqTxID: &common.TxID{2}},
-		{TxID: common.TxID{2}, RqTxID: &common.TxID{1}},
-		{TxID: common.TxID{3}, RqTxID: &common.TxID{4}},
-		{TxID: common.TxID{4}, RqTxID: &common.TxID{3}},
+	txs = []common.PoolL2Tx{
+		{TxID: common.TxID{1}, RqTxID: common.TxID{2}},
+		{TxID: common.TxID{2}, RqTxID: common.TxID{1}},
+		{TxID: common.TxID{3}, RqTxID: common.TxID{4}},
+		{TxID: common.TxID{4}, RqTxID: common.TxID{3}},
 	}
 	assert.False(t, isAtomicGroup(txs))
 
 	// Atomic cases
 	// Case circular: 1 ==> 2 ==> 3 ==> 4 ==> 1
-	txs = []l2db.PoolL2TxWrite{
-		{TxID: common.TxID{1}, RqTxID: &common.TxID{2}},
-		{TxID: common.TxID{2}, RqTxID: &common.TxID{3}},
-		{TxID: common.TxID{3}, RqTxID: &common.TxID{4}},
-		{TxID: common.TxID{4}, RqTxID: &common.TxID{1}},
+	txs = []common.PoolL2Tx{
+		{TxID: common.TxID{1}, RqTxID: common.TxID{2}},
+		{TxID: common.TxID{2}, RqTxID: common.TxID{3}},
+		{TxID: common.TxID{3}, RqTxID: common.TxID{4}},
+		{TxID: common.TxID{4}, RqTxID: common.TxID{1}},
 	}
 	assert.True(t, isAtomicGroup(txs))
 }

--- a/common/formats.go
+++ b/common/formats.go
@@ -1,0 +1,309 @@
+package common
+
+import (
+	"database/sql/driver"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/hermeznetwork/tracerr"
+	"github.com/iden3/go-iden3-crypto/babyjub"
+)
+
+/*
+	This is a WIP refactor to simplify how API types are used
+	at the moment this is a copy of api/apitypes/apitypes.go (just fixing namespace errors) to avoid circular imports.
+	The idea is to gradually stop using api/apitypes package in favor of just using common,
+	but since there is a lot of code depending on this it's hard to do it in a single shot.
+
+	Things added that were not included in api/apitypes/apitypes.go:
+	- Modified StrHezIdx to include TokenSymbol
+	- Added func idxToHez(idx Idx, tokenSymbol string) string (copy from api/parsers.go)
+	- Added func ethAddrToHez(addr ethCommon.Address) string (copy from api/parsers.go)
+	- Added func bjjToString(bjj babyjub.PublicKeyComp) string (copy from api/parsers.go)
+
+*/
+
+// BigIntStr is used to scan/value *big.Int directly into strings from/to sql DBs.
+// It assumes that *big.Int are inserted/fetched to/from the DB using the BigIntMeddler meddler
+// defined at github.com/hermeznetwork/hermez-node/db.  Since *big.Int is
+// stored as DECIMAL in SQL, there's no need to implement Scan()/Value()
+// because DECIMALS are encoded/decoded as strings by the sql driver, and
+// BigIntStr is already a string.
+type BigIntStr string
+
+// NewBigIntStr creates a *BigIntStr from a *big.Int.
+// If the provided bigInt is nil the returned *BigIntStr will also be nil
+func NewBigIntStr(bigInt *big.Int) *BigIntStr {
+	if bigInt == nil {
+		return nil
+	}
+	bigIntStr := BigIntStr(bigInt.String())
+	return &bigIntStr
+}
+
+// StrBigInt is used to unmarshal BigIntStr directly into an alias of big.Int
+type StrBigInt big.Int
+
+// UnmarshalText unmarshals a StrBigInt
+func (s *StrBigInt) UnmarshalText(text []byte) error {
+	bi, ok := (*big.Int)(s).SetString(string(text), 10)
+	if !ok {
+		return tracerr.Wrap(fmt.Errorf("could not unmarshal %s into a StrBigInt", text))
+	}
+	*s = StrBigInt(*bi)
+	return nil
+}
+
+// CollectedFeesAPI is send common.batch.CollectedFee through the API
+type CollectedFeesAPI map[TokenID]BigIntStr
+
+// NewCollectedFeesAPI creates a new CollectedFeesAPI from a *big.Int map
+func NewCollectedFeesAPI(m map[TokenID]*big.Int) CollectedFeesAPI {
+	c := CollectedFeesAPI(make(map[TokenID]BigIntStr))
+	for k, v := range m {
+		c[k] = *NewBigIntStr(v)
+	}
+	return c
+}
+
+// HezEthAddr is used to scan/value Ethereum Address directly into strings that follow the Ethereum address hez format (^hez:0x[a-fA-F0-9]{40}$) from/to sql DBs.
+// It assumes that Ethereum Address are inserted/fetched to/from the DB using the default Scan/Value interface
+type HezEthAddr string
+
+// NewHezEthAddr creates a HezEthAddr from an Ethereum addr
+func NewHezEthAddr(addr ethCommon.Address) HezEthAddr {
+	return HezEthAddr("hez:" + addr.String())
+}
+
+// ToEthAddr returns an Ethereum Address created from HezEthAddr
+func (a HezEthAddr) ToEthAddr() (ethCommon.Address, error) {
+	addrStr := strings.TrimPrefix(string(a), "hez:")
+	var addr ethCommon.Address
+	return addr, addr.UnmarshalText([]byte(addrStr))
+}
+
+// Scan implements Scanner for database/sql
+func (a *HezEthAddr) Scan(src interface{}) error {
+	ethAddr := &ethCommon.Address{}
+	if err := ethAddr.Scan(src); err != nil {
+		return tracerr.Wrap(err)
+	}
+	if ethAddr == nil {
+		return nil
+	}
+	*a = NewHezEthAddr(*ethAddr)
+	return nil
+}
+
+// Value implements valuer for database/sql
+func (a HezEthAddr) Value() (driver.Value, error) {
+	ethAddr, err := a.ToEthAddr()
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	return ethAddr.Value()
+}
+
+// StrHezEthAddr is used to unmarshal HezEthAddr directly into an alias of ethCommon.Address
+type StrHezEthAddr ethCommon.Address
+
+// UnmarshalText unmarshals a StrHezEthAddr
+func (s *StrHezEthAddr) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*s = StrHezEthAddr(EmptyAddr)
+		return nil
+	}
+	withoutHez := strings.TrimPrefix(string(text), "hez:")
+	var addr ethCommon.Address
+	if err := addr.UnmarshalText([]byte(withoutHez)); err != nil {
+		return tracerr.Wrap(err)
+	}
+	*s = StrHezEthAddr(addr)
+	return nil
+}
+
+// HezBJJ is used to scan/value *babyjub.PublicKeyComp directly into strings that follow the BJJ public key hez format (^hez:[A-Za-z0-9_-]{44}$) from/to sql DBs.
+// It assumes that *babyjub.PublicKeyComp are inserted/fetched to/from the DB using the default Scan/Value interface
+type HezBJJ string
+
+// NewHezBJJ creates a HezBJJ from a *babyjub.PublicKeyComp.
+// Calling this method with a nil bjj causes panic
+func NewHezBJJ(pkComp babyjub.PublicKeyComp) HezBJJ {
+	sum := pkComp[0]
+	for i := 1; i < len(pkComp); i++ {
+		sum += pkComp[i]
+	}
+	bjjSum := append(pkComp[:], sum)
+	return HezBJJ("hez:" + base64.RawURLEncoding.EncodeToString(bjjSum))
+}
+
+func hezStrToBJJ(s string) (babyjub.PublicKeyComp, error) {
+	const (
+		decodedLen = 33
+		encodedLen = 44
+	)
+	formatErr := errors.New("invalid BJJ format. Must follow this regex: ^hez:[A-Za-z0-9_-]{44}$")
+	encoded := strings.TrimPrefix(s, "hez:")
+	if len(encoded) != encodedLen {
+		return EmptyBJJComp, formatErr
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return EmptyBJJComp, formatErr
+	}
+	if len(decoded) != decodedLen {
+		return EmptyBJJComp, formatErr
+	}
+	bjjBytes := [decodedLen - 1]byte{}
+	copy(bjjBytes[:decodedLen-1], decoded[:decodedLen-1])
+	sum := bjjBytes[0]
+	for i := 1; i < len(bjjBytes); i++ {
+		sum += bjjBytes[i]
+	}
+	if decoded[decodedLen-1] != sum {
+		return EmptyBJJComp, tracerr.Wrap(errors.New("checksum verification failed"))
+	}
+	bjjComp := babyjub.PublicKeyComp(bjjBytes)
+	return bjjComp, nil
+}
+
+// ToBJJ returns a babyjub.PublicKeyComp created from HezBJJ
+func (b HezBJJ) ToBJJ() (babyjub.PublicKeyComp, error) {
+	return hezStrToBJJ(string(b))
+}
+
+// Scan implements Scanner for database/sql
+func (b *HezBJJ) Scan(src interface{}) error {
+	bjj := &babyjub.PublicKeyComp{}
+	if err := bjj.Scan(src); err != nil {
+		return tracerr.Wrap(err)
+	}
+	if bjj == nil {
+		return nil
+	}
+	*b = NewHezBJJ(*bjj)
+	return nil
+}
+
+// Value implements valuer for database/sql
+func (b HezBJJ) Value() (driver.Value, error) {
+	bjj, err := b.ToBJJ()
+	if err != nil {
+		return nil, tracerr.Wrap(err)
+	}
+	return bjj.Value()
+}
+
+// StrHezBJJ is used to unmarshal HezBJJ directly into an alias of babyjub.PublicKeyComp
+type StrHezBJJ babyjub.PublicKeyComp
+
+// UnmarshalText unmarshalls a StrHezBJJ
+func (s *StrHezBJJ) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*s = StrHezBJJ(EmptyBJJComp)
+		return nil
+	}
+	bjj, err := hezStrToBJJ(string(text))
+	if err != nil {
+		return tracerr.Wrap(err)
+	}
+	*s = StrHezBJJ(bjj)
+	return nil
+}
+
+// HezIdx is used to value Idx directly into strings that follow the Idx key hez format (hez:tokenSymbol:idx) to sql DBs.
+// Note that this can only be used to insert to DB since there is no way to automatically read from the DB since it needs the tokenSymbol
+type HezIdx string
+
+// StrHezIdx is used to unmarshal HezIdx directly into an alias of Idx
+type StrHezIdx struct {
+	Idx         Idx
+	TokenSymbol string
+}
+
+// UnmarshalText unmarshals a StrHezIdx
+func (s *StrHezIdx) UnmarshalText(text []byte) error {
+	withoutHez := strings.TrimPrefix(string(text), "hez:")
+	splitted := strings.Split(withoutHez, ":")
+	const expectedLen = 2
+	if len(splitted) != expectedLen {
+		return tracerr.Wrap(fmt.Errorf("can not unmarshal %s into StrHezIdx", text))
+	}
+	idxInt, err := strconv.Atoi(splitted[1])
+	if err != nil {
+		return tracerr.Wrap(err)
+	}
+	*s = StrHezIdx{
+		Idx:         Idx(idxInt),
+		TokenSymbol: splitted[0],
+	}
+	return nil
+}
+
+// EthSignature is used to scan/value []byte representing an Ethereum signature directly into strings from/to sql DBs.
+type EthSignature string
+
+// NewEthSignature creates a *EthSignature from []byte
+// If the provided signature is nil the returned *EthSignature will also be nil
+func NewEthSignature(signature []byte) *EthSignature {
+	if signature == nil {
+		return nil
+	}
+	ethSignature := EthSignature("0x" + hex.EncodeToString(signature))
+	return &ethSignature
+}
+
+// Scan implements Scanner for database/sql
+func (e *EthSignature) Scan(src interface{}) error {
+	if srcStr, ok := src.(string); ok {
+		// src is a string
+		*e = *(NewEthSignature([]byte(srcStr)))
+		return nil
+	} else if srcBytes, ok := src.([]byte); ok {
+		// src is []byte
+		*e = *(NewEthSignature(srcBytes))
+		return nil
+	}
+	return tracerr.Wrap(fmt.Errorf("can't scan %T into apitypes.EthSignature", src))
+}
+
+// Value implements valuer for database/sql
+func (e EthSignature) Value() (driver.Value, error) {
+	without0x := strings.TrimPrefix(string(e), "0x")
+	return hex.DecodeString(without0x)
+}
+
+// UnmarshalText unmarshals a StrEthSignature
+func (e *EthSignature) UnmarshalText(text []byte) error {
+	without0x := strings.TrimPrefix(string(text), "0x")
+	signature, err := hex.DecodeString(without0x)
+	if err != nil {
+		return tracerr.Wrap(err)
+	}
+	*e = EthSignature([]byte(signature))
+	return nil
+}
+
+func idxToHez(idx Idx, tokenSymbol string) string {
+	return "hez:" + tokenSymbol + ":" + strconv.Itoa(int(idx))
+}
+
+func ethAddrToHez(addr ethCommon.Address) string {
+	return "hez:" + addr.String()
+}
+
+func bjjToString(bjj babyjub.PublicKeyComp) string {
+	pkComp := [32]byte(bjj)
+	sum := pkComp[0]
+	for i := 1; i < len(pkComp); i++ {
+		sum += pkComp[i]
+	}
+	bjjSum := append(pkComp[:], sum)
+	return "hez:" + base64.RawURLEncoding.EncodeToString(bjjSum)
+}

--- a/common/formats_test.go
+++ b/common/formats_test.go
@@ -1,0 +1,419 @@
+package common
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	dbUtils "github.com/hermeznetwork/hermez-node/db"
+	"github.com/iden3/go-iden3-crypto/babyjub"
+
+	// nolint sqlite driver
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/russross/meddler"
+	"github.com/stretchr/testify/assert"
+)
+
+var db *sql.DB
+
+func TestMain(m *testing.M) {
+	// Register meddler
+	meddler.Default = meddler.SQLite
+	meddler.Register("bigint", dbUtils.BigIntMeddler{})
+	meddler.Register("bigintnull", dbUtils.BigIntNullMeddler{})
+	// Create temporary sqlite DB
+	dir, err := ioutil.TempDir("", "db")
+	if err != nil {
+		panic(err)
+	}
+	db, err = sql.Open("sqlite3", dir+"sqlite.db")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir) //nolint
+	schema := `CREATE TABLE test (i BLOB);`
+	if _, err := db.Exec(schema); err != nil {
+		panic(err)
+	}
+	// Run tests
+	result := m.Run()
+	os.Exit(result)
+}
+
+func TestBigIntStrScannerValuer(t *testing.T) {
+	// Clean DB
+	_, err := db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Example structs
+	type bigInMeddlerStruct struct {
+		I *big.Int `meddler:"i,bigint"` // note the bigint that instructs meddler to use BigIntMeddler
+	}
+	type bigIntStrStruct struct {
+		I BigIntStr `meddler:"i"` // note that no meddler is specified, and Scan/Value will be used
+	}
+	type bigInMeddlerStructNil struct {
+		I *big.Int `meddler:"i,bigintnull"` // note the bigint that instructs meddler to use BigIntNullMeddler
+	}
+	type bigIntStrStructNil struct {
+		I *BigIntStr `meddler:"i"` // note that no meddler is specified, and Scan/Value will be used
+	}
+
+	// Not nil case
+	// Insert into DB using meddler
+	const x = int64(12345)
+	fromMeddler := bigInMeddlerStruct{
+		I: big.NewInt(x),
+	}
+	err = meddler.Insert(db, "test", &fromMeddler)
+	assert.NoError(t, err)
+	// Read from DB using BigIntStr
+	toBigIntStr := bigIntStrStruct{}
+	err = meddler.QueryRow(db, &toBigIntStr, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, fromMeddler.I.String(), string(toBigIntStr.I))
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using BigIntStr
+	fromBigIntStr := bigIntStrStruct{
+		I: "54321",
+	}
+	err = meddler.Insert(db, "test", &fromBigIntStr)
+	assert.NoError(t, err)
+	// Read from DB using meddler
+	toMeddler := bigInMeddlerStruct{}
+	err = meddler.QueryRow(db, &toMeddler, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, string(fromBigIntStr.I), toMeddler.I.String())
+
+	// Nil case
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using meddler
+	fromMeddlerNil := bigInMeddlerStructNil{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromMeddlerNil)
+	assert.NoError(t, err)
+	// Read from DB using BigIntStr
+	foo := BigIntStr("foo")
+	toBigIntStrNil := bigIntStrStructNil{
+		I: &foo, // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toBigIntStrNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toBigIntStrNil.I)
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using BigIntStr
+	fromBigIntStrNil := bigIntStrStructNil{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromBigIntStrNil)
+	assert.NoError(t, err)
+	// Read from DB using meddler
+	toMeddlerNil := bigInMeddlerStructNil{
+		I: big.NewInt(x), // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toMeddlerNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toMeddlerNil.I)
+}
+
+func TestStrBigInt(t *testing.T) {
+	type testStrBigInt struct {
+		I StrBigInt
+	}
+	from := []byte(`{"I":"4"}`)
+	to := &testStrBigInt{}
+	assert.NoError(t, json.Unmarshal(from, to))
+	assert.Equal(t, big.NewInt(4), (*big.Int)(&to.I))
+}
+
+func TestStrHezEthAddr(t *testing.T) {
+	type testStrHezEthAddr struct {
+		I StrHezEthAddr
+	}
+	withoutHez := "0xaa942cfcd25ad4d90a62358b0dd84f33b398262a"
+	from := []byte(`{"I":"hez:` + withoutHez + `"}`)
+	var addr ethCommon.Address
+	if err := addr.UnmarshalText([]byte(withoutHez)); err != nil {
+		panic(err)
+	}
+	to := &testStrHezEthAddr{}
+	assert.NoError(t, json.Unmarshal(from, to))
+	assert.Equal(t, addr, ethCommon.Address(to.I))
+}
+
+func TestStrHezBJJ(t *testing.T) {
+	type testStrHezBJJ struct {
+		I StrHezBJJ
+	}
+	priv := babyjub.NewRandPrivKey()
+	hezBjj := NewHezBJJ(priv.Public().Compress())
+	from := []byte(`{"I":"` + hezBjj + `"}`)
+	to := &testStrHezBJJ{}
+	assert.NoError(t, json.Unmarshal(from, to))
+	assert.Equal(t, priv.Public().Compress(), (babyjub.PublicKeyComp)(to.I))
+}
+
+func TestStrHezIdx(t *testing.T) {
+	type testStrHezIdx struct {
+		I StrHezIdx
+	}
+	from := []byte(`{"I":"hez:foo:4"}`)
+	to := &testStrHezIdx{}
+	assert.NoError(t, json.Unmarshal(from, to))
+	assert.Equal(t, Idx(4), Idx(to.I.Idx))
+	assert.Equal(t, "foo", to.I.TokenSymbol)
+}
+
+func TestHezEthAddr(t *testing.T) {
+	// Clean DB
+	_, err := db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Example structs
+	type ethAddrStruct struct {
+		I ethCommon.Address `meddler:"i"`
+	}
+	type hezEthAddrStruct struct {
+		I HezEthAddr `meddler:"i"`
+	}
+	type ethAddrStructNil struct {
+		I *ethCommon.Address `meddler:"i"`
+	}
+	type hezEthAddrStructNil struct {
+		I *HezEthAddr `meddler:"i"`
+	}
+
+	// Not nil case
+	// Insert into DB using ethCommon.Address Scan/Value
+	fromEth := ethAddrStruct{
+		I: ethCommon.BigToAddress(big.NewInt(73737373)),
+	}
+	err = meddler.Insert(db, "test", &fromEth)
+	assert.NoError(t, err)
+	// Read from DB using HezEthAddr Scan/Value
+	toHezEth := hezEthAddrStruct{}
+	err = meddler.QueryRow(db, &toHezEth, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, NewHezEthAddr(fromEth.I), toHezEth.I)
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using HezEthAddr Scan/Value
+	fromHezEth := hezEthAddrStruct{
+		I: NewHezEthAddr(ethCommon.BigToAddress(big.NewInt(3786872586))),
+	}
+	err = meddler.Insert(db, "test", &fromHezEth)
+	assert.NoError(t, err)
+	// Read from DB using ethCommon.Address Scan/Value
+	toEth := ethAddrStruct{}
+	err = meddler.QueryRow(db, &toEth, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, fromHezEth.I, NewHezEthAddr(toEth.I))
+
+	// Nil case
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using ethCommon.Address Scan/Value
+	fromEthNil := ethAddrStructNil{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromEthNil)
+	assert.NoError(t, err)
+	// Read from DB using HezEthAddr Scan/Value
+	foo := HezEthAddr("foo")
+	toHezEthNil := hezEthAddrStructNil{
+		I: &foo, // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toHezEthNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toHezEthNil.I)
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using HezEthAddr Scan/Value
+	fromHezEthNil := hezEthAddrStructNil{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromHezEthNil)
+	assert.NoError(t, err)
+	// Read from DB using ethCommon.Address Scan/Value
+	fooAddr := ethCommon.BigToAddress(big.NewInt(1))
+	toEthNil := ethAddrStructNil{
+		I: &fooAddr, // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toEthNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toEthNil.I)
+}
+
+func TestHezBJJ(t *testing.T) {
+	// Clean DB
+	_, err := db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Example structs
+	type bjjStruct struct {
+		I babyjub.PublicKeyComp `meddler:"i"`
+	}
+	type hezBJJStruct struct {
+		I HezBJJ `meddler:"i"`
+	}
+	type bjjStructNil struct {
+		I *babyjub.PublicKeyComp `meddler:"i"`
+	}
+	type hezBJJStructNil struct {
+		I *HezBJJ `meddler:"i"`
+	}
+
+	// Not nil case
+	// Insert into DB using *babyjub.PublicKeyComp Scan/Value
+	priv := babyjub.NewRandPrivKey()
+	fromBJJ := bjjStruct{
+		I: priv.Public().Compress(),
+	}
+	err = meddler.Insert(db, "test", &fromBJJ)
+	assert.NoError(t, err)
+	// Read from DB using HezBJJ Scan/Value
+	toHezBJJ := hezBJJStruct{}
+	err = meddler.QueryRow(db, &toHezBJJ, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, NewHezBJJ(fromBJJ.I), toHezBJJ.I)
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using HezBJJ Scan/Value
+	fromHezBJJ := hezBJJStruct{
+		I: NewHezBJJ(priv.Public().Compress()),
+	}
+	err = meddler.Insert(db, "test", &fromHezBJJ)
+	assert.NoError(t, err)
+	// Read from DB using *babyjub.PublicKeyComp Scan/Value
+	toBJJ := bjjStruct{}
+	err = meddler.QueryRow(db, &toBJJ, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, fromHezBJJ.I, NewHezBJJ(toBJJ.I))
+
+	// Nil case
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using *babyjub.PublicKeyComp Scan/Value
+	fromBJJNil := bjjStructNil{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromBJJNil)
+	assert.NoError(t, err)
+	// Read from DB using HezBJJ Scan/Value
+	foo := HezBJJ("foo")
+	toHezBJJNil := hezBJJStructNil{
+		I: &foo, // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toHezBJJNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toHezBJJNil.I)
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using HezBJJ Scan/Value
+	fromHezBJJNil := hezBJJStructNil{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromHezBJJNil)
+	assert.NoError(t, err)
+	// Read from DB using *babyjub.PublicKeyComp Scan/Value
+	bjjComp := priv.Public().Compress()
+	toBJJNil := bjjStructNil{
+		I: &bjjComp, // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toBJJNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toBJJNil.I)
+}
+
+func TestEthSignature(t *testing.T) {
+	// Clean DB
+	_, err := db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Example structs
+	type ethSignStruct struct {
+		I []byte `meddler:"i"`
+	}
+	type hezEthSignStruct struct {
+		I EthSignature `meddler:"i"`
+	}
+	type hezEthSignStructNil struct {
+		I *EthSignature `meddler:"i"`
+	}
+
+	// Not nil case
+	// Insert into DB using []byte Scan/Value
+	s := "someRandomFooForYou"
+	fromEth := ethSignStruct{
+		I: []byte(s),
+	}
+	err = meddler.Insert(db, "test", &fromEth)
+	assert.NoError(t, err)
+	// Read from DB using EthSignature Scan/Value
+	toHezEth := hezEthSignStruct{}
+	err = meddler.QueryRow(db, &toHezEth, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, NewEthSignature(fromEth.I), &toHezEth.I)
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using EthSignature Scan/Value
+	fromHezEth := hezEthSignStruct{
+		I: *NewEthSignature([]byte(s)),
+	}
+	err = meddler.Insert(db, "test", &fromHezEth)
+	assert.NoError(t, err)
+	// Read from DB using []byte Scan/Value
+	toEth := ethSignStruct{}
+	err = meddler.QueryRow(db, &toEth, "select * from test")
+	assert.NoError(t, err)
+	assert.Equal(t, &fromHezEth.I, NewEthSignature(toEth.I))
+
+	// Nil case
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using []byte Scan/Value
+	fromEthNil := ethSignStruct{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromEthNil)
+	assert.NoError(t, err)
+	// Read from DB using EthSignature Scan/Value
+	foo := EthSignature("foo")
+	toHezEthNil := hezEthSignStructNil{
+		I: &foo, // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toHezEthNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toHezEthNil.I)
+	// Clean DB
+	_, err = db.Exec("delete from test")
+	assert.NoError(t, err)
+	// Insert into DB using EthSignature Scan/Value
+	fromHezEthNil := hezEthSignStructNil{
+		I: nil,
+	}
+	err = meddler.Insert(db, "test", &fromHezEthNil)
+	assert.NoError(t, err)
+	// Read from DB using []byte Scan/Value
+	toEthNil := ethSignStruct{
+		I: []byte(s), // check that this will be set to nil, not because of not being initialized
+	}
+	err = meddler.QueryRow(db, &toEthNil, "select * from test")
+	assert.NoError(t, err)
+	assert.Nil(t, toEthNil.I)
+}

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -486,7 +486,7 @@ func (tx PoolL2Tx) MarshalJSON() ([]byte, error) {
 		Fee         FeeSelector           `json:"fee"`
 		Nonce       Nonce                 `json:"nonce"`
 		Signature   babyjub.SignatureComp `json:"signature"`
-		RqTxID      *TxID                 `json:"requestId`
+		RqTxID      *TxID                 `json:"requestId"`
 		RqFromIdx   *string               `json:"requestFromAccountIndex"`
 		RqToIdx     *string               `json:"requestToAccountIndex"`
 		RqToEthAddr *string               `json:"requestToHezEthereumAddress"`

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -486,6 +486,7 @@ func (tx PoolL2Tx) MarshalJSON() ([]byte, error) {
 		Fee         FeeSelector           `json:"fee"`
 		Nonce       Nonce                 `json:"nonce"`
 		Signature   babyjub.SignatureComp `json:"signature"`
+		RqTxID      *TxID                 `json:"requestId`
 		RqFromIdx   *string               `json:"requestFromAccountIndex"`
 		RqToIdx     *string               `json:"requestToAccountIndex"`
 		RqToEthAddr *string               `json:"requestToHezEthereumAddress"`
@@ -526,6 +527,7 @@ func (tx PoolL2Tx) MarshalJSON() ([]byte, error) {
 		if tx.RqTokenSymbol == "" {
 			return nil, errors.New("Invalid tx.RqTokenSymbol")
 		}
+		toMarshal.RqTxID = &tx.RqTxID
 		rqFromIdx := idxToHez(tx.RqFromIdx, tx.TokenSymbol)
 		toMarshal.RqFromIdx = &rqFromIdx
 		toMarshal.RqTokenID = &tx.RqTokenID
@@ -565,6 +567,7 @@ func (tx *PoolL2Tx) UnmarshalJSON(data []byte) error {
 		Fee         FeeSelector           `json:"fee"`
 		Nonce       Nonce                 `json:"nonce"`
 		Signature   babyjub.SignatureComp `json:"signature" binding:"required"`
+		RqTxID      TxID                  `json:"requestId"`
 		RqFromIdx   StrHezIdx             `json:"requestFromAccountIndex"`
 		RqToIdx     StrHezIdx             `json:"requestToAccountIndex"`
 		RqToEthAddr StrHezEthAddr         `json:"requestToHezEthereumAddress"`
@@ -598,6 +601,7 @@ func (tx *PoolL2Tx) UnmarshalJSON(data []byte) error {
 		Fee:           receivedJSON.Fee,
 		Nonce:         receivedJSON.Nonce,
 		Signature:     receivedJSON.Signature,
+		RqTxID:        receivedJSON.RqTxID,
 		RqFromIdx:     (Idx)(receivedJSON.RqFromIdx.Idx),
 		RqToIdx:       (Idx)(receivedJSON.RqToIdx.Idx),
 		RqToEthAddr:   (ethCommon.Address)(receivedJSON.RqToEthAddr),

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -61,8 +62,12 @@ type PoolL2Tx struct {
 	AbsoluteFee       float64               `meddler:"fee_usd,zeroisnull"`
 	AbsoluteFeeUpdate time.Time             `meddler:"usd_update,utctimez"`
 	Type              TxType                `meddler:"tx_type"`
+	// Extra DB write fields (not included in JSON)
+	ClientIP string `meddler:"client_ip"`
 	// Extra metadata, may be uninitialized
 	RqTxCompressedData []byte `meddler:"-"` // 253 bits, optional for atomic txs
+	TokenSymbol        string `meddler:"-"` // Used for JSON marshaling the ToIdx
+	RqTokenSymbol      string `meddler:"-"` // Used for JSON marshaling the RqToIdx
 }
 
 // NewPoolL2Tx returns the given L2Tx with the TxId & Type parameters calculated
@@ -281,12 +286,19 @@ func (tx *PoolL2Tx) TxCompressedDataV2() (*big.Int, error) {
 // [ 48 bits ] rqFromIdx // 6 bytes
 // Total bits compressed data:  217 bits // 28 bytes in *big.Int representation
 func (tx *PoolL2Tx) RqTxCompressedDataV2() (*big.Int, error) {
+	var amountFloat40 Float40
 	if tx.RqAmount == nil {
-		tx.RqAmount = big.NewInt(0)
-	}
-	amountFloat40, err := NewFloat40(tx.RqAmount)
-	if err != nil {
-		return nil, tracerr.Wrap(err)
+		af40, err := NewFloat40(big.NewInt(0))
+		if err != nil {
+			return nil, tracerr.Wrap(err)
+		}
+		amountFloat40 = af40
+	} else {
+		af40, err := NewFloat40(tx.RqAmount)
+		if err != nil {
+			return nil, tracerr.Wrap(err)
+		}
+		amountFloat40 = af40
 	}
 	amountFloat40Bytes, err := amountFloat40.Bytes()
 	if err != nil {
@@ -445,3 +457,159 @@ const (
 	// PoolL2TxStateInvalid represents a L2Tx that has been invalidated
 	PoolL2TxStateInvalid PoolL2TxState = "invl"
 )
+
+// IsValid returns true if matches one of the supported PoolL2TxState
+func (s PoolL2TxState) IsValid() bool {
+	switch s {
+	case PoolL2TxStatePending, PoolL2TxStateForging, PoolL2TxStateForged, PoolL2TxStateInvalid:
+		return true
+	default:
+		return false
+	}
+}
+
+// MarshalJSON formats a PoolL2Tx in the expected JSON defined by the API,
+// this format is specified in `api/swagger.yml:schemas/PostPoolL2Transaction`
+func (tx PoolL2Tx) MarshalJSON() ([]byte, error) {
+	if tx.TokenSymbol == "" {
+		return nil, errors.New("Invalid tx.TokenSymbol")
+	}
+	type jsonFormat struct {
+		TxID        TxID                  `json:"id"`
+		Type        TxType                `json:"type"`
+		TokenID     TokenID               `json:"tokenId"`
+		FromIdx     string                `json:"fromAccountIndex"`
+		ToIdx       *string               `json:"toAccountIndex"`
+		ToEthAddr   *string               `json:"toHezEthereumAddress"`
+		ToBJJ       *string               `json:"toBjj"`
+		Amount      string                `json:"amount"`
+		Fee         FeeSelector           `json:"fee"`
+		Nonce       Nonce                 `json:"nonce"`
+		Signature   babyjub.SignatureComp `json:"signature"`
+		RqFromIdx   *string               `json:"requestFromAccountIndex"`
+		RqToIdx     *string               `json:"requestToAccountIndex"`
+		RqToEthAddr *string               `json:"requestToHezEthereumAddress"`
+		RqToBJJ     *string               `json:"requestToBjj"`
+		RqTokenID   *TokenID              `json:"requestTokenId"`
+		RqAmount    *string               `json:"requestAmount"`
+		RqFee       *FeeSelector          `json:"requestFee"`
+		RqNonce     *Nonce                `json:"requestNonce"`
+	}
+	// Set fields that do not require extra logic
+	toMarshal := jsonFormat{
+		TxID:      tx.TxID,
+		Type:      tx.Type,
+		TokenID:   tx.TokenID,
+		FromIdx:   idxToHez(tx.FromIdx, tx.TokenSymbol),
+		Amount:    tx.Amount.String(),
+		Fee:       tx.Fee,
+		Nonce:     tx.Nonce,
+		Signature: tx.Signature,
+		RqFee:     &tx.RqFee,
+		RqNonce:   &tx.RqNonce,
+	}
+	// Set To fileds
+	if tx.ToIdx != 0 {
+		toIdx := idxToHez(tx.ToIdx, tx.TokenSymbol)
+		toMarshal.ToIdx = &toIdx
+	}
+	if tx.ToEthAddr != EmptyAddr {
+		toEth := ethAddrToHez(tx.ToEthAddr)
+		toMarshal.ToEthAddr = &toEth
+	}
+	if tx.ToBJJ != EmptyBJJComp {
+		toBJJ := bjjToString(tx.ToBJJ)
+		toMarshal.ToBJJ = &toBJJ
+	}
+	// Set Rq fields
+	if tx.RqFromIdx != 0 {
+		if tx.RqTokenSymbol == "" {
+			return nil, errors.New("Invalid tx.RqTokenSymbol")
+		}
+		rqFromIdx := idxToHez(tx.RqFromIdx, tx.TokenSymbol)
+		toMarshal.RqFromIdx = &rqFromIdx
+		toMarshal.RqTokenID = &tx.RqTokenID
+		rqAmount := tx.RqAmount.String()
+		toMarshal.RqAmount = &rqAmount
+		toMarshal.RqNonce = &tx.RqNonce
+		toMarshal.RqFee = &tx.RqFee
+		if tx.RqToIdx != 0 {
+			rqToIdx := idxToHez(tx.RqToIdx, tx.RqTokenSymbol)
+			toMarshal.RqToIdx = &rqToIdx
+		}
+		if tx.RqToEthAddr != EmptyAddr {
+			rqToEth := ethAddrToHez(tx.RqToEthAddr)
+			toMarshal.RqToEthAddr = &rqToEth
+		}
+		if tx.RqToBJJ != EmptyBJJComp {
+			rqToBJJ := bjjToString(tx.RqToBJJ)
+			toMarshal.RqToBJJ = &rqToBJJ
+		}
+	}
+	return json.Marshal(toMarshal)
+}
+
+// UnmarshalJSON unmarshals a PoolL2Tx that has been formated in json as specified in `api/swagger.yml:schemas/PostPoolL2Transaction`.
+// Note that ClientIP is not included as part of the json and will be set to "".
+// If State is not setted (State == ""), it will be set to PoolL2TxStatePending.
+func (tx *PoolL2Tx) UnmarshalJSON(data []byte) error {
+	receivedJSON := struct {
+		TxID        TxID                  `json:"id" binding:"required"`
+		Type        TxType                `json:"type" binding:"required"`
+		TokenID     TokenID               `json:"tokenId"`
+		FromIdx     StrHezIdx             `json:"fromAccountIndex" binding:"required"`
+		ToIdx       StrHezIdx             `json:"toAccountIndex"`
+		ToEthAddr   StrHezEthAddr         `json:"toHezEthereumAddress"`
+		ToBJJ       StrHezBJJ             `json:"toBjj"`
+		Amount      *StrBigInt            `json:"amount" binding:"required"`
+		Fee         FeeSelector           `json:"fee"`
+		Nonce       Nonce                 `json:"nonce"`
+		Signature   babyjub.SignatureComp `json:"signature" binding:"required"`
+		RqFromIdx   StrHezIdx             `json:"requestFromAccountIndex"`
+		RqToIdx     StrHezIdx             `json:"requestToAccountIndex"`
+		RqToEthAddr StrHezEthAddr         `json:"requestToHezEthereumAddress"`
+		RqToBJJ     StrHezBJJ             `json:"requestToBjj"`
+		RqTokenID   TokenID               `json:"requestTokenId"`
+		RqAmount    *StrBigInt            `json:"requestAmount"`
+		RqFee       FeeSelector           `json:"requestFee"`
+		RqNonce     Nonce                 `json:"requestNonce"`
+		State       string                `json:"state"`
+	}{}
+	if err := json.Unmarshal(data, &receivedJSON); err != nil {
+		return err
+	}
+	// Check state
+	state := PoolL2TxStatePending
+	if receivedJSON.State != "" {
+		state = PoolL2TxState(receivedJSON.State)
+		if !state.IsValid() {
+			return fmt.Errorf("Invalid state: %s", state)
+		}
+	}
+	// Set values to destination struct
+	*tx = PoolL2Tx{
+		TxID:          receivedJSON.TxID,
+		FromIdx:       Idx(receivedJSON.FromIdx.Idx),
+		ToIdx:         Idx(receivedJSON.ToIdx.Idx),
+		ToEthAddr:     ethCommon.Address(receivedJSON.ToEthAddr),
+		ToBJJ:         babyjub.PublicKeyComp(receivedJSON.ToBJJ),
+		TokenID:       receivedJSON.TokenID,
+		Amount:        (*big.Int)(receivedJSON.Amount),
+		Fee:           receivedJSON.Fee,
+		Nonce:         receivedJSON.Nonce,
+		Signature:     receivedJSON.Signature,
+		RqFromIdx:     (Idx)(receivedJSON.RqFromIdx.Idx),
+		RqToIdx:       (Idx)(receivedJSON.RqToIdx.Idx),
+		RqToEthAddr:   (ethCommon.Address)(receivedJSON.RqToEthAddr),
+		RqToBJJ:       (babyjub.PublicKeyComp)(receivedJSON.RqToBJJ),
+		RqTokenID:     receivedJSON.RqTokenID,
+		RqAmount:      (*big.Int)(receivedJSON.RqAmount),
+		RqFee:         receivedJSON.RqFee,
+		RqNonce:       receivedJSON.RqNonce,
+		Type:          receivedJSON.Type,
+		State:         state,
+		TokenSymbol:   receivedJSON.FromIdx.TokenSymbol,
+		RqTokenSymbol: receivedJSON.RqFromIdx.TokenSymbol,
+	}
+	return nil
+}

--- a/db/l2db/apiqueries.go
+++ b/db/l2db/apiqueries.go
@@ -44,19 +44,19 @@ func (l2db *L2DB) GetAccountCreationAuthAPI(addr ethCommon.Address) (*AccountCre
 }
 
 // AddTxAPI inserts a tx to the pool
-func (l2db *L2DB) AddTxAPI(tx *PoolL2TxWrite) error {
+func (l2db *L2DB) AddTxAPI(tx *common.PoolL2Tx) error {
 	cancel, err := l2db.apiConnCon.Acquire()
 	defer cancel()
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
 	defer l2db.apiConnCon.Release()
-
+	// Check fee is in range
 	row := l2db.dbRead.QueryRow(`SELECT
 		($1::NUMERIC * COALESCE(token.usd, 0) * fee_percentage($2::NUMERIC)) /
 			(10.0 ^ token.decimals::NUMERIC)
 		FROM token WHERE token.token_id = $3;`,
-		tx.AmountFloat, tx.Fee, tx.TokenID)
+		tx.Amount.String(), tx.Fee, tx.TokenID)
 	var feeUSD float64
 	if err := row.Scan(&feeUSD); err != nil {
 		return tracerr.Wrap(err)
@@ -69,32 +69,12 @@ func (l2db *L2DB) AddTxAPI(tx *PoolL2TxWrite) error {
 		return tracerr.Wrap(fmt.Errorf("tx.feeUSD (%v) > maxFeeUSD (%v)",
 			feeUSD, l2db.maxFeeUSD))
 	}
-
-	// Prepare insert SQL query argument parameters
-	namesPart, err := meddler.Default.ColumnsQuoted(tx, false)
+	// Add tx if pool is not full
+	res, err := l2db.addTx(tx, true)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
-	valuesPart, err := meddler.Default.PlaceholdersString(tx, false)
-	if err != nil {
-		return tracerr.Wrap(err)
-	}
-	values, err := meddler.Default.Values(tx, false)
-	if err != nil {
-		return tracerr.Wrap(err)
-	}
-
-	q := fmt.Sprintf(
-		`INSERT INTO tx_pool (%s)
-		SELECT %s
-		WHERE (SELECT COUNT(*) FROM tx_pool WHERE state = $%v AND NOT external_delete) < $%v;`,
-		namesPart, valuesPart,
-		len(values)+1, len(values)+2) //nolint:gomnd
-	values = append(values, common.PoolL2TxStatePending, l2db.maxTxs)
-	res, err := l2db.dbWrite.Exec(q, values...)
-	if err != nil {
-		return tracerr.Wrap(err)
-	}
+	// Return error if pool was full
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
 		return tracerr.Wrap(err)

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -2,7 +2,6 @@ package l2db
 
 import (
 	"encoding/json"
-	"math/big"
 	"time"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -10,33 +9,6 @@ import (
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/iden3/go-iden3-crypto/babyjub"
 )
-
-// PoolL2TxWrite holds the necessary data to perform inserts in tx_pool
-type PoolL2TxWrite struct {
-	TxID        common.TxID            `meddler:"tx_id"`
-	FromIdx     common.Idx             `meddler:"from_idx"`
-	ToIdx       *common.Idx            `meddler:"to_idx"`
-	ToEthAddr   *ethCommon.Address     `meddler:"to_eth_addr"`
-	ToBJJ       *babyjub.PublicKeyComp `meddler:"to_bjj"`
-	TokenID     common.TokenID         `meddler:"token_id"`
-	Amount      *big.Int               `meddler:"amount,bigint"`
-	AmountFloat float64                `meddler:"amount_f"`
-	Fee         common.FeeSelector     `meddler:"fee"`
-	Nonce       common.Nonce           `meddler:"nonce"`
-	State       common.PoolL2TxState   `meddler:"state"`
-	Signature   babyjub.SignatureComp  `meddler:"signature"`
-	RqFromIdx   *common.Idx            `meddler:"rq_from_idx"`
-	RqToIdx     *common.Idx            `meddler:"rq_to_idx"`
-	RqToEthAddr *ethCommon.Address     `meddler:"rq_to_eth_addr"`
-	RqToBJJ     *babyjub.PublicKeyComp `meddler:"rq_to_bjj"`
-	RqTokenID   *common.TokenID        `meddler:"rq_token_id"`
-	RqAmount    *big.Int               `meddler:"rq_amount,bigintnull"`
-	RqFee       *common.FeeSelector    `meddler:"rq_fee"`
-	RqNonce     *common.Nonce          `meddler:"rq_nonce"`
-	RqTxID      *common.TxID           `meddler:"rq_tx_id"`
-	Type        common.TxType          `meddler:"tx_type"`
-	ClientIP    string                 `meddler:"client_ip"`
-}
 
 // PoolTxAPI represents a L2 Tx pool with extra metadata used by the API
 type PoolTxAPI struct {

--- a/go.mod
+++ b/go.mod
@@ -25,12 +25,12 @@ require (
 	github.com/prometheus/client_golang v1.3.0
 	github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351
 	github.com/russross/meddler v1.0.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/yourbasic/graph v0.0.0-20170921192928-40eb135c0b26
 	go.uber.org/zap v1.16.0
-	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
-	golang.org/x/net v0.0.0-20200822124328-c89045814202
-	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
+	golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/go-playground/validator.v9 v9.29.1
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
@@ -512,6 +513,7 @@ github.com/openconfig/reference v0.0.0-20190727015836-8dfd928c9696/go.mod h1:ym2
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxSfWAKL3wpBW7V8scJMt8N8gnaMCS9E/cA=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
@@ -640,6 +642,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v0.0.0-20180621010148-0d5a0ceb10cf/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D69SiV4JoN7kkfvJdOWlPpfxrzxpLMoUk=
@@ -724,8 +728,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 h1:3wPMTskHO3+O6jqTEXyFcsnuxMQOqYSaHsDxcbUXpqA=
-golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
@@ -778,6 +782,9 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6 h1:0PC75Fz/kyMGhL0e1QnypqK2kQMqKt9csD1GnMJR+Zk=
+golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -788,6 +795,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -816,7 +825,6 @@ golang.org/x/sys v0.0.0-20190912141932-bc967efca4b8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -825,12 +833,17 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8 h1:AvbQYmiaaaza3cW3QXRyPo5kYgpFIzOAfeAAN7m3qQ4=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
-golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Partialy implements #833

### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- With this refactor, sending pool txs from an external Go project is as easy as marshaling `common.PoolL2Tx` into a JSON 
- Merge structs Merge `api.receivedPoolTx`, `api.testPoolTxSend` and `l2db.PoolL2TxWrite` into `common.PoolL2Tx`
- Use the same method to insert txs into the pool for testing and API (production)
- Prevent method `func (tx *PoolL2Tx) RqTxCompressedDataV2() (*big.Int, error)` from modifying `tx.RqAmount` value 

Note that `common.formats.go` and `common.formats.go` (which represents about 70% of the added code) are basically copied code from `api/apitypes` and `api` packages. In future PRs I will finish the refactoring by deleting the equivalent code from `./api/**`. I didn't make it in this one since the amount of altered code would have made the PR very hard to reason about.

### How to test?

<!-- What steps in order should someone run to test -->
Since this is a refactor, existing tests should be valid

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

