### PR TITLE
Add MaxNumBatch support at API level

### DIFF
--- a/api/atomicpool.go
+++ b/api/atomicpool.go
@@ -57,6 +57,11 @@ func (a *API) postAtomicPool(c *gin.Context) {
 	txIDStrings := make([]string, nTxs) // used for successful response
 	clientIP := c.ClientIP()
 	for i, tx := range receivedAtomicGroup.Txs {
+		// Check MaxNumBatch
+		if tx.MaxNumBatch != 0 {
+			retBadReq(errors.New(ErrUnsupportedMaxNumBatch), c)
+			return
+		}
 		// Find requested transaction
 		relativePosition, err := requestOffset2RelativePosition(tx.RqOffset)
 		if err != nil {

--- a/api/errors.go
+++ b/api/errors.go
@@ -35,4 +35,6 @@ const (
 
 	// ErrInvalidAtomicGroupID error message returned when received an invalid AtomicGroupID
 	ErrInvalidAtomicGroupID = "Invalid atomicGroupId"
+	// ErrUnsupportedMaxNumBatch error message returned when tx.MaxNumBatch != 0 until the feature is fully implemented
+	ErrUnsupportedMaxNumBatch = "Currently only supported value for maxNumBatch is 0, this will change soon when the feature is fully implemented"
 )

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1478,10 +1478,16 @@ components:
             - $ref: '#/components/schemas/BJJSignature'
             - description: Signature of the transaction. More info [here](https://idocs.hermez.io/#/spec/zkrollup/README?id=l2a-idl2).
             - example: "72024a43f546b0e1d9d5d7c4c30c259102a9726363adcc4ec7b6aea686bcb5116f485c5542d27c4092ae0ceaf38e3bb44417639bd2070a58ba1aa1aab9d92c03"
+        maxNumBatch:
+          type: integer
+          description: Batch until the transaction can be forged. If the transaction isn't forged before batch `maxNumBatch`, it will never be forged. 0 means no restriction.
+          example: 0  
         requestOffset:
           type: integer
-          description: Identifier of the relative index of the transaction that would be linked. More info on how the identifiers are built [here](https://docs.hermez.io/#/developers/protocol/hermez-protocol/circuits/circuits?id=rq-tx-verifier)
-          example: 1
+          description: |
+            Identifier of the relative index of the transaction that would be linked. 0 means no linked transaction.
+            More info on how the identifiers are built [here](https://docs.hermez.io/#/developers/protocol/hermez-protocol/circuits/circuits?id=rq-tx-verifier)
+          example: 0
           nullable: true
       example:
         id: '0x020000000001000000000006'
@@ -1495,6 +1501,8 @@ components:
         fee: 0
         nonce: 6
         signature: 1a79dd5e661d58266901a0de8afb046b466c4c1af937100f627a421771f2911fa3fde8ea2e272b4802a8b1f1229689292acd6f7e8ab4cadc4ab37b6b9e13a101
+        maxNumBatch: 0
+        requestOffset: 0
       additionalProperties: false
       required:
       - id

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -24,6 +24,10 @@ func (a *API) postPoolTx(c *gin.Context) {
 		retBadReq(errors.New(ErrNotAtomicTxsInPostPoolTx), c)
 		return
 	}
+	if receivedTx.MaxNumBatch != 0 {
+		retBadReq(errors.New(ErrUnsupportedMaxNumBatch), c)
+		return
+	}
 	// Check that tx is valid
 	if err := a.verifyPoolL2Tx(receivedTx); err != nil {
 		retBadReq(err, c)

--- a/api/txspool_test.go
+++ b/api/txspool_test.go
@@ -201,6 +201,14 @@ func TestPoolTxs(t *testing.T) {
 	jsonTxReader = bytes.NewReader(jsonTxBytes)
 	err = doBadReq("POST", endpoint, jsonTxReader, 409)
 	require.NoError(t, err)
+	// Wrong maxNumBatch
+	badTx = tc.poolTxsToSend[0]
+	badTx.MaxNumBatch = 30
+	jsonTxBytes, err = json.Marshal(badTx)
+	require.NoError(t, err)
+	jsonTxReader = bytes.NewReader(jsonTxBytes)
+	err = doBadReq("POST", endpoint, jsonTxReader, 400)
+	require.NoError(t, err)
 	// GET
 	// init structures
 	fetchedTxsTotal := []testPoolTxReceive{}

--- a/db/l2db/apiqueries.go
+++ b/db/l2db/apiqueries.go
@@ -155,7 +155,7 @@ tx_pool.effective_from_bjj, hez_idx(tx_pool.to_idx, token.symbol) AS to_idx, tx_
 tx_pool.effective_to_bjj, tx_pool.token_id, tx_pool.amount, tx_pool.fee, tx_pool.nonce, 
 tx_pool.state, tx_pool.info, tx_pool.signature, tx_pool.timestamp, tx_pool.batch_num, hez_idx(tx_pool.rq_from_idx, token.symbol) AS rq_from_idx, 
 hez_idx(tx_pool.rq_to_idx, token.symbol) AS rq_to_idx, tx_pool.rq_to_eth_addr, tx_pool.rq_to_bjj, tx_pool.rq_token_id, tx_pool.rq_amount, 
-tx_pool.rq_fee, tx_pool.rq_nonce, tx_pool.tx_type, 
+tx_pool.rq_fee, tx_pool.rq_nonce, tx_pool.tx_type, tx_pool.max_num_batch, 
 token.item_id AS token_item_id, token.eth_block_num, token.eth_addr, token.name, token.symbol, token.decimals, token.usd, token.usd_update 
 FROM tx_pool INNER JOIN token ON tx_pool.token_id = token.token_id `
 
@@ -165,7 +165,7 @@ tx_pool.effective_from_bjj, hez_idx(tx_pool.to_idx, token.symbol) AS to_idx, tx_
 tx_pool.effective_to_bjj, tx_pool.token_id, tx_pool.amount, tx_pool.fee, tx_pool.nonce, 
 tx_pool.state, tx_pool.info, tx_pool.signature, tx_pool.timestamp, tx_pool.batch_num, hez_idx(tx_pool.rq_from_idx, token.symbol) AS rq_from_idx, 
 hez_idx(tx_pool.rq_to_idx, token.symbol) AS rq_to_idx, tx_pool.rq_to_eth_addr, tx_pool.rq_to_bjj, tx_pool.rq_token_id, tx_pool.rq_amount, 
-tx_pool.rq_fee, tx_pool.rq_nonce, tx_pool.tx_type, 
+tx_pool.rq_fee, tx_pool.rq_nonce, tx_pool.tx_type, tx_pool.max_num_batch,
 token.item_id AS token_item_id, token.eth_block_num, token.eth_addr, token.name, token.symbol, token.decimals, token.usd, token.usd_update, 
 count(*) OVER() AS total_items 
 FROM tx_pool INNER JOIN token ON tx_pool.token_id = token.token_id `

--- a/db/l2db/l2db_test.go
+++ b/db/l2db/l2db_test.go
@@ -290,7 +290,7 @@ func TestGetPending(t *testing.T) {
 	poolL2Txs, err := generatePoolL2Txs()
 	require.NoError(t, err)
 	var pendingTxs []*common.PoolL2Tx
-	// Add case for atomic related fields
+	// Add case for fields that have been added after the original schema
 	poolL2Txs[0].AtomicGroupID = common.AtomicGroupID([common.AtomicGroupIDLen]byte{9})
 	poolL2Txs[0].RqNonce = 1
 	poolL2Txs[0].RqTokenID = 1
@@ -300,6 +300,7 @@ func TestGetPending(t *testing.T) {
 	poolL2Txs[0].RqFee = 200
 	poolL2Txs[0].RqOffset = 3
 	poolL2Txs[0].RqToEthAddr = ethCommon.BigToAddress(big.NewInt(11111111))
+	poolL2Txs[0].MaxNumBatch = 123456
 
 	for i := range poolL2Txs {
 		err := l2DB.AddTxTest(&poolL2Txs[i])

--- a/db/migrations/0007.sql
+++ b/db/migrations/0007.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE tx_pool ADD COLUMN max_num_batch BIGINT DEFAULT NULL;
+
+-- +migrate Down
+ALTER TABLE tx_pool DROP COLUMN max_num_batch;

--- a/db/migrations/0007_test.go
+++ b/db/migrations/0007_test.go
@@ -1,0 +1,201 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+)
+
+// This migration adds the column `rq_offset` and `atomic_group_id` on `tx_pool`
+
+type migrationTest0007 struct{}
+
+func (m migrationTest0007) InsertData(db *sqlx.DB) error {
+	// insert block to respect the FKey of token
+	const queryInsertBlock = `INSERT INTO block (
+		eth_block_num,"timestamp",hash
+	) VALUES (
+		4417296,'2021-03-10 16:44:06.000',decode('C4D46677F3B2511D96389521C2BDFFE91127DE214423FF14899A6177631D2105','hex')
+	);`
+	// insert token to respect the FKey of tx_pool
+	const queryInsertToken = `INSERT INTO "token" (
+		token_id,eth_block_num,eth_addr,"name",symbol,decimals,usd,usd_update
+	) VALUES (
+		2,4417296,decode('1B36A4DED4DF40248C0E0E52CEA5EDC9A298B721','hex'),'Dai Stablecoin','DAI',18,1.01,'2021-04-17 20:21:16.870'
+	);`
+	// insert batch to respect the FKey of account
+	const queryInsertBatch = `INSERT INTO batch (
+		batch_num, 
+		eth_block_num, 
+		forger_addr, 
+		fees_collected, 
+		fee_idxs_coordinator, 
+		state_root, 
+		num_accounts, 
+		last_idx, 
+		exit_root, 
+		forge_l1_txs_num, 
+		slot_num, 
+		total_fees_usd
+	) VALUES (
+		6758, 
+		4417296, 
+		decode('459264CC7D2BF350AFDDA828C273E81367729C1F', 'hex'),
+		decode('7B2230223A34383337383531313632323134343030307D0A', 'hex'),
+		decode('5B3236335D0A', 'hex'),
+		12898140512818699175738765060248919016800434587665040485377676113605873428098, 
+		256, 
+		1044, 
+		0, 
+		NULL, 
+		717, 
+		115.047487133272
+	);`
+	// isert account to set effective_from_eth_addr, effective_from_bjj through trigger
+	const queryInsertAccount = `INSERT INTO account (
+		idx,token_id,batch_num,bjj,eth_addr
+	) VALUES (
+		789,2,6758,decode('FDDACE21457376B0952CCD19CE66B854FDD7C6E45905B0A0A75747C87D41719A','hex'),decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F','hex')
+	);`
+	// insert a row in tx_pool with all the fields setted
+	const queryInsertTxPool = `INSERT INTO tx_pool (
+		tx_id, from_idx, effective_from_eth_addr, effective_from_bjj, to_idx, to_eth_addr, to_bjj, effective_to_eth_addr, effective_to_bjj,
+		token_id, amount, amount_f, fee, nonce, state, info, signature, "timestamp", batch_num,
+		rq_from_idx,rq_to_idx,rq_to_eth_addr,rq_to_bjj,rq_token_id,rq_amount,rq_fee,rq_nonce,tx_type,client_ip,external_delete,rq_offset,atomic_group_id
+	) VALUES (
+		decode('023A0D72BEB1095C28A7130D896F484CC9D465C1C95F1617C0A7B2094E3E1F11FF', 'hex'),
+		789,
+		decode('FF', 'hex'), -- Note that this field will be replaced by trigger with account table values
+		decode('FF', 'hex'), -- Note that this field will be replaced by trigger with account table values
+		1,
+		decode('1224456678907543564567567567567657567567', 'hex'),
+		decode('1224456678907543564567567567567657567567000000000000000000000000', 'hex'),
+		decode('1224456678907543564567567567567657567567', 'hex'),
+		decode('1224456678907543564567567567567657567567000000000000000000000000', 'hex'),
+		2,
+		5,
+		5,
+		227,
+		3,
+		'pend',
+		'Exits with amount 0 have no sense, not accepting to prevent unintended transactions',
+		decode('9C6A159C57D7FC58E3E5D3510FBC64EAC9C0D56A1B3144D94D6BBA4C23B9402CEE57D0CFF4A3BE135CBD2393AB8FD2A1840A62281B1721801DBF708D27F1DF00', 'hex'),
+		'2021-05-06 15:02:47.616',
+		32,
+		765,
+		567,
+		decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex'),
+		decode('FDDACE21457376B0952CCD19CE66B854FDD7C6E45905B0A0A75747C87D41719A', 'hex'),
+		5,
+		345345345,
+		33,
+		4,
+		'Exit',
+		'93.176.174.84',
+		true,
+		1,
+		decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex')
+	);`
+	_, err := db.Exec(queryInsertBlock +
+		queryInsertToken +
+		queryInsertBatch +
+		queryInsertAccount +
+		queryInsertTxPool,
+	)
+	return err
+}
+
+func (m migrationTest0007) RunAssertsAfterMigrationUp(t *testing.T, db *sqlx.DB) {
+	// check that the tx_pool inserted in previous step is persisted
+	// with same content, except item_id is added
+	const queryGetTxPool = `SELECT COUNT(*) FROM tx_pool WHERE
+		tx_id = decode('023A0D72BEB1095C28A7130D896F484CC9D465C1C95F1617C0A7B2094E3E1F11FF', 'hex') AND
+		from_idx = 789 AND
+		effective_from_eth_addr = decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex') AND
+		effective_from_bjj = decode('FDDACE21457376B0952CCD19CE66B854FDD7C6E45905B0A0A75747C87D41719A', 'hex') AND
+		to_idx = 1 AND
+		to_eth_addr = decode('1224456678907543564567567567567657567567', 'hex') AND
+		to_bjj = decode('1224456678907543564567567567567657567567000000000000000000000000', 'hex') AND
+		effective_to_eth_addr = decode('1224456678907543564567567567567657567567', 'hex') AND
+		effective_to_bjj = decode('1224456678907543564567567567567657567567000000000000000000000000', 'hex') AND
+		token_id = 2 AND
+		amount = 5 AND
+		amount_f = 5 AND
+		fee = 227 AND
+		nonce = 3 AND
+		state = 'pend' AND
+		info = 'Exits with amount 0 have no sense, not accepting to prevent unintended transactions' AND
+		signature = decode('9C6A159C57D7FC58E3E5D3510FBC64EAC9C0D56A1B3144D94D6BBA4C23B9402CEE57D0CFF4A3BE135CBD2393AB8FD2A1840A62281B1721801DBF708D27F1DF00', 'hex') AND
+		"timestamp" = '2021-05-06 15:02:47.616' AND
+		batch_num = 32 AND
+		rq_from_idx = 765 AND
+		rq_to_idx = 567 AND
+		rq_to_eth_addr = decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex') AND
+		rq_to_bjj = decode('FDDACE21457376B0952CCD19CE66B854FDD7C6E45905B0A0A75747C87D41719A', 'hex') AND
+		rq_token_id = 5 AND
+		rq_amount = 345345345 AND
+		rq_fee = 33 AND
+		rq_nonce = 4 AND
+		tx_type = 'Exit' AND
+		client_ip = '93.176.174.84' AND
+		external_delete = true AND
+		item_id = 1 AND -- Note that item_id is an autoincremental column, so this value is setted automaticallyAND
+		rq_offset = 1 AND
+		atomic_group_id = decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex') AND
+		max_num_batch IS NULL;`
+	row := db.QueryRow(queryGetTxPool)
+	var result int
+	assert.NoError(t, row.Scan(&result))
+	assert.Equal(t, 1, result)
+}
+
+func (m migrationTest0007) RunAssertsAfterMigrationDown(t *testing.T, db *sqlx.DB) {
+	// check that the tx_pool inserted in previous step is persisted with same content
+	const queryGetTxPool = `SELECT COUNT(*) FROM tx_pool WHERE
+		tx_id = decode('023A0D72BEB1095C28A7130D896F484CC9D465C1C95F1617C0A7B2094E3E1F11FF', 'hex') AND
+		from_idx = 789 AND
+		effective_from_eth_addr = decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex') AND
+		effective_from_bjj = decode('FDDACE21457376B0952CCD19CE66B854FDD7C6E45905B0A0A75747C87D41719A', 'hex') AND
+		to_idx = 1 AND
+		to_eth_addr = decode('1224456678907543564567567567567657567567', 'hex') AND
+		to_bjj = decode('1224456678907543564567567567567657567567000000000000000000000000', 'hex') AND
+		effective_to_eth_addr = decode('1224456678907543564567567567567657567567', 'hex') AND
+		effective_to_bjj = decode('1224456678907543564567567567567657567567000000000000000000000000', 'hex') AND
+		token_id = 2 AND
+		amount = 5 AND
+		amount_f = 5 AND
+		fee = 227 AND
+		nonce = 3 AND
+		state = 'pend' AND
+		info = 'Exits with amount 0 have no sense, not accepting to prevent unintended transactions' AND
+		signature = decode('9C6A159C57D7FC58E3E5D3510FBC64EAC9C0D56A1B3144D94D6BBA4C23B9402CEE57D0CFF4A3BE135CBD2393AB8FD2A1840A62281B1721801DBF708D27F1DF00', 'hex') AND
+		"timestamp" = '2021-05-06 15:02:47.616' AND
+		batch_num = 32 AND
+		rq_from_idx = 765 AND
+		rq_to_idx = 567 AND
+		rq_to_eth_addr = decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex') AND
+		rq_to_bjj = decode('FDDACE21457376B0952CCD19CE66B854FDD7C6E45905B0A0A75747C87D41719A', 'hex') AND
+		rq_token_id = 5 AND
+		rq_amount = 345345345 AND
+		rq_fee = 33 AND
+		rq_nonce = 4 AND
+		tx_type = 'Exit' AND
+		client_ip = '93.176.174.84' AND
+		item_id = 1 AND
+		external_delete = true AND
+		rq_offset = 1 AND
+		atomic_group_id = decode('A631BE6995643E6085330A31B9E1AF48DD5D6B7F', 'hex');`
+	row := db.QueryRow(queryGetTxPool)
+	var result int
+	assert.NoError(t, row.Scan(&result))
+	assert.Equal(t, 1, result)
+	// check that max_num_batch colum doesn't exist anymore
+	const queryCheckRqOffset = `SELECT COUNT(*) FROM tx_pool WHERE max_num_batch IS NULL;`
+	row = db.QueryRow(queryCheckRqOffset)
+	assert.Equal(t, `pq: column "max_num_batch" does not exist`, row.Scan(&result).Error())
+}
+
+func TestMigration0007(t *testing.T) {
+	runMigrationTest(t, 7, migrationTest0007{})
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->
Implements part of #926

### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Add `MaxNumBatch` field at `common.PoolL2Tx`, including (Un)Marshal for JSON
- Add sql migration to add `max_num_batch` column at `tx_pool` and updates methods that read/write from this table to use the new column
- Update swagger to reference the `maxNumBatch`, filter any value that is not 0 at the api until the feature is complete

### How to test?

<!-- What steps in order should someone run to test -->

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint
- [x] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

