### PR TITLE
Order L2Txs considering atomic txs

### DIFF
--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -1065,3 +1065,5 @@ func TestL1UserFutureTxs(t *testing.T) {
 	stateDB.Close()
 	txsel.LocalAccountsDB().Close()
 }
+
+// TODO: add unit test for sortL2Txs


### PR DESCRIPTION
### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Edit the current sortL2Txs funcitons to consider atomic transactions
- Change interface of `splitL2ForgableAndNonForgable`

### How to test?

<!-- What steps in order should someone run to test -->

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

