### PR TITLE
Feature/marshal json refactor

### DIFF
--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -64,8 +64,8 @@ type txAPIJSON struct {
 	BatchNum    *common.BatchNum     `json:"batchNum"`
 	HistoricUSD *float64             `json:"historicUSD"`
 	Timestamp   time.Time            `json:"timestamp"`
-	L1Info      l1infoJSON           `json:"L1Info"`
-	L2Info      l2infoJSON           `json:"L2Info"`
+	L1Info      *l1infoJSON          `json:"L1Info"`
+	L2Info      *l2infoJSON          `json:"L2Info"`
 	TokenJSON   tokenJSON            `json:"token"`
 	L1orL2      string               `json:"L1orL2"`
 }
@@ -143,10 +143,15 @@ func (tx TxAPI) MarshalJSON() ([]byte, error) {
 		FromIdx:     tx.FromIdx,
 		FromEthAddr: tx.FromEthAddr,
 		FromBJJ:     tx.FromBJJ,
+		ToIdx:       tx.ToIdx,
+		ToEthAddr:   tx.ToEthAddr,
+		ToBJJ:       tx.ToBJJ,
 		Amount:      tx.Amount,
 		BatchNum:    tx.BatchNum,
 		HistoricUSD: tx.HistoricUSD,
 		Timestamp:   tx.Timestamp,
+		L1Info:      nil,
+		L2Info:      nil,
 		TokenJSON: tokenJSON{
 			TokenID:          tx.TokenID,
 			TokenItemID:      tx.TokenItemID,
@@ -168,7 +173,7 @@ func (tx TxAPI) MarshalJSON() ([]byte, error) {
 			amountSuccess = false
 			depositAmountSuccess = false
 		}
-		txa.L1Info = l1infoJSON{
+		txa.L1Info = &l1infoJSON{
 			ToForgeL1TxsNum:          tx.ToForgeL1TxsNum,
 			UserOrigin:               tx.UserOrigin,
 			DepositAmount:            tx.DepositAmount,
@@ -179,7 +184,7 @@ func (tx TxAPI) MarshalJSON() ([]byte, error) {
 		}
 	} else {
 		txa.L1orL2 = "L2"
-		txa.L2Info = l2infoJSON{
+		txa.L2Info = &l2infoJSON{
 			Fee:            tx.Fee,
 			HistoricFeeUSD: tx.HistoricFeeUSD,
 			Nonce:          tx.Nonce,

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -12,6 +12,43 @@ import (
 	"github.com/iden3/go-merkletree"
 )
 
+// Helper structs for JSON serialization
+type tokenJSON struct {
+	TokenID          common.TokenID    `json:"id"`
+	TokenItemID      uint64            `json:"itemId"`
+	TokenEthBlockNum int64             `json:"ethereumBlockNum"`
+	TokenEthAddr     ethCommon.Address `json:"ethereumAddress"`
+	TokenName        string            `json:"name"`
+	TokenSymbol      string            `json:"symbol"`
+	TokenDecimals    uint64            `json:"decimals"`
+	TokenUSD         *float64          `json:"USD"`
+	TokenUSDUpdate   *time.Time        `json:"fiatUpdate"`
+}
+
+type exitAPIJSON struct {
+	ItemID                 uint64                          `json:"itemId"`
+	BatchNum               common.BatchNum                 `json:"batchNum"`
+	AccountIdx             apitypes.HezIdx                 `json:"accountIndex"`
+	Bjj                    *apitypes.HezBJJ                `json:"bjj"`
+	EthAddr                *apitypes.HezEthAddr            `json:"hezEthereumAddress"`
+	MerkleProof            *merkletree.CircomVerifierProof `json:"merkleProof"`
+	Balance                apitypes.BigIntStr              `json:"balance"`
+	InstantWithdrawn       *int64                          `json:"instantWithdraw"`
+	DelayedWithdrawRequest *int64                          `json:"delayedWithdrawRequest"`
+	DelayedWithdrawn       *int64                          `json:"delayedWithdraw"`
+	TokenJSON              tokenJSON                       `json:"token"`
+}
+
+type accountAPIJSON struct {
+	ItemID             uint64              `json:"itemId"`
+	AccountIndex       apitypes.HezIdx     `json:"accountIndex"`
+	Nonce              common.Nonce        `json:"nonce"`
+	Balance            *apitypes.BigIntStr `json:"balance"`
+	Bjj                apitypes.HezBJJ     `json:"bjj"`
+	HezEthereumAddress apitypes.HezEthAddr `json:"hezEthereumAddress"`
+	TokenJSON          tokenJSON           `json:"token"`
+}
+
 // TxAPI is a representation of a generic Tx with additional information
 // required by the API, and extracted by joining block and token tables
 type TxAPI struct {
@@ -196,32 +233,6 @@ type ExitAPI struct {
 	TokenUSDUpdate         *time.Time                      `meddler:"usd_update"`
 }
 
-type exitAPIJSON struct {
-	ItemID                 uint64                          `json:"itemId"`
-	BatchNum               common.BatchNum                 `json:"batchNum"`
-	AccountIdx             apitypes.HezIdx                 `json:"accountIndex"`
-	Bjj                    *apitypes.HezBJJ                `json:"bjj"`
-	EthAddr                *apitypes.HezEthAddr            `json:"hezEthereumAddress"`
-	MerkleProof            *merkletree.CircomVerifierProof `json:"merkleProof"`
-	Balance                apitypes.BigIntStr              `json:"balance"`
-	InstantWithdrawn       *int64                          `json:"instantWithdraw"`
-	DelayedWithdrawRequest *int64                          `json:"delayedWithdrawRequest"`
-	DelayedWithdrawn       *int64                          `json:"delayedWithdraw"`
-	TokenJSON              tokenJSON                       `json:"token"`
-}
-
-type tokenJSON struct {
-	TokenID          common.TokenID    `json:"id"`
-	TokenItemID      uint64            `json:"itemId"`
-	TokenEthBlockNum int64             `json:"ethereumBlockNum"`
-	TokenEthAddr     ethCommon.Address `json:"ethereumAddress"`
-	TokenName        string            `json:"name"`
-	TokenSymbol      string            `json:"symbol"`
-	TokenDecimals    uint64            `json:"decimals"`
-	TokenUSD         *float64          `json:"USD"`
-	TokenUSDUpdate   *time.Time        `json:"fiatUpdate"`
-}
-
 // MarshalJSON is used to neast some of the fields of ExitAPI
 // without the need of auxiliar structs
 func (e ExitAPI) MarshalJSON() ([]byte, error) {
@@ -292,26 +303,26 @@ type AccountAPI struct {
 // MarshalJSON is used to neast some of the fields of AccountAPI
 // without the need of auxiliar structs
 func (account AccountAPI) MarshalJSON() ([]byte, error) {
-	jsonAccount := map[string]interface{}{
-		"itemId":             account.ItemID,
-		"accountIndex":       account.Idx,
-		"nonce":              account.Nonce,
-		"balance":            account.Balance,
-		"bjj":                account.PublicKey,
-		"hezEthereumAddress": account.EthAddr,
-		"token": map[string]interface{}{
-			"id":               account.TokenID,
-			"itemId":           account.TokenItemID,
-			"ethereumBlockNum": account.TokenEthBlockNum,
-			"ethereumAddress":  account.TokenEthAddr,
-			"name":             account.TokenName,
-			"symbol":           account.TokenSymbol,
-			"decimals":         account.TokenDecimals,
-			"USD":              account.TokenUSD,
-			"fiatUpdate":       account.TokenUSDUpdate,
+	act := accountAPIJSON{
+		ItemID:             account.ItemID,
+		AccountIndex:       account.Idx,
+		Nonce:              account.Nonce,
+		Balance:            account.Balance,
+		Bjj:                account.PublicKey,
+		HezEthereumAddress: account.EthAddr,
+		TokenJSON: tokenJSON{
+			TokenID:          account.TokenID,
+			TokenItemID:      uint64(account.TokenItemID),
+			TokenEthBlockNum: account.TokenEthBlockNum,
+			TokenEthAddr:     account.TokenEthAddr,
+			TokenName:        account.TokenName,
+			TokenSymbol:      account.TokenSymbol,
+			TokenDecimals:    account.TokenDecimals,
+			TokenUSD:         account.TokenUSD,
+			TokenUSDUpdate:   account.TokenUSDUpdate,
 		},
 	}
-	return json.Marshal(jsonAccount)
+	return json.Marshal(act)
 }
 
 // BatchAPI is a representation of a batch with additional information

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -12,8 +12,9 @@ import (
 	"github.com/iden3/go-merkletree"
 )
 
-// Helper structs for JSON serialization
-type tokenJSON struct {
+// TokenJSON is a representation of the JSON structure returned
+// by the serialization method
+type TokenJSON struct {
 	TokenID          common.TokenID    `json:"id"`
 	TokenItemID      uint64            `json:"itemId"`
 	TokenEthBlockNum int64             `json:"ethereumBlockNum"`
@@ -25,7 +26,9 @@ type tokenJSON struct {
 	TokenUSDUpdate   *time.Time        `json:"fiatUpdate"`
 }
 
-type exitAPIJSON struct {
+// ExitAPIJSON is a representation of the JSON structure returned
+// by the serialization method
+type ExitAPIJSON struct {
 	ItemID                 uint64                          `json:"itemId"`
 	BatchNum               common.BatchNum                 `json:"batchNum"`
 	AccountIdx             apitypes.HezIdx                 `json:"accountIndex"`
@@ -36,20 +39,24 @@ type exitAPIJSON struct {
 	InstantWithdrawn       *int64                          `json:"instantWithdraw"`
 	DelayedWithdrawRequest *int64                          `json:"delayedWithdrawRequest"`
 	DelayedWithdrawn       *int64                          `json:"delayedWithdraw"`
-	TokenJSON              tokenJSON                       `json:"token"`
+	TokenJSON              TokenJSON                       `json:"token"`
 }
 
-type accountAPIJSON struct {
+// AccountAPIJSON is a representation of the JSON structure returned
+// by the serialization method
+type AccountAPIJSON struct {
 	ItemID             uint64              `json:"itemId"`
 	AccountIndex       apitypes.HezIdx     `json:"accountIndex"`
 	Nonce              common.Nonce        `json:"nonce"`
 	Balance            *apitypes.BigIntStr `json:"balance"`
 	Bjj                apitypes.HezBJJ     `json:"bjj"`
 	HezEthereumAddress apitypes.HezEthAddr `json:"hezEthereumAddress"`
-	TokenJSON          tokenJSON           `json:"token"`
+	TokenJSON          TokenJSON           `json:"token"`
 }
 
-type txAPIJSON struct {
+// TxAPIJSON is a representation of the JSON structure returned
+// by the serialization method
+type TxAPIJSON struct {
 	TxID        common.TxID          `json:"id"`
 	ItemID      uint64               `json:"itemId"`
 	Type        common.TxType        `json:"type"`
@@ -64,13 +71,15 @@ type txAPIJSON struct {
 	BatchNum    *common.BatchNum     `json:"batchNum"`
 	HistoricUSD *float64             `json:"historicUSD"`
 	Timestamp   time.Time            `json:"timestamp"`
-	L1Info      *l1infoJSON          `json:"L1Info"`
-	L2Info      *l2infoJSON          `json:"L2Info"`
-	TokenJSON   tokenJSON            `json:"token"`
+	L1Info      *L1infoJSON          `json:"L1Info"`
+	L2Info      *L2infoJSON          `json:"L2Info"`
+	TokenJSON   TokenJSON            `json:"token"`
 	L1orL2      string               `json:"L1orL2"`
 }
 
-type l1infoJSON struct {
+// L1infoJSON is a representation of the JSON structure returned
+// by the serialization method
+type L1infoJSON struct {
 	ToForgeL1TxsNum          *int64              `json:"toForgeL1TransactionsNum"`
 	UserOrigin               *bool               `json:"userOrigin"`
 	DepositAmount            *apitypes.BigIntStr `json:"depositAmount"`
@@ -80,7 +89,9 @@ type l1infoJSON struct {
 	EthereumBlockNum         int64               `json:"ethereumBlockNum"`
 }
 
-type l2infoJSON struct {
+// L2infoJSON is a representation of the JSON structure returned
+// by the serialization method
+type L2infoJSON struct {
 	Fee            *common.FeeSelector `json:"fee"`
 	HistoricFeeUSD *float64            `json:"historicFeeUSD"`
 	Nonce          *common.Nonce       `json:"nonce"`
@@ -135,7 +146,7 @@ type TxAPI struct {
 // MarshalJSON is used to neast some of the fields of TxAPI
 // without the need of auxiliar structs
 func (tx TxAPI) MarshalJSON() ([]byte, error) {
-	txa := txAPIJSON{
+	txa := TxAPIJSON{
 		TxID:        tx.TxID,
 		ItemID:      tx.ItemID,
 		Type:        tx.Type,
@@ -152,7 +163,7 @@ func (tx TxAPI) MarshalJSON() ([]byte, error) {
 		Timestamp:   tx.Timestamp,
 		L1Info:      nil,
 		L2Info:      nil,
-		TokenJSON: tokenJSON{
+		TokenJSON: TokenJSON{
 			TokenID:          tx.TokenID,
 			TokenItemID:      tx.TokenItemID,
 			TokenEthBlockNum: tx.TokenEthBlockNum,
@@ -173,7 +184,7 @@ func (tx TxAPI) MarshalJSON() ([]byte, error) {
 			amountSuccess = false
 			depositAmountSuccess = false
 		}
-		txa.L1Info = &l1infoJSON{
+		txa.L1Info = &L1infoJSON{
 			ToForgeL1TxsNum:          tx.ToForgeL1TxsNum,
 			UserOrigin:               tx.UserOrigin,
 			DepositAmount:            tx.DepositAmount,
@@ -184,7 +195,7 @@ func (tx TxAPI) MarshalJSON() ([]byte, error) {
 		}
 	} else {
 		txa.L1orL2 = "L2"
-		txa.L2Info = &l2infoJSON{
+		txa.L2Info = &L2infoJSON{
 			Fee:            tx.Fee,
 			HistoricFeeUSD: tx.HistoricFeeUSD,
 			Nonce:          tx.Nonce,
@@ -274,7 +285,7 @@ type ExitAPI struct {
 // MarshalJSON is used to neast some of the fields of ExitAPI
 // without the need of auxiliar structs
 func (e ExitAPI) MarshalJSON() ([]byte, error) {
-	eaj := exitAPIJSON{
+	eaj := ExitAPIJSON{
 		ItemID:                 e.ItemID,
 		BatchNum:               e.BatchNum,
 		AccountIdx:             e.AccountIdx,
@@ -285,7 +296,7 @@ func (e ExitAPI) MarshalJSON() ([]byte, error) {
 		InstantWithdrawn:       e.InstantWithdrawn,
 		DelayedWithdrawRequest: e.DelayedWithdrawRequest,
 		DelayedWithdrawn:       e.DelayedWithdrawn,
-		TokenJSON: tokenJSON{
+		TokenJSON: TokenJSON{
 			TokenID:          e.TokenID,
 			TokenItemID:      e.TokenItemID,
 			TokenEthBlockNum: e.TokenEthBlockNum,
@@ -341,14 +352,14 @@ type AccountAPI struct {
 // MarshalJSON is used to neast some of the fields of AccountAPI
 // without the need of auxiliar structs
 func (account AccountAPI) MarshalJSON() ([]byte, error) {
-	act := accountAPIJSON{
+	act := AccountAPIJSON{
 		ItemID:             account.ItemID,
 		AccountIndex:       account.Idx,
 		Nonce:              account.Nonce,
 		Balance:            account.Balance,
 		Bjj:                account.PublicKey,
 		HezEthereumAddress: account.EthAddr,
-		TokenJSON: tokenJSON{
+		TokenJSON: TokenJSON{
 			TokenID:          account.TokenID,
 			TokenItemID:      uint64(account.TokenItemID),
 			TokenEthBlockNum: account.TokenEthBlockNum,

--- a/db/historydb/views.go
+++ b/db/historydb/views.go
@@ -196,32 +196,60 @@ type ExitAPI struct {
 	TokenUSDUpdate         *time.Time                      `meddler:"usd_update"`
 }
 
+type exitAPIJSON struct {
+	ItemID                 uint64                          `json:"itemId"`
+	BatchNum               common.BatchNum                 `json:"batchNum"`
+	AccountIdx             apitypes.HezIdx                 `json:"accountIndex"`
+	Bjj                    *apitypes.HezBJJ                `json:"bjj"`
+	EthAddr                *apitypes.HezEthAddr            `json:"hezEthereumAddress"`
+	MerkleProof            *merkletree.CircomVerifierProof `json:"merkleProof"`
+	Balance                apitypes.BigIntStr              `json:"balance"`
+	InstantWithdrawn       *int64                          `json:"instantWithdraw"`
+	DelayedWithdrawRequest *int64                          `json:"delayedWithdrawRequest"`
+	DelayedWithdrawn       *int64                          `json:"delayedWithdraw"`
+	TokenJSON              tokenJSON                       `json:"token"`
+}
+
+type tokenJSON struct {
+	TokenID          common.TokenID    `json:"id"`
+	TokenItemID      uint64            `json:"itemId"`
+	TokenEthBlockNum int64             `json:"ethereumBlockNum"`
+	TokenEthAddr     ethCommon.Address `json:"ethereumAddress"`
+	TokenName        string            `json:"name"`
+	TokenSymbol      string            `json:"symbol"`
+	TokenDecimals    uint64            `json:"decimals"`
+	TokenUSD         *float64          `json:"USD"`
+	TokenUSDUpdate   *time.Time        `json:"fiatUpdate"`
+}
+
 // MarshalJSON is used to neast some of the fields of ExitAPI
 // without the need of auxiliar structs
 func (e ExitAPI) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"itemId":                 e.ItemID,
-		"batchNum":               e.BatchNum,
-		"accountIndex":           e.AccountIdx,
-		"bjj":                    e.BJJ,
-		"hezEthereumAddress":     e.EthAddr,
-		"merkleProof":            e.MerkleProof,
-		"balance":                e.Balance,
-		"instantWithdraw":        e.InstantWithdrawn,
-		"delayedWithdrawRequest": e.DelayedWithdrawRequest,
-		"delayedWithdraw":        e.DelayedWithdrawn,
-		"token": map[string]interface{}{
-			"id":               e.TokenID,
-			"itemId":           e.TokenItemID,
-			"ethereumBlockNum": e.TokenEthBlockNum,
-			"ethereumAddress":  e.TokenEthAddr,
-			"name":             e.TokenName,
-			"symbol":           e.TokenSymbol,
-			"decimals":         e.TokenDecimals,
-			"USD":              e.TokenUSD,
-			"fiatUpdate":       e.TokenUSDUpdate,
+	eaj := exitAPIJSON{
+		ItemID:                 e.ItemID,
+		BatchNum:               e.BatchNum,
+		AccountIdx:             e.AccountIdx,
+		Bjj:                    e.BJJ,
+		EthAddr:                e.EthAddr,
+		MerkleProof:            e.MerkleProof,
+		Balance:                e.Balance,
+		InstantWithdrawn:       e.InstantWithdrawn,
+		DelayedWithdrawRequest: e.DelayedWithdrawRequest,
+		DelayedWithdrawn:       e.DelayedWithdrawn,
+		TokenJSON: tokenJSON{
+			TokenID:          e.TokenID,
+			TokenItemID:      e.TokenItemID,
+			TokenEthBlockNum: e.TokenEthBlockNum,
+			TokenEthAddr:     e.TokenEthAddr,
+			TokenName:        e.TokenName,
+			TokenSymbol:      e.TokenSymbol,
+			TokenDecimals:    e.TokenDecimals,
+			TokenUSD:         e.TokenUSD,
+			TokenUSDUpdate:   e.TokenUSDUpdate,
 		},
-	})
+	}
+
+	return json.Marshal(eaj)
 }
 
 // CoordinatorAPI is a representation of a coordinator with additional information


### PR DESCRIPTION
Closes #801

### What does this PR does?

## Rationale

Today as you can see at https://github.com/hermeznetwork/hermez-node/blob/51d4dd5390df5f99eb746e315c751194fd700d37/db/historydb/views.go#L64 the Marshal function create a generic struct in runtime. This does not allow third-party software, such as a SDK or any other software, to reuse hermez-node code and assure the struct it is being used is the same used on hermez-node and keep the compatibility with confidence. 

Also, is not idiomatic to use interface{} in Go. Always is preferable to define a struct and in this case seems to do not have a reason to not use a defined struct.

This change create structs and remove the interface use in the historydb package. 

### How to test?

`make test`

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Include tests - since PR is just a refactor tests are already available
- [X] Respect code style and lint
- [X] Update swagger file (if needed)
- [X] Update documentation (*.md) (if needed)

