### PR TITLE
Adds filter addresses to tokens endpoint

### DIFF
--- a/api/parsers/tokens.go
+++ b/api/parsers/tokens.go
@@ -60,12 +60,12 @@ func ParseTokensFilters(c *gin.Context) (historydb.GetTokensAPIRequest, error) {
 		symbols = strings.Split(tokensFilters.Symbols, "|")
 	}
 
-	var tokensAddress []ethCommon.Address
+	var tokenAddresses []ethCommon.Address
 	if tokensFilters.Addresses != "" {
 		addrs := strings.Split(tokensFilters.Addresses, "|")
 		for _, addr := range addrs {
 			address := ethCommon.HexToAddress(addr)
-			tokensAddress = append(tokensAddress, address)
+			tokenAddresses = append(tokenAddresses, address)
 		}
 	}
 
@@ -73,7 +73,7 @@ func ParseTokensFilters(c *gin.Context) (historydb.GetTokensAPIRequest, error) {
 		Ids:       tokensIDs,
 		Symbols:   symbols,
 		Name:      tokensFilters.Name,
-		Addresses: tokensAddress,
+		Addresses: tokenAddresses,
 		FromItem:  tokensFilters.FromItem,
 		Limit:     tokensFilters.Limit,
 		Order:     *tokensFilters.Order,

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1265,7 +1265,7 @@ paths:
           schema:
             type: string
             description: Pipeline "|" separated list of token identifiers
-            example: "2,44,689"
+            example: "2|44|689"
         - name: symbols
           in: query
           required: false
@@ -1273,7 +1273,7 @@ paths:
           schema:
             type: string
             description: Pipeline "|" separated list of token symbols.
-            example: "DAI,NEC,UMA"
+            example: "DAI|NEC|UMA"
         - name: name
           in: query
           required: false

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1264,7 +1264,7 @@ paths:
           description: Include only specific tokens by their Hermez identifiers.
           schema:
             type: string
-            description: Comma separated list of token identifiers
+            description: Pipeline "|" separated list of token identifiers
             example: "2,44,689"
         - name: symbols
           in: query
@@ -1272,7 +1272,7 @@ paths:
           description: Include only specific tokens by their symbols.
           schema:
             type: string
-            description: Comma separated list of token symbols.
+            description: Pipeline "|" separated list of token symbols.
             example: "DAI,NEC,UMA"
         - name: name
           in: query
@@ -1280,6 +1280,14 @@ paths:
           description: Include token(s) by their names (or a substring of the name).
           schema:
             type: string
+        - name: addresses
+          in: query
+          required: false
+          description: Include only specific tokens by their SC addresses.
+          schema:
+            type: string
+            description: Pipeline "|" separated list of token identifiers
+            example: "0xdac17f959d2ee523a2206207994597c13d831ec8|0xdac17f958e2ee523a2207206994597c12d831ec7|0xfac17f058d2ee527a2206206994597d13d831ec7"
         - name: fromItem
           in: query
           required: false

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -106,14 +106,30 @@ func TestGetTokens(t *testing.T) {
 	tokensFiltered = append(tokensFiltered, tc.tokens[8])
 	assertTokensAPIs(t, tokensFiltered, fetchedTokens)
 
+	// Get by addresses
+	fetchedTokens = []historydb.TokenWithUSD{}
+	limit = 7
+	stringAddresses := tc.tokens[1].EthAddr.String() + "|" + tc.tokens[3].EthAddr.String()
+	path = fmt.Sprintf(
+		"%s?addresses=%s&limit=%d",
+		endpoint, stringAddresses, limit,
+	)
+	err = doGoodReqPaginated(path, db.OrderAsc, &testTokensResponse{}, appendIter)
+	assert.NoError(t, err)
+	tokensFiltered = nil
+	tokensFiltered = append(tokensFiltered, tc.tokens[1])
+	tokensFiltered = append(tokensFiltered, tc.tokens[3])
+	assertTokensAPIs(t, tokensFiltered, fetchedTokens)
+
 	// Multiple filters
 	fetchedTokens = []historydb.TokenWithUSD{}
 	limit = 5
 	stringSymbols = tc.tokens[2].Symbol + "|" + tc.tokens[6].Symbol
 	stringIds = strconv.Itoa(int(tc.tokens[2].TokenID)) + "|" + strconv.Itoa(int(tc.tokens[5].TokenID)) + "|" + strconv.Itoa(int(tc.tokens[6].TokenID))
+	stringAddresses = tc.tokens[2].EthAddr.String() + "|" + tc.tokens[6].EthAddr.String() + "|" + tc.tokens[4].EthAddr.String()
 	path = fmt.Sprintf(
-		"%s?symbols=%s&ids=%s&limit=%d",
-		endpoint, stringSymbols, stringIds, limit,
+		"%s?symbols=%s&ids=%s&addresses=%s&limit=%d",
+		endpoint, stringSymbols, stringIds, stringAddresses, limit,
 	)
 	err = doGoodReqPaginated(path, db.OrderAsc, &testTokensResponse{}, appendIter)
 	assert.NoError(t, err)

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -63,7 +63,7 @@ func TestGetTokens(t *testing.T) {
 	// Get by tokenIds
 	fetchedTokens = []historydb.TokenWithUSD{}
 	limit = 7
-	stringIds := strconv.Itoa(int(tc.tokens[2].TokenID)) + "," + strconv.Itoa(int(tc.tokens[5].TokenID)) + "," + strconv.Itoa(int(tc.tokens[6].TokenID))
+	stringIds := strconv.Itoa(int(tc.tokens[2].TokenID)) + "|" + strconv.Itoa(int(tc.tokens[5].TokenID)) + "|" + strconv.Itoa(int(tc.tokens[6].TokenID))
 	path = fmt.Sprintf(
 		"%s?ids=%s&limit=%d",
 		endpoint, stringIds, limit,
@@ -79,7 +79,7 @@ func TestGetTokens(t *testing.T) {
 	// Get by symbols
 	fetchedTokens = []historydb.TokenWithUSD{}
 	limit = 7
-	stringSymbols := tc.tokens[1].Symbol + "," + tc.tokens[3].Symbol
+	stringSymbols := tc.tokens[1].Symbol + "|" + tc.tokens[3].Symbol
 	path = fmt.Sprintf(
 		"%s?symbols=%s&limit=%d",
 		endpoint, stringSymbols, limit,
@@ -109,8 +109,8 @@ func TestGetTokens(t *testing.T) {
 	// Multiple filters
 	fetchedTokens = []historydb.TokenWithUSD{}
 	limit = 5
-	stringSymbols = tc.tokens[2].Symbol + "," + tc.tokens[6].Symbol
-	stringIds = strconv.Itoa(int(tc.tokens[2].TokenID)) + "," + strconv.Itoa(int(tc.tokens[5].TokenID)) + "," + strconv.Itoa(int(tc.tokens[6].TokenID))
+	stringSymbols = tc.tokens[2].Symbol + "|" + tc.tokens[6].Symbol
+	stringIds = strconv.Itoa(int(tc.tokens[2].TokenID)) + "|" + strconv.Itoa(int(tc.tokens[5].TokenID)) + "|" + strconv.Itoa(int(tc.tokens[6].TokenID))
 	path = fmt.Sprintf(
 		"%s?symbols=%s&ids=%s&limit=%d",
 		endpoint, stringSymbols, stringIds, limit,

--- a/db/historydb/apiqueries.go
+++ b/db/historydb/apiqueries.go
@@ -371,9 +371,10 @@ func (hdb *HistoryDB) GetTokenAPI(tokenID common.TokenID) (*TokenWithUSD, error)
 
 // GetTokensAPIRequest is an API request struct for getting tokens
 type GetTokensAPIRequest struct {
-	Ids     []common.TokenID
-	Symbols []string
-	Name    string
+	Ids       []common.TokenID
+	Symbols   []string
+	Name      string
+	Addresses []ethCommon.Address
 
 	FromItem *uint
 	Limit    *uint
@@ -418,6 +419,16 @@ func (hdb *HistoryDB) GetTokensAPI(
 		}
 		queryStr += "name ~ ? "
 		args = append(args, request.Name)
+		nextIsAnd = true
+	}
+	if len(request.Addresses) > 0 {
+		if nextIsAnd {
+			queryStr += "AND "
+		} else {
+			queryStr += "WHERE "
+		}
+		queryStr += "eth_addr IN (?) "
+		args = append(args, request.Addresses)
 		nextIsAnd = true
 	}
 	if request.FromItem != nil {


### PR DESCRIPTION
Closes #921

### What does this PR does?

This PR allows filter tokens using addresses.
Also, in this PR has change comma by pipeline to be mor consistent with api rest.

Example:
http://<ip_addr>:<port>/v1/tokens?addresses=0xaded47e7b9275b17189f0b17bf6a4ce909047084|0xe07d8aa8b0d6b390fbde895271601bc27ba89fe2

### How to test?

Run the hermez node and call the api.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Include tests
- [X] Respect code style and lint
- [X] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

