### PR TITLE
Fix txselector L1CoordTxs

### DIFF
--- a/test/zkproof/flows_test.go
+++ b/test/zkproof/flows_test.go
@@ -189,7 +189,7 @@ func TestTxSelectorBatchBuilderZKInputsMinimumFlow0(t *testing.T) {
 	zki, err := bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
 	require.NoError(t, err)
 	assert.Equal(t,
-		"17845026419825606568297898952886451490968178996859596985115147673317944565005",
+		"4392049343656836675348565048374261353937130287163762821533580216441778455298",
 		bb.LocalStateDB().MT.Root().BigInt().String())
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(oL2Txs),
@@ -219,7 +219,7 @@ func TestTxSelectorBatchBuilderZKInputsMinimumFlow0(t *testing.T) {
 	zki, err = bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
 	require.NoError(t, err)
 	assert.Equal(t,
-		"5011486595982139468087543085074814351795839959948110063153096719520312696275",
+		"8905191229562583213069132470917469035834300549892959854483573322676101624713",
 		bb.LocalStateDB().MT.Root().BigInt().String())
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(l2Txs),
@@ -246,7 +246,7 @@ func TestTxSelectorBatchBuilderZKInputsMinimumFlow0(t *testing.T) {
 	zki, err = bb.BuildBatch(coordIdxs, configBatch, oL1UserTxs, oL1CoordTxs, oL2Txs)
 	require.NoError(t, err)
 	assert.Equal(t,
-		"6530394748986447282151711357194248066562667891309466162814480602176851300695",
+		"20593679664586247774284790801579542411781976279024409415159440382607791042723",
 		bb.LocalStateDB().MT.Root().BigInt().String())
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(l2Txs),
@@ -268,7 +268,7 @@ func TestTxSelectorBatchBuilderZKInputsMinimumFlow0(t *testing.T) {
 	// same root as previous batch, as the L1CoordinatorTxs created by the
 	// Til set is not created by the TxSelector in this test
 	assert.Equal(t,
-		"6530394748986447282151711357194248066562667891309466162814480602176851300695",
+		"20593679664586247774284790801579542411781976279024409415159440382607791042723",
 		bb.LocalStateDB().MT.Root().BigInt().String())
 	sendProofAndCheckResp(t, zki)
 	err = l2DBTxSel.StartForging(common.TxIDsFromPoolL2Txs(l2Txs),

--- a/txselector/txbatch.go
+++ b/txselector/txbatch.go
@@ -72,6 +72,7 @@ func (b *TxBatch) getSelection() ([]common.Idx, [][]byte, []common.L1Tx, []commo
 		auths = append(auths, auth...)
 
 		l1UserTxs = append(l1UserTxs, group.l1UserTxs...)
+		// TODO: How can we have L1 coord txs at this point?
 		l1CoordTxs = append(l1CoordTxs, group.l1CoordTxs...)
 		poolL2Txs = append(poolL2Txs, group.l2Txs...)
 		discardedL2Txs = append(discardedL2Txs, group.discardedTxs...)
@@ -127,6 +128,7 @@ func (b *TxBatch) prune() error {
 	// check if the batch length is greater than the maximum transaction
 	i := len(b.txs) - 1
 	for b.length() > maxTx && i >= 0 {
+		// TODO: how can we have l1 coord txs at this point?
 		last := b.txs[i]
 		if last == nil {
 			return fmt.Errorf("invalid TxGroup")

--- a/txselector/txgroup.go
+++ b/txselector/txgroup.go
@@ -137,6 +137,7 @@ func (g *TxGroup) createL1Txs(processor txProcessor, l2db l2DB, localAccountsDB 
 
 	// create L1 transactions based in the L2
 	for _, l2Tx := range g.l2Txs {
+		// TODO: ¿check if it's actually needed to create account to receive fee, fee could be 0! ?
 		// generate the unique hash from the coordinator account and check if this tx already exist
 		accHash := hashAccount(g.coordAccount.Addr, g.coordAccount.BJJ, l2Tx.TokenID)
 		_, ok := l1TxsCheck[accHash]
@@ -184,7 +185,7 @@ func (g *TxGroup) createL1Txs(processor txProcessor, l2db l2DB, localAccountsDB 
 				continue
 			}
 			// create L1CoordinatorTx for the accountCreation
-			g.l1UserTxs = append(g.l1UserTxs, common.L1Tx{
+			g.l1CoordTxs = append(g.l1CoordTxs, common.L1Tx{
 				UserOrigin:    false,
 				FromEthAddr:   accAuth.EthAddr,
 				FromBJJ:       accAuth.BJJ,
@@ -207,7 +208,7 @@ func (g *TxGroup) createL1Txs(processor txProcessor, l2db l2DB, localAccountsDB 
 			if _, err := localAccountsDB.GetIdxByEthAddrBJJ(l2Tx.ToEthAddr, l2Tx.ToBJJ, l2Tx.TokenID); err == nil {
 				continue
 			}
-			g.l1UserTxs = append(g.l1UserTxs, common.L1Tx{
+			g.l1CoordTxs = append(g.l1CoordTxs, common.L1Tx{
 				UserOrigin:    false,
 				FromEthAddr:   l2Tx.ToEthAddr,
 				FromBJJ:       l2Tx.ToBJJ,

--- a/txselector/txgroup_test.go
+++ b/txselector/txgroup_test.go
@@ -109,9 +109,9 @@ func TestTxGroup_addPoolTxs(t *testing.T) {
 						Info: statedb.ErrIdxNotFound.Error(), Amount: big.NewInt(10), Fee: 33, Nonce: 1,
 						Type: common.TxTypeTransferToBJJ},
 				},
-				coordIdxs:  map[common.TokenID]common.Idx{},
-				l1CoordTxs: []common.L1Tx{},
-				l1UserTxs: []common.L1Tx{
+				coordIdxs: map[common.TokenID]common.Idx{},
+				l1UserTxs: []common.L1Tx{},
+				l1CoordTxs: []common.L1Tx{
 					{
 						UserOrigin:    false,
 						FromEthAddr:   common.FFAddr,
@@ -835,8 +835,8 @@ func TestTxGroup_createL1Txs(t *testing.T) {
 				l1Txs: []common.L1Tx{},
 			},
 			want: want{
-				l1CoordTxs: []common.L1Tx{},
-				l1UserTxs: []common.L1Tx{{
+				l1UserTxs: []common.L1Tx{},
+				l1CoordTxs: []common.L1Tx{{
 					UserOrigin:    false,
 					FromEthAddr:   _invalidEthAddr1,
 					FromBJJ:       _bjj1,
@@ -861,8 +861,8 @@ func TestTxGroup_createL1Txs(t *testing.T) {
 				l1Txs: []common.L1Tx{},
 			},
 			want: want{
-				l1CoordTxs: []common.L1Tx{},
-				l1UserTxs: []common.L1Tx{{
+				l1UserTxs: []common.L1Tx{},
+				l1CoordTxs: []common.L1Tx{{
 					UserOrigin:    false,
 					FromEthAddr:   _invalidEthAddr1,
 					FromBJJ:       _bjj1,
@@ -909,8 +909,8 @@ func TestTxGroup_createL1Txs(t *testing.T) {
 				l1Txs: []common.L1Tx{},
 			},
 			want: want{
-				l1CoordTxs: []common.L1Tx{},
-				l1UserTxs: []common.L1Tx{{
+				l1UserTxs: []common.L1Tx{},
+				l1CoordTxs: []common.L1Tx{{
 					UserOrigin:    false,
 					FromEthAddr:   common.FFAddr,
 					FromBJJ:       _bjj1,
@@ -950,8 +950,8 @@ func TestTxGroup_createL1Txs(t *testing.T) {
 				l1Txs: []common.L1Tx{},
 			},
 			want: want{
-				l1CoordTxs: []common.L1Tx{},
-				l1UserTxs: []common.L1Tx{{
+				l1UserTxs: []common.L1Tx{},
+				l1CoordTxs: []common.L1Tx{{
 					UserOrigin:    false,
 					FromEthAddr:   common.FFAddr,
 					FromBJJ:       _bjj1,
@@ -1012,6 +1012,7 @@ func TestTxGroup_createL1Txs(t *testing.T) {
 				l1Txs: []common.L1Tx{},
 			},
 			want: want{
+				l1UserTxs: []common.L1Tx{},
 				l1CoordTxs: []common.L1Tx{
 					{
 						UserOrigin:    false,
@@ -1022,10 +1023,7 @@ func TestTxGroup_createL1Txs(t *testing.T) {
 						DepositAmount: big.NewInt(0),
 						Position:      0,
 						Type:          common.TxTypeCreateAccountDeposit,
-					},
-				},
-				l1UserTxs: []common.L1Tx{
-					{
+					}, {
 						UserOrigin:    false,
 						FromEthAddr:   _invalidEthAddr1,
 						FromBJJ:       _bjj1,

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -122,6 +122,7 @@ func (s *TxSelector) getL1L2TxSelection(selectionConfig txprocessor.Config, l1Us
 	for _, tx := range l1UserTxs {
 		log.Debugw("TxSelector: processing L1 user tx", "TxID", tx.TxID.String())
 		// assumption: l1usertx are sorted by L1Tx.Position
+		// TODO: why is the output of the function ignored?
 		_, _, _, _, err := processor.ProcessL1Tx(nil, &tx) //nolint:gosec
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, tracerr.Wrap(err)


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Close #866 

### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Revert the asserts of `test/zkproof/flows_test.go` so they match the ones in `compatibility-canary`
- When a coordinator creates accounts on behalf of the user, this transactions where grouped under `l1UserTxs` instead of `l1CoordTxs`, fixed it
- Added some `// TODO:` coments in part of the code that we should undertand better. They don't necessarily represent an actual request to change code, but just a pointer on stuff that we've to look deeper into it 

### How to test?

<!-- What steps in order should someone run to test -->
Unit tests now match `compatibility-canary` again

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

