### PR TITLE
toEthAddr api filter removed

### DIFF
--- a/api/txspool.go
+++ b/api/txspool.go
@@ -171,9 +171,9 @@ func (a *API) verifyPoolL2Tx(tx common.PoolL2Tx) error {
 			Type: ErrInvalidSignatureType,
 		}
 	}
+	switch tx.Type {
 	// Check destination, note that transactions that are not transfers
 	// will always be valid in terms of destination (they use special ToIdx by protocol)
-	switch tx.Type {
 	case common.TxTypeTransfer:
 		// ToIdx exists and match token
 		toAccount, err := a.h.GetCommonAccountAPI(tx.ToIdx)
@@ -192,29 +192,8 @@ func (a *API) verifyPoolL2Tx(tx common.PoolL2Tx) error {
 				Type: ErrAccountTokenNotEqualTxTokenType,
 			}
 		}
-	case common.TxTypeTransferToEthAddr:
-		// ToEthAddr has account created with matching token ID or authorization
-		ok, err := a.h.CanSendToEthAddr(tx.ToEthAddr, tx.TokenID)
-		if err != nil {
-			return &apiError{
-				Err:  tracerr.Wrap(err),
-				Code: ErrCantSendToEthAddrCode,
-				Type: ErrCantSendToEthAddrType,
-			}
-		}
-		if !ok {
-			return &apiError{
-				Err: tracerr.Wrap(fmt.Errorf(
-					"destination eth addr (%v) has not a valid account created nor authorization",
-					tx.ToEthAddr)),
-				Code: ErrCantSendToEthAddrCode,
-				Type: ErrCantSendToEthAddrType,
-			}
-		}
-	}
 	// Extra sanity checks: those checks are valid as per the protocol, but are very likely to
 	// have unexpected side effects that could have a negative impact on users
-	switch tx.Type {
 	case common.TxTypeExit:
 		if tx.Amount.Cmp(big.NewInt(0)) <= 0 {
 			return &apiError{

--- a/db/historydb/apiqueries.go
+++ b/db/historydb/apiqueries.go
@@ -1163,29 +1163,6 @@ func (hdb *HistoryDB) GetCommonAccountAPI(idx common.Idx) (*common.Account, erro
 	}, nil
 }
 
-// CanSendToEthAddr returns true if it's possible to send a tx to an Eth addr
-// either because there is an idx associated to the Eth addr and token
-// or the cordinator has an authorization to create a valid account
-func (hdb *HistoryDB) CanSendToEthAddr(ethAddr ethCommon.Address, tokenID common.TokenID) (bool, error) {
-	cancel, err := hdb.apiConnCon.Acquire()
-	defer cancel()
-	if err != nil {
-		return false, tracerr.Wrap(err)
-	}
-	defer hdb.apiConnCon.Release()
-
-	row := hdb.dbRead.QueryRow(
-		`SELECT (
-			SELECT COUNT(*) > 0 FROM account WHERE eth_addr = $1 AND token_id = $2 LIMIT 1
-		) OR (
-			SELECT COUNT(*) > 0 FROM account_creation_auth WHERE eth_addr = $1 LIMIT 1
-		);`,
-		ethAddr, tokenID,
-	)
-	var ok bool
-	return ok, tracerr.Wrap(row.Scan(&ok))
-}
-
 // GetCoordinatorAPI returns a coordinator by its bidderAddr
 func (hdb *HistoryDB) GetCoordinatorAPI(bidderAddr ethCommon.Address) (*CoordinatorAPI, error) {
 	cancel, err := hdb.apiConnCon.Acquire()

--- a/db/historydb/historydb_test.go
+++ b/db/historydb/historydb_test.go
@@ -385,25 +385,6 @@ func TestAccounts(t *testing.T) {
 	fetchedAccBalances, err := historyDB.GetAllAccountUpdates()
 	require.NoError(t, err)
 	assert.Equal(t, accUpdates, fetchedAccBalances)
-
-	// Test if can send to EthAddr for created accounts
-	var ok bool
-	for _, acc := range fetchedAccs {
-		// can send to created accounts
-		ok, err = historyDBWithACC.CanSendToEthAddr(acc.EthAddr, acc.TokenID)
-		require.NoError(t, err)
-		assert.True(t, ok)
-
-		// cannot send to wrong tokenID
-		ok, err = historyDBWithACC.CanSendToEthAddr(acc.EthAddr, 0)
-		require.NoError(t, err)
-		assert.False(t, ok)
-
-		// cannot send to wrong ethAddr
-		ok, err = historyDBWithACC.CanSendToEthAddr(ethCommon.HexToAddress("0xE39fEc6224708f0772D2A74fd3f9055A90E00000"), acc.TokenID)
-		require.NoError(t, err)
-		assert.False(t, ok)
-	}
 }
 
 func TestTxs(t *testing.T) {


### PR DESCRIPTION
Closes #974

### What does this PR does?

This PR removes the api filter that was blocking toEthAddr tx if the account didn't exist. Now, the api will allow this kind of tx. The tx selector will show in the info field the reason why this tx can not be forged.

Batch forged: https://explorer.internaltestnet.hermez.io/batch/25371

### How to test?

Run the hermez node, send a toEthAddr tx and try to forge it in a batch.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [X] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

