### PR TITLE
Feature/txselector maxbatchnum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,6 @@ db/*.go                 @arnaubennassar
 db/historydb            @arnaubennassar
 db/migrations           @arnaubennassar
 db/l2db                 @arnaubennassar
+txselector/             @arnaubennassar
 etherscan/              @ARR552
 priceupdater/           @ARR552

--- a/db/l2db/l2db.go
+++ b/db/l2db/l2db.go
@@ -458,6 +458,8 @@ func (l2db *L2DB) Purge(currentBatchNum common.BatchNum) (err error) {
 			batch_num < $1 AND (state = $2 OR state = $3)
 		) OR (
 			state = $4 AND timestamp < $5
+		) OR (
+			max_num_batch < $1
 		);`,
 		currentBatchNum-l2db.safetyPeriod,
 		common.PoolL2TxStateForged,

--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -791,6 +791,7 @@ func (tp *TxProcessor) ProcessL2Tx(coordIdxsMap map[common.TokenID]common.Idx,
 		}
 		tp.zki.AmountF[tp.i] = big.NewInt(int64(amountF40))
 		tp.zki.NewAccount[tp.i] = big.NewInt(0)
+		tp.zki.MaxNumBatch[tp.i] = big.NewInt(tx.MaxNumBatch)
 
 		// Rq fields: set zki to link the requested tx
 		if tx.RqOffset != 0 {

--- a/txprocessor/txprocessor.go
+++ b/txprocessor/txprocessor.go
@@ -791,7 +791,7 @@ func (tp *TxProcessor) ProcessL2Tx(coordIdxsMap map[common.TokenID]common.Idx,
 		}
 		tp.zki.AmountF[tp.i] = big.NewInt(int64(amountF40))
 		tp.zki.NewAccount[tp.i] = big.NewInt(0)
-		tp.zki.MaxNumBatch[tp.i] = big.NewInt(tx.MaxNumBatch)
+		tp.zki.MaxNumBatch[tp.i] = big.NewInt(int64(tx.MaxNumBatch))
 
 		// Rq fields: set zki to link the requested tx
 		if tx.RqOffset != 0 {

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -441,6 +441,7 @@ func (txsel *TxSelector) processL2Txs(
 	// TODO: differentiate between nonSelectedL2Txs and unforjableL2Txs
 	// (right now all fall into nonSelectedL2Txs, which is safe but non optimal)
 	positionL1 := nAlreadyProcessedL1Txs
+	nextBatchNum := uint32(txsel.localAccountsDB.CurrentBatch()) + 1
 	// Iterate over l2Txs
 	// - check Nonces
 	// - check enough Balance for the Amount+Fee
@@ -472,8 +473,8 @@ func (txsel *TxSelector) processL2Txs(
 			break
 		}
 
-		// Check if MaxNumBatch is exceeded
-		if l2Txs[i].MaxNumBatch > int64(txsel.localAccountsDB.CurrentBatch())+1 {
+		// Reject tx if the batch that is being selected is greater than MaxNumBatch
+		if l2Txs[i].MaxNumBatch != 0 && nextBatchNum > l2Txs[i].MaxNumBatch {
 			const failingMsg = "MaxNumBatch exceeded"
 			// If tx is atomic, restart process without txs from the atomic group
 			if l2Txs[i].AtomicGroupID != common.EmptyAtomicGroupID {


### PR DESCRIPTION
### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Filter transactions when `MaxNumBatch > current batch num` at `txselector`
- Add zki signal for MaxNumBatch at `txprocessor`
- Purge transactions that became invalid due to `MaxNumBatch` at `db/l2db` (aka transaction pool)
- Added myself as owner for `txselector`

### How to test?

<!-- What steps in order should someone run to test -->

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

