### PR TITLE
set min gas fee & convert gwei to wei before submit tx

### DIFF
--- a/coordinator/txmanager.go
+++ b/coordinator/txmanager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
 	"github.com/hermeznetwork/hermez-node/eth"
@@ -129,29 +130,36 @@ func (t *TxManager) syncSCVars(vars common.SCVariablesPtr) {
 
 // NewAuth generates a new auth object for an ethereum transaction
 func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.TransactOpts, error) {
-	//First we try getting the gas price from etherscan. If it fails we get the gas price from the ethereum node.
-	var gasPrice *big.Int
+	// First we try getting the gas price from etherscan. If it fails we get the gas price from the ethereum node.
+
+	// If gas price is higher than 2000, probably we are going to get the gasLimit exceed error
+	const maxGasPrice = 2000
+	// If gas price is to low, probably there is an error or at Etherscan or Ethereum node.
+	// So setting a minimum value
+	const minGasPrice = 5
+
+	gasPrice := big.NewInt(minGasPrice)
+	eGasPrice := big.NewInt(minGasPrice)
+
 	if t.etherscanService != nil {
 		etherscanGasPrice, err := t.etherscanService.GetGasPrice(ctx)
 		if err != nil {
-			log.Warn("Error getting the gas price from etherscan. Trying another method. Error: ", err.Error())
+			log.Warn("[Etherscan gas price service] Error getting the gas price from etherscan. Trying another method. Error: ", err.Error())
 			var er error
 			gasPrice, er = t.ethClient.EthSuggestGasPrice(ctx)
 			if er != nil {
 				return nil, tracerr.Wrap(er)
 			}
 		} else {
-			eGasPrice := new(big.Int)
-			eGasPrice, ok := eGasPrice.SetString(etherscanGasPrice.ProposeGasPrice, 10)
+			var ok bool
+			eGasPrice, ok = eGasPrice.SetString(etherscanGasPrice.ProposeGasPrice, 10)
 			if !ok {
-				log.Warn("invalid big int: \"%v\"", etherscanGasPrice.ProposeGasPrice, ". Trying another method to get gas price")
+				log.Warn("[Etherscan gas price service] invalid big int: \"%v\"", etherscanGasPrice.ProposeGasPrice, ". Trying another method to get gas price")
 				var er error
 				gasPrice, er = t.ethClient.EthSuggestGasPrice(ctx)
 				if er != nil {
 					return nil, tracerr.Wrap(er)
 				}
-			} else {
-				gasPrice = eGasPrice
 			}
 		}
 	} else {
@@ -161,12 +169,31 @@ func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.Tr
 			return nil, tracerr.Wrap(er)
 		}
 	}
-	//If gas price is higher than 2000, probably we are going to get the gasLimit exceed error
-	const maxGasPrice = 2000
+
+	// If the gas price that comes from Etherscan is higher, uses Etherscan's price
+	// It's better pay few more gas than the transaction get stucked at ethereum node pool
+	log.Debugw("TxManager gas prices - ", "Ethereum node gasPrice:", gasPrice, " Etherscan gasPrice:", eGasPrice)
+
 	maxGasPriceBig := big.NewInt(maxGasPrice)
