### PR TITLE
allows don't specify symbols and addresses in config file

### DIFF
--- a/priceupdater/priceupdater.go
+++ b/priceupdater/priceupdater.go
@@ -111,6 +111,8 @@ func (d *symbolsMap) strToMapSymbol(str string) error {
 		}
 		d.Symbols = mapping
 		log.Debug("Symbol mapping from config file: ", mapping)
+	} else {
+		d.Symbols = make(map[uint]string)
 	}
 	return lastErr
 }
@@ -141,6 +143,8 @@ func (d *addressesMap) strToMapAddress(str string) error {
 		}
 		d.Addresses = mapping
 		log.Debug("Address mapping from config file: ", mapping)
+	} else {
+		d.Addresses = make(map[uint]ethCommon.Address)
 	}
 	return lastErr
 }
@@ -331,15 +335,18 @@ func (p *PriceUpdater) UpdateTokenList() error {
 			}
 		}
 		for _, provider := range p.providers {
-			if len(provider.SymbolsMap.Symbols) != 0 {
+			switch provider.Provider {
+			case UpdateMethodTypeBitFinexV2:
 				if _, ok := provider.SymbolsMap.Symbols[dbToken.TokenID]; !ok {
 					provider.SymbolsMap.Symbols[dbToken.TokenID] = dbToken.Symbol
 				}
-			}
-			if len(provider.AddressesMap.Addresses) != 0 {
+			case UpdateMethodTypeCoingeckoV3:
 				if _, ok := provider.AddressesMap.Addresses[dbToken.TokenID]; !ok {
 					provider.AddressesMap.Addresses[dbToken.TokenID] = dbToken.Addr
 				}
+			default:
+				log.Error("Unknown provider detected: ", provider.Provider)
+				return tracerr.Wrap(fmt.Errorf("Error: Unknown price provider: " + provider.Provider))
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR does?

This PR allows don't specify symbols and addresses in the config file. Now, you can even remove those properties if you are not gonna use them.

### How to test?

Sync the hermez node in mainnet and check using config file without symbols and addresses properties.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Include tests
- [X] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

