### PR TITLE
Inprove the format of POST /atomic-poolby adding deterministic Atomic…

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -13,8 +13,6 @@ const (
 	ErrTxsNotAtomic = "There is at least one transaction in the payload that could be forged without the others"
 	// ErrSingleTxInAtomicEndpoint only one tx sent to the atomic-pool endpoint
 	ErrSingleTxInAtomicEndpoint = "To use the atomic-pool endpoint at least two transactions are required"
-	// ErrRqTxIDNotProvided error message returned when receiving (and rejecting) a tx that has malformed RqTxID
-	ErrRqTxIDNotProvided = "Transaction requestId is not set or is invalid"
 
 	// Internal error messages (used for logs or handling errors returned from internal comopnents)
 
@@ -32,4 +30,7 @@ const (
 
 	// ErrNotAtomicTxsInPostPoolTx error message returned when received an non-atomic transaction inside atomic pool
 	ErrNotAtomicTxsInPostPoolTx = "Atomic transactions are only accepted in POST /atomic-pool"
+
+	// ErrInvalidAtomicGroupID error message returned when received an invalid AtomicGroupID
+	ErrInvalidAtomicGroupID = "Invalid atomicGroupId"
 )

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1510,11 +1510,6 @@ components:
             - $ref: '#/components/schemas/BJJSignature'
             - description: Signature of the transaction. More info [here](https://idocs.hermez.io/#/spec/zkrollup/README?id=l2a-idl2).
             - example: "72024a43f546b0e1d9d5d7c4c30c259102a9726363adcc4ec7b6aea686bcb5116f485c5542d27c4092ae0ceaf38e3bb44417639bd2070a58ba1aa1aab9d92c03"
-        requestId:
-          type: string
-          description: Identifier for transactions. Used for any kind of transaction (both L1 and L2). More info on how the identifiers are built [here](https://idocs.hermez.io/#/spec/architecture/db/README?id=txid)
-          example: "0x00000000000001e240004700" 
-          nullable: true
         requestOffset:
           type: integer
           description: Identifier of the relative index of the transaction that would be linked. More info on how the identifiers are built [here](https://docs.hermez.io/#/developers/protocol/hermez-protocol/circuits/circuits?id=rq-tx-verifier)
@@ -1542,63 +1537,80 @@ components:
       - fee
       - nonce
       - signature
+    AtomicGroupID:
+      type: string
+      description: |
+        Identifier for atomic groups (set of transactions that have to be forged in the same batch, constrained by the request fields of the transactions on the group).
+        This identifier is calculated by hashing the concatenation of the transaction id bytes that conform the group).
+      example:  '0x02b0c3d2fe18df3cd192d862804641190f99b79df3f1d6449b65fe246412120af0'
     PostPoolL2Transactions:
-      type: array
-      items:
-        $ref: '#/components/schemas/PostPoolL2Transaction'
+      type: object
+      properties:
+        atomicGroupId:
+          $ref: '#/components/schemas/AtomicGroupID'
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PostPoolL2Transaction'
+      required:
+        - atomicGroupId
+        - transactions
+      additionalProperties: false
       example:
-        - id: '0x02b0c3d2fe18df3cd192d862804641190f99b79df3f1d6449b65fe246412120af0'
-          type: Transfer
-          tokenId: 0
-          fromAccountIndex: hez:ETH:789
-          toAccountIndex: hez:ETH:790
-          toHezEthereumAddress:
-          toBjj:
-          amount: '1000'
-          fee: 229
-          nonce: 4
-          signature: 6472c352ae96f3cc6c698e6c19d07b46fd70a8035a8131605f4442d57bc5941a0a87240f4ad3d9cfc662bf5bbe2f42db4a5f77fef28fad06cb41b0c00c589905
-          requestId: '0x026c26d626dd40bf4f83737b9237674a1e7d235b38393a008dfc8d401ca2f7a412'
-          requestOffset: 1
-        - id: '0x026c26d626dd40bf4f83737b9237674a1e7d235b38393a008dfc8d401ca2f7a412'
-          type: Transfer
-          tokenId: 0
-          fromAccountIndex: hez:ETH:790
-          toAccountIndex: hez:ETH:789
-          toHezEthereumAddress:
-          toBjj:
-          amount: '1000'
-          fee: 229
-          nonce: 4
-          signature: 62945599b3b3cfafdf71ec6fe935634234bc5c7f9cd13e84850646deb62b348b35c23c327917f869162f625c5848c8c6b83bd1456fd76fea181c757ddc811f04
-          requestId: '0x0247ecd484e9f5710a703ee1cf36f6e7e00a294e93be7de0463a7108255eac6fa9'
-          requestOffset: 1
-        - id: '0x0247ecd484e9f5710a703ee1cf36f6e7e00a294e93be7de0463a7108255eac6fa9'
-          type: Transfer
-          tokenId: 0
-          fromAccountIndex: hez:ETH:789
-          toAccountIndex: hez:ETH:790
-          toHezEthereumAddress:
-          toBjj:
-          amount: '1000'
-          fee: 229
-          nonce: 5
-          signature: d71fa5d4ee8c12f111bf3d80dfb7e99af4eccab59c90a5b092e3b18c77860d140de73e2c104b77bcd6564af7db330ab626a29ae72a777fd00d4f56bf16334f01
-          requestId: '0x024be7ae4f0df9c956628d187069fde63e616749e2d2ce447b7386c4fa431b7d45'
-          requestOffset: 1
-        - id: '0x024be7ae4f0df9c956628d187069fde63e616749e2d2ce447b7386c4fa431b7d45'
-          type: Transfer
-          tokenId: 0
-          fromAccountIndex: hez:ETH:790
-          toAccountIndex: hez:ETH:789
-          toHezEthereumAddress:
-          toBjj:
-          amount: '1000'
-          fee: 229
-          nonce: 5
-          signature: 8738afdc744b5e87d79f09a61924a89811f12c74fdff4314afdb5966264276a5a44748dbb6540c8a0029e1e03a1b01ede4ceaffa49b8e6f7f98a16bccd400005
-          requestId: '0x02b0c3d2fe18df3cd192d862804641190f99b79df3f1d6449b65fe246412120af0'
-          requestOffset: 5
+        atomicGroupId: '0x02b0c3d2fe18df3cd192d862804641190f99b79df3f1d6449b65fe246412120af0'
+        transactions:
+          - id: '0x02b0c3d2fe18df3cd192d862804641190f99b79df3f1d6449b65fe246412120af0'
+            type: Transfer
+            tokenId: 0
+            fromAccountIndex: hez:ETH:789
+            toAccountIndex: hez:ETH:790
+            toHezEthereumAddress:
+            toBjj:
+            amount: '1000'
+            fee: 229
+            nonce: 4
+            signature: 6472c352ae96f3cc6c698e6c19d07b46fd70a8035a8131605f4442d57bc5941a0a87240f4ad3d9cfc662bf5bbe2f42db4a5f77fef28fad06cb41b0c00c589905
+            requestId: '0x026c26d626dd40bf4f83737b9237674a1e7d235b38393a008dfc8d401ca2f7a412'
+            requestOffset: 1
+          - id: '0x026c26d626dd40bf4f83737b9237674a1e7d235b38393a008dfc8d401ca2f7a412'
+            type: Transfer
+            tokenId: 0
+            fromAccountIndex: hez:ETH:790
+            toAccountIndex: hez:ETH:789
+            toHezEthereumAddress:
+            toBjj:
+            amount: '1000'
+            fee: 229
+            nonce: 4
+            signature: 62945599b3b3cfafdf71ec6fe935634234bc5c7f9cd13e84850646deb62b348b35c23c327917f869162f625c5848c8c6b83bd1456fd76fea181c757ddc811f04
+            requestId: '0x0247ecd484e9f5710a703ee1cf36f6e7e00a294e93be7de0463a7108255eac6fa9'
+            requestOffset: 1
+          - id: '0x0247ecd484e9f5710a703ee1cf36f6e7e00a294e93be7de0463a7108255eac6fa9'
+            type: Transfer
+            tokenId: 0
+            fromAccountIndex: hez:ETH:789
+            toAccountIndex: hez:ETH:790
+            toHezEthereumAddress:
+            toBjj:
+            amount: '1000'
+            fee: 229
+            nonce: 5
+            signature: d71fa5d4ee8c12f111bf3d80dfb7e99af4eccab59c90a5b092e3b18c77860d140de73e2c104b77bcd6564af7db330ab626a29ae72a777fd00d4f56bf16334f01
+            requestId: '0x024be7ae4f0df9c956628d187069fde63e616749e2d2ce447b7386c4fa431b7d45'
+            requestOffset: 1
+          - id: '0x024be7ae4f0df9c956628d187069fde63e616749e2d2ce447b7386c4fa431b7d45'
+            type: Transfer
+            tokenId: 0
+            fromAccountIndex: hez:ETH:790
+            toAccountIndex: hez:ETH:789
+            toHezEthereumAddress:
+            toBjj:
+            amount: '1000'
+            fee: 229
+            nonce: 5
+            signature: 8738afdc744b5e87d79f09a61924a89811f12c74fdff4314afdb5966264276a5a44748dbb6540c8a0029e1e03a1b01ede4ceaffa49b8e6f7f98a16bccd400005
+            requestId: '0x02b0c3d2fe18df3cd192d862804641190f99b79df3f1d6449b65fe246412120af0'
+            requestOffset: 5
     PoolL2Transaction:
       type: object
       properties:

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -41,8 +41,8 @@ func (a *API) postPoolTx(c *gin.Context) {
 
 // AtomicGroup represents a set of atomic transactions
 type AtomicGroup struct {
-	AtomicGroupID common.AtomicGroupID `json:"atomicGroupId"`
-	Txs           []common.PoolL2Tx    `json:"transactions"`
+	ID  common.AtomicGroupID `json:"atomicGroupId"`
+	Txs []common.PoolL2Tx    `json:"transactions"`
 }
 
 // SetAtomicGroupID set the atomic group ID for an atomic group that already has Txs
@@ -51,7 +51,7 @@ func (ag *AtomicGroup) SetAtomicGroupID() {
 	for _, tx := range ag.Txs {
 		ids = append(ids, tx.TxID)
 	}
-	ag.AtomicGroupID = common.CalculateAtomicGroupID(ids)
+	ag.ID = common.CalculateAtomicGroupID(ids)
 }
 
 // IsAtomicGroupIDValid return false if the atomic group ID that is set
@@ -62,7 +62,7 @@ func (ag AtomicGroup) IsAtomicGroupIDValid() bool {
 		ids = append(ids, tx.TxID)
 	}
 	actualAGID := common.CalculateAtomicGroupID(ids)
-	return actualAGID == ag.AtomicGroupID
+	return actualAGID == ag.ID
 }
 
 func (a *API) postAtomicPool(c *gin.Context) {
@@ -108,7 +108,7 @@ func (a *API) postAtomicPool(c *gin.Context) {
 		receivedAtomicGroup.Txs[i].RqFee = requestedTx.Fee
 		receivedAtomicGroup.Txs[i].RqNonce = requestedTx.Nonce
 		receivedAtomicGroup.Txs[i].ClientIP = clientIP
-		receivedAtomicGroup.Txs[i].AtomicGroupID = receivedAtomicGroup.AtomicGroupID
+		receivedAtomicGroup.Txs[i].AtomicGroupID = receivedAtomicGroup.ID
 
 		// Validate transaction
 		if err := a.verifyPoolL2Tx(receivedAtomicGroup.Txs[i]); err != nil {

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/db/l2db"
-	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/tracerr"
 	"github.com/yourbasic/graph"
 )
@@ -21,7 +20,7 @@ func (a *API) postPoolTx(c *gin.Context) {
 		retBadReq(err, c)
 		return
 	}
-	if receivedTx.RqOffset != 0 || receivedTx.RqTxID != common.EmptyTxID {
+	if receivedTx.RqOffset != 0 {
 		retBadReq(errors.New(ErrNotAtomicTxsInPostPoolTx), c)
 		return
 	}
@@ -40,61 +39,94 @@ func (a *API) postPoolTx(c *gin.Context) {
 	c.JSON(http.StatusOK, receivedTx.TxID.String())
 }
 
+// AtomicGroup represents a set of atomic transactions
+type AtomicGroup struct {
+	AtomicGroupID common.AtomicGroupID `json:"atomicGroupId"`
+	Txs           []common.PoolL2Tx    `json:"transactions"`
+}
+
+// SetAtomicGroupID set the atomic group ID for an atomic group that already has Txs
+func (ag *AtomicGroup) SetAtomicGroupID() {
+	ids := []common.TxID{}
+	for _, tx := range ag.Txs {
+		ids = append(ids, tx.TxID)
+	}
+	ag.AtomicGroupID = common.CalculateAtomicGroupID(ids)
+}
+
+// IsAtomicGroupIDValid return false if the atomic group ID that is set
+// doesn't match with the calculated
+func (ag AtomicGroup) IsAtomicGroupIDValid() bool {
+	ids := []common.TxID{}
+	for _, tx := range ag.Txs {
+		ids = append(ids, tx.TxID)
+	}
+	actualAGID := common.CalculateAtomicGroupID(ids)
+	return actualAGID == ag.AtomicGroupID
+}
+
 func (a *API) postAtomicPool(c *gin.Context) {
 	// Parse body
-	var receivedTxs []common.PoolL2Tx
-	if err := c.ShouldBindJSON(&receivedTxs); err != nil {
+	var receivedAtomicGroup AtomicGroup
+	if err := c.ShouldBindJSON(&receivedAtomicGroup); err != nil {
 		retBadReq(err, c)
 		return
 	}
-	nTxs := len(receivedTxs)
+	// Validate atomic group id
+	if !receivedAtomicGroup.IsAtomicGroupIDValid() {
+		retBadReq(errors.New(ErrInvalidAtomicGroupID), c)
+		return
+	}
+	nTxs := len(receivedAtomicGroup.Txs)
 	if nTxs <= 1 {
 		retBadReq(errors.New(ErrSingleTxInAtomicEndpoint), c)
 		return
 	}
-	// set the Rq fields
-	for i, tx1 := range receivedTxs {
+	// Validate txs
+	txIDStrings := make([]string, nTxs) // used for successful response
+	clientIP := c.ClientIP()
+	for i, tx1 := range receivedAtomicGroup.Txs {
+		// Find requested transaction
 		relativePosition, err := requestOffset2RelativePosition(tx1.RqOffset)
 		if err != nil {
 			retBadReq(err, c)
 			return
 		}
 		requestedPosition := i + relativePosition
-		if requestedPosition > len(receivedTxs)-1 || requestedPosition < 0 {
+		if requestedPosition > len(receivedAtomicGroup.Txs)-1 || requestedPosition < 0 {
 			retBadReq(errors.New(ErrRqOffsetOutOfBounds), c)
 			return
 		}
-		requestedTx := receivedTxs[requestedPosition]
-		if tx1.RqTxID == requestedTx.TxID {
-			receivedTxs[i].RqFromIdx = requestedTx.FromIdx
-			receivedTxs[i].RqToIdx = requestedTx.ToIdx
-			receivedTxs[i].RqToEthAddr = requestedTx.ToEthAddr
-			receivedTxs[i].RqToBJJ = requestedTx.ToBJJ
-			receivedTxs[i].RqTokenID = requestedTx.TokenID
-			receivedTxs[i].RqAmount = requestedTx.Amount
-			receivedTxs[i].RqFee = requestedTx.Fee
-			receivedTxs[i].RqNonce = requestedTx.Nonce
-		}
-	}
-	// Validate txs individually
-	txIDStrings := make([]string, nTxs) // used for successful response
-	clientIP := c.ClientIP()
-	for i, tx := range receivedTxs {
-		if err := a.verifyPoolL2Tx(tx); err != nil {
+		// Set fields that are omitted in the JSON
+		requestedTx := receivedAtomicGroup.Txs[requestedPosition]
+		receivedAtomicGroup.Txs[i].RqFromIdx = requestedTx.FromIdx
+		receivedAtomicGroup.Txs[i].RqToIdx = requestedTx.ToIdx
+		receivedAtomicGroup.Txs[i].RqToEthAddr = requestedTx.ToEthAddr
+		receivedAtomicGroup.Txs[i].RqToBJJ = requestedTx.ToBJJ
+		receivedAtomicGroup.Txs[i].RqTokenID = requestedTx.TokenID
+		receivedAtomicGroup.Txs[i].RqAmount = requestedTx.Amount
+		receivedAtomicGroup.Txs[i].RqFee = requestedTx.Fee
+		receivedAtomicGroup.Txs[i].RqNonce = requestedTx.Nonce
+		receivedAtomicGroup.Txs[i].ClientIP = clientIP
+		receivedAtomicGroup.Txs[i].AtomicGroupID = receivedAtomicGroup.AtomicGroupID
+
+		// Validate transaction
+		if err := a.verifyPoolL2Tx(receivedAtomicGroup.Txs[i]); err != nil {
 			retBadReq(err, c)
 			return
 		}
-		receivedTxs[i].ClientIP = clientIP
-		txIDStrings[i] = tx.TxID.String()
+
+		// Prepare response
+		txIDStrings[i] = receivedAtomicGroup.Txs[i].TxID.String()
 	}
-	// Validate that all txs in the payload represent an atomic group
-	if !isSingleAtomicGroup(receivedTxs) {
-		log.Error("isSingleAtomicGroup")
+
+	// Validate that all txs in the payload represent a single atomic group
+	if !isSingleAtomicGroup(receivedAtomicGroup.Txs) {
 		retBadReq(errors.New(ErrTxsNotAtomic), c)
 		return
 	}
 	// Insert to DB
-	if err := a.l2.AddAtomicTxsAPI(receivedTxs); err != nil {
+	if err := a.l2.AddAtomicTxsAPI(receivedAtomicGroup.Txs); err != nil {
 		retSQLErr(err, c)
 		return
 	}
@@ -119,7 +151,6 @@ func requestOffset2RelativePosition(rqoffset uint8) (int, error) {
 
 	switch rqoffset {
 	case rqOffsetZero:
-		log.Error("requestOffset2RelativePosition")
 		return rqOffsetZero, errors.New(ErrTxsNotAtomic)
 	case rqOffsetOne:
 		return rqOffsetOne, nil
@@ -145,24 +176,18 @@ func requestOffset2RelativePosition(rqoffset uint8) (int, error) {
 func isSingleAtomicGroup(txs []common.PoolL2Tx) bool {
 	// Create a graph from the given txs to represent requests between transactions
 	g := graph.New(len(txs))
-	idToPos := make(map[common.TxID]int, len(txs))
-	// Map tx ID to integers that will represent the nodes of the graph
+	// Create vertices that connect nodes of the graph (txs) using RqOffset
 	for i, tx := range txs {
-		idToPos[tx.TxID] = i
-	}
-	// Create vertices that connect nodes of the graph (txs) using RqTxID
-	for i, tx := range txs {
-		if tx.RqTxID == common.EmptyTxID {
-			// if just one tx doesn't request any other tx, this tx could be forged alone
-			// making the hole group not atomic
+		requestedRelativePosition, err := requestOffset2RelativePosition(tx.RqOffset)
+		if err != nil {
 			return false
 		}
-		if rqTxPos, ok := idToPos[tx.RqTxID]; ok {
-			g.Add(i, rqTxPos)
-		} else {
-			// tx is requesting a tx that is not provided in the payload
+		requestedPosition := i + requestedRelativePosition
+		if requestedPosition < 0 || requestedPosition >= len(txs) {
+			// Safety check: requested tx is not out of array bounds
 			return false
 		}
+		g.Add(i, requestedPosition)
 	}
 	// A graph with a single strongly connected component,
 	// means that all the nodes can be reached from all the nodes.

--- a/api/txspool_test.go
+++ b/api/txspool_test.go
@@ -681,7 +681,7 @@ func TestAtomicPool(t *testing.T) {
 	}
 	// Sign and format txs
 	atomicGroup, _ = signAndTransformTxs(txs)
-	atomicGroup.AtomicGroupID = common.AtomicGroupID([32]byte{1, 2, 3, 4})
+	atomicGroup.ID = common.AtomicGroupID([32]byte{1, 2, 3, 4})
 	// Send txs
 	jsonTxBytes, err = json.Marshal(atomicGroup)
 	require.NoError(t, err)

--- a/db/l2db/apiqueries.go
+++ b/db/l2db/apiqueries.go
@@ -145,17 +145,6 @@ func (l2db *L2DB) AddAtomicTxsAPI(txs []common.PoolL2Tx) error {
 			avgFeeUSD, l2db.maxFeeUSD))
 	}
 
-	// Set AtomicGroupID
-	var lastAtomicGroup int
-	row := l2db.dbRead.QueryRow(`SELECT COALESCE(MAX(atomic_group_id), 0) FROM tx_pool`)
-	if err := row.Scan(&lastAtomicGroup); err != nil {
-		return tracerr.Wrap(err)
-	}
-	atomicGroupID := lastAtomicGroup + 1
-	for i := 0; i < len(txs); i++ {
-		txs[i].AtomicGroupID = atomicGroupID
-	}
-
 	// Insert txs if the pool is not full
 	return tracerr.Wrap(l2db.addTxs(txs, true))
 }
@@ -164,7 +153,7 @@ func (l2db *L2DB) AddAtomicTxsAPI(txs []common.PoolL2Tx) error {
 const selectPoolTxAPI = `SELECT tx_pool.item_id, tx_pool.tx_id, hez_idx(tx_pool.from_idx, token.symbol) AS from_idx, tx_pool.effective_from_eth_addr, 
 tx_pool.effective_from_bjj, hez_idx(tx_pool.to_idx, token.symbol) AS to_idx, tx_pool.effective_to_eth_addr, 
 tx_pool.effective_to_bjj, tx_pool.token_id, tx_pool.amount, tx_pool.fee, tx_pool.nonce, 
-tx_pool.state, tx_pool.info, tx_pool.signature, tx_pool.timestamp, tx_pool.batch_num, tx_pool.rq_tx_id, hez_idx(tx_pool.rq_from_idx, token.symbol) AS rq_from_idx, 
+tx_pool.state, tx_pool.info, tx_pool.signature, tx_pool.timestamp, tx_pool.batch_num, hez_idx(tx_pool.rq_from_idx, token.symbol) AS rq_from_idx, 
 hez_idx(tx_pool.rq_to_idx, token.symbol) AS rq_to_idx, tx_pool.rq_to_eth_addr, tx_pool.rq_to_bjj, tx_pool.rq_token_id, tx_pool.rq_amount, 
 tx_pool.rq_fee, tx_pool.rq_nonce, tx_pool.tx_type, 
 token.item_id AS token_item_id, token.eth_block_num, token.eth_addr, token.name, token.symbol, token.decimals, token.usd, token.usd_update 
@@ -174,7 +163,7 @@ FROM tx_pool INNER JOIN token ON tx_pool.token_id = token.token_id `
 const selectPoolTxsAPI = `SELECT tx_pool.item_id, tx_pool.tx_id, hez_idx(tx_pool.from_idx, token.symbol) AS from_idx, tx_pool.effective_from_eth_addr, 
 tx_pool.effective_from_bjj, hez_idx(tx_pool.to_idx, token.symbol) AS to_idx, tx_pool.effective_to_eth_addr, 
 tx_pool.effective_to_bjj, tx_pool.token_id, tx_pool.amount, tx_pool.fee, tx_pool.nonce, 
-tx_pool.state, tx_pool.info, tx_pool.signature, tx_pool.timestamp, tx_pool.batch_num, tx_pool.rq_tx_id, hez_idx(tx_pool.rq_from_idx, token.symbol) AS rq_from_idx, 
+tx_pool.state, tx_pool.info, tx_pool.signature, tx_pool.timestamp, tx_pool.batch_num, hez_idx(tx_pool.rq_from_idx, token.symbol) AS rq_from_idx, 
 hez_idx(tx_pool.rq_to_idx, token.symbol) AS rq_to_idx, tx_pool.rq_to_eth_addr, tx_pool.rq_to_bjj, tx_pool.rq_token_id, tx_pool.rq_amount, 
 tx_pool.rq_fee, tx_pool.rq_nonce, tx_pool.tx_type, 
 token.item_id AS token_item_id, token.eth_block_num, token.eth_addr, token.name, token.symbol, token.decimals, token.usd, token.usd_update, 

--- a/db/l2db/l2db_test.go
+++ b/db/l2db/l2db_test.go
@@ -291,8 +291,7 @@ func TestGetPending(t *testing.T) {
 	require.NoError(t, err)
 	var pendingTxs []*common.PoolL2Tx
 	// Add case for atomic related fields
-	poolL2Txs[0].AtomicGroupID = 1
-	poolL2Txs[0].RqTxID = common.TxID([common.TxIDLen]byte{7})
+	poolL2Txs[0].AtomicGroupID = common.AtomicGroupID([common.AtomicGroupIDLen]byte{9})
 	poolL2Txs[0].RqNonce = 1
 	poolL2Txs[0].RqTokenID = 1
 	poolL2Txs[0].RqFromIdx = 678

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -26,7 +26,6 @@ type PoolTxAPI struct {
 	State                common.PoolL2TxState  `meddler:"state"`
 	Info                 *string               `meddler:"info"`
 	Signature            babyjub.SignatureComp `meddler:"signature"`
-	RqTxID               *common.TxID          `meddler:"rq_tx_id"`
 	RqFromIdx            *apitypes.HezIdx      `meddler:"rq_from_idx"`
 	RqToIdx              *apitypes.HezIdx      `meddler:"rq_to_idx"`
 	RqToEthAddr          *apitypes.HezEthAddr  `meddler:"rq_to_eth_addr"`
@@ -71,7 +70,6 @@ func (tx PoolTxAPI) MarshalJSON() ([]byte, error) {
 		"info":                        tx.Info,
 		"signature":                   tx.Signature,
 		"timestamp":                   tx.Timestamp,
-		"requestId":                   tx.RqTxID,
 		"requestFromAccountIndex":     tx.RqFromIdx,
 		"requestToAccountIndex":       tx.RqToIdx,
 		"requestToHezEthereumAddress": tx.RqToEthAddr,

--- a/db/migrations/0005.sql
+++ b/db/migrations/0005.sql
@@ -1,11 +1,9 @@
 -- +migrate Up
 ALTER TABLE tx_pool
-ADD COLUMN rq_tx_id BYTEA DEFAULT NULL,
 ADD COLUMN rq_offset SMALLINT DEFAULT NULL,
-ADD COLUMN atomic_group_id BIGINT DEFAULT NULL;
+ADD COLUMN atomic_group_id BYTEA DEFAULT NULL;
 
 -- +migrate Down
 ALTER TABLE tx_pool
-DROP COLUMN rq_tx_id,
 DROP COLUMN rq_offset,
 DROP COLUMN atomic_group_id;

--- a/db/migrations/0005_test.go
+++ b/db/migrations/0005_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// This migration adds the column `rq_tx_id` on `tx_pool`
+// This migration adds the column `rq_offset` and `atomic_group_id` on `tx_pool`
 
 type migrationTest0005 struct{}
 
@@ -139,7 +139,6 @@ func (m migrationTest0005) RunAssertsAfterMigrationUp(t *testing.T, db *sqlx.DB)
 		client_ip = '93.176.174.84' AND
 		external_delete = true AND
 		item_id = 1 AND -- Note that item_id is an autoincremental column, so this value is setted automatically
-		rq_tx_id IS NULL AND
 		rq_offset IS NULL AND
 		atomic_group_id IS NULL;`
 	row := db.QueryRow(queryGetTxPool)
@@ -186,10 +185,13 @@ func (m migrationTest0005) RunAssertsAfterMigrationDown(t *testing.T, db *sqlx.D
 	var result int
 	assert.NoError(t, row.Scan(&result))
 	assert.Equal(t, 1, result)
-	// check that rq_tx_id colum doesn't exist anymore
-	const queryCheckItemID = `SELECT COUNT(*) FROM tx_pool WHERE rq_tx_id IS NULL;`
-	row = db.QueryRow(queryCheckItemID)
-	assert.Equal(t, `pq: column "rq_tx_id" does not exist`, row.Scan(&result).Error())
+	// check that atomic_group_id amd rq_offset colum doesn't exist anymore
+	const queryCheckRqOffset = `SELECT COUNT(*) FROM tx_pool WHERE rq_offset IS NULL;`
+	row = db.QueryRow(queryCheckRqOffset)
+	assert.Equal(t, `pq: column "rq_offset" does not exist`, row.Scan(&result).Error())
+	const queryCheckAtomicGroupID = `SELECT COUNT(*) FROM tx_pool WHERE atomic_group_id IS NULL;`
+	row = db.QueryRow(queryCheckAtomicGroupID)
+	assert.Equal(t, `pq: column "atomic_group_id" does not exist`, row.Scan(&result).Error())
 }
 
 func TestMigration0005(t *testing.T) {

--- a/test/zkproof/flows_test.go
+++ b/test/zkproof/flows_test.go
@@ -462,7 +462,7 @@ func TestZKInputsAtomicTxs(t *testing.T) {
 		RqNonce:       0,
 		State:         common.PoolL2TxStatePending,
 		RqOffset:      1,
-		AtomicGroupID: 1,
+		AtomicGroupID: common.AtomicGroupID([common.AtomicGroupIDLen]byte{1}),
 	}
 	_, err = common.NewPoolL2Tx(&atomicTxA)
 	require.NoError(t, err)
@@ -485,7 +485,7 @@ func TestZKInputsAtomicTxs(t *testing.T) {
 		RqNonce:       0,
 		State:         common.PoolL2TxStatePending,
 		RqOffset:      7,
-		AtomicGroupID: 1,
+		AtomicGroupID: common.AtomicGroupID([common.AtomicGroupIDLen]byte{1}),
 	}
 	_, err = common.NewPoolL2Tx(&atomicTxB)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #913 
Closes #905 

### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Calculate the atomic group ID in a deterministic way, this change forces to change the type from int to bytes, and because of that, many lines on the code has changed
- Change the API request body format for `POST /atomic-pool`
- Completely remove `RqTxID` from all the code since it's not safe to use it to reference other txs 

### How to test?

<!-- What steps in order should someone run to test -->
Included unit tests

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint
- [x] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