-	if gasPrice.Cmp(maxGasPriceBig) == 1 {
-		gasPrice = maxGasPriceBig
+	minGasPriceBig := big.NewInt(minGasPrice)
+
+	if eGasPrice.Cmp(maxGasPriceBig) == 1 {
+		eGasPrice = maxGasPriceBig
 	}
+
+	if eGasPrice.Cmp(minGasPriceBig) < 0 {
+		eGasPrice = minGasPriceBig
+	}
+
+	// Convert the eGasPrice from gwei , such as 20 to wei
+	eGasPrice = eGasPrice.Mul(eGasPrice, big.NewInt(params.GWei))
+
+	if gasPrice.Cmp(eGasPrice) < 0 {
+		gasPrice = eGasPrice
+	}
+
+	log.Debugw("TxManager: transaction metadata", "gasPrice", gasPrice)
+
 	if t.cfg.GasPriceIncPerc != 0 {
 		inc := new(big.Int).Set(gasPrice)
 		inc.Mul(inc, new(big.Int).SetInt64(t.cfg.GasPriceIncPerc))
@@ -174,8 +201,6 @@ func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.Tr
 		inc.Div(inc, new(big.Int).SetUint64(100)) //nolint:gomnd
 		gasPrice.Add(gasPrice, inc)
 	}
-
-	// log.Debugw("TxManager: transaction metadata", "gasPrice", gasPrice)
 
 	auth, err := bind.NewKeyStoreTransactorWithChainID(t.ethClient.EthKeyStore(), t.account, t.chainID)
 	if err != nil {
@@ -514,7 +539,8 @@ func (t *TxManager) Run(ctx context.Context) {
 				log.Warnw("TxManager: shouldSend", "err", err,
 					"batch", batchInfo.BatchNum)
 				t.coord.SendMsg(ctx, MsgStopPipeline{
-					Reason: fmt.Sprintf("forgeBatch shouldSend: %v", err)})
+					Reason: fmt.Sprintf("forgeBatch shouldSend: %v", err),
+				})
 				continue
 			}
 			if err := t.sendRollupForgeBatch(ctx, batchInfo, false); ctx.Err() != nil {
@@ -528,7 +554,8 @@ func (t *TxManager) Run(ctx context.Context) {
 				log.Warnw("TxManager: forgeBatch send failed", "err", err,
 					"batch", batchInfo.BatchNum)
 				t.coord.SendMsg(ctx, MsgStopPipeline{
-					Reason: fmt.Sprintf("forgeBatch send: %v", err)})
+					Reason: fmt.Sprintf("forgeBatch send: %v", err),
+				})
 				continue
 			}
 			t.queue.Push(batchInfo)
@@ -553,7 +580,8 @@ func (t *TxManager) Run(ctx context.Context) {
 				// mined and failed.  This could be due to the
 				// ethNode failure.
 				t.coord.SendMsg(ctx, MsgStopPipeline{
-					Reason: fmt.Sprintf("forgeBatch receipt: %v", err)})
+					Reason: fmt.Sprintf("forgeBatch receipt: %v", err),
+				})
 			}
 
 			confirm, err := t.handleReceipt(ctx, batchInfo)
@@ -568,7 +596,8 @@ func (t *TxManager) Run(ctx context.Context) {
 					continue
 				}
 				t.coord.SendMsg(ctx, MsgStopPipeline{
-					Reason: fmt.Sprintf("forgeBatch reject: %v", err)})
+					Reason: fmt.Sprintf("forgeBatch reject: %v", err),
+				})
 				continue
 			}
 			now := time.Now()
@@ -591,7 +620,8 @@ func (t *TxManager) Run(ctx context.Context) {
 					log.Warnw("TxManager: forgeBatch resend failed", "err", err,
 						"batch", batchInfo.BatchNum)
 					t.coord.SendMsg(ctx, MsgStopPipeline{
-						Reason: fmt.Sprintf("forgeBatch resend: %v", err)})
+						Reason: fmt.Sprintf("forgeBatch resend: %v", err),
+					})
 					continue
 				}
 			}


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #843 . 

### What does this PR does?

It defines a min gas fee value to use to send tx to Ethereum (5 gwei - asked by @davidsrz , @invocamanman and @jbaylina ) and converts gas price from Etherscan API that comes in gwei format to wei format as wei format is the one used by Ethereum to post a transaction.

### How to test?

Forge a batch in an Ethereum testnet (rinkeby or goerli) . Local GETH or Ganache are not valid to be used in this test case. 

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [X] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

PS.: As it were hurting the testnet this change was already applied at release/v1.3.0 branch and at v1.3.0-rc4 tag