### PR TITLE
Msg improved to be more clear

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -393,7 +393,7 @@ func canForge(auctionConstants *common.AuctionConstants, auctionVars *common.Auc
 	if slot.Forger == addr || (anyoneForge && mustForgeAtDeadline) {
 		return true
 	}
-	log.Debugw("canForge: can't forge", "slot.Forger", slot.Forger)
+	log.Debugw("canForge: can't forge because you didn't win the auction. Current slot auction winner: ", "slot.Forger", slot.Forger)
 	return false
 }
 


### PR DESCRIPTION
Closes #824

### What does this PR does?

This PR improve the message showed in the logs when hermez-node can't forge because it didn't win the auction.

### How to test?

Run the hermez node without bidding for the current slot and check the logs.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

