### PR TITLE
Add maxNumBatch to API

### DIFF
--- a/api/atomicpool.go
+++ b/api/atomicpool.go
@@ -74,6 +74,7 @@ func (a *API) postAtomicPool(c *gin.Context) {
 		receivedAtomicGroup.Txs[i].RqNonce = requestedTx.Nonce
 		receivedAtomicGroup.Txs[i].ClientIP = clientIP
 		receivedAtomicGroup.Txs[i].AtomicGroupID = receivedAtomicGroup.ID
+		receivedAtomicGroup.Txs[i].Info = ""
 
 		// Validate transaction
 		if err := a.verifyPoolL2Tx(receivedAtomicGroup.Txs[i]); err != nil {

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1664,6 +1664,12 @@ components:
             - $ref: '#/components/schemas/BJJSignature'
             - description: Signature of the transaction. More info [here](https://idocs.hermez.io/#/spec/zkrollup/README?id=l2a-idl2).
             - example: "72024a43f546b0e1d9d5d7c4c30c259102a9726363adcc4ec7b6aea686bcb5116f485c5542d27c4092ae0ceaf38e3bb44417639bd2070a58ba1aa1aab9d92c03"
+        errorType:
+          type: string
+          nullable: true
+        errorCode:
+          type: integer
+          nullable: true
         timestamp:
           type: string
           description: Moment in which the transaction was added to the pool.

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1601,6 +1601,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/TransactionId'
+        itemId:
+          $ref: '#/components/schemas/ItemId'
         type:
           $ref: '#/components/schemas/TransactionTypeL2'
         fromAccountIndex:
@@ -1647,6 +1649,10 @@ components:
           $ref: '#/components/schemas/Nonce'
         state:
           $ref: '#/components/schemas/PoolL2TransactionState'
+        maxNumBatch:
+          type: integer
+          description: Batch until the transaction can be forged. If the transaction isn't forged before batch `maxNumBatch`, it will never be forged. 0 means no restriction.
+          example: 0 
         info:
           type: string
           description: "Info contains information about the status & State of the transaction. As for example, if the Tx has not been selected in the last batch due not enough Balance at the Sender account, this reason would appear at this parameter."
@@ -1662,6 +1668,56 @@ components:
           type: string
           description: Moment in which the transaction was added to the pool.
           format: date-time
+        requestFromAccountIndex:
+          type: string
+          description: >-
+            Identifier of an account. It references the position where the account is inside the state Merkle tree.
+            The identifier is built using: `hez:` + `token symbol:` + `index`
+          nullable: true
+          example: null
+        requestToAccountIndex:
+          type: string
+          description: >-
+            Identifier of an account. It references the position where the account is inside the state Merkle tree.
+            The identifier is built using: `hez:` + `token symbol:` + `index`
+          nullable: true
+          example: null
+        requestToHezEthereumAddress:
+          type: string
+          description: "Address of an Etherum account linked to the Hermez Network."
+          pattern: "^hez:0x[a-fA-F0-9]{40}$"
+          nullable: true
+          example: null
+        requestToBJJ:
+          type: string
+          description: "BabyJubJub compressed public key, encoded as base64 URL (RFC 4648), which result in 33 bytes. The padding byte is replaced by a sum of the encoded bytes."
+          pattern: "^hez:[A-Za-z0-9_-]{44}$"
+          nullable: true
+          example: null
+        requestTokenId:
+          type: integer
+          description: References the `tokenId` of the requested transaction.
+          example: null
+          nullable: true
+        requestAmount:
+          type: string
+          description: BigInt is an integer encoded as a string for numbers that are very large.
+          nullable: true
+          example: null
+        requestFee:
+          type: integer
+          description: Index of the fee type to select, more info [here](https://idocs.hermez.io/#/spec/zkrollup/fee-table?id=transaction-fee-table).
+          minimum: 0
+          maximum: 256
+          nullable: true
+          example: null
+        requestNonce:
+          type: integer
+          description: Number that can only be used once per account. Increments by one with each transaction.
+          minimum: 0
+          maximum: 1.84467440737096e+19
+          nullable: true
+          example: null
         token:
           $ref: '#/components/schemas/Token'
       example:
@@ -1672,12 +1728,21 @@ components:
         fromHezEthereumAddress: hez:0x00000000000000000000000000000000004Ab84F
         id: '0x020000000001000000000006'
         nonce: 6
+        requestAmount: 
+        requestFee: 0
+        requestFromAccountIndex: 
+        requestNonce: 0
+        requestToAccountIndex: 
+        requestToBJJ: 
+        requestToHezEthereumAddress: 
+        requestTokenId: 
         signature: 5ee9c7b5baa243ba282d18596a55cc357b01513eaed75165365f802102cce4a7a1dd35e3ab31cf9039e2b8a9f570d935115be9379a3dd47813dfc014031ab201
         state: pend
         timestamp: '2020-11-17T13:58:54.422232Z'
         toAccountIndex: hez:SCC:257
         toBJJ: hez:r_trOasVEk0zNaalOoS9aLedu6mO7jI5XTIPu_zGXoyn
         toHezEthereumAddress: hez:0x00000000000000000000000000000000004Ab84F
+        maxNumBatch: 0
         token:
           USD: 23.74
           decimals: 7
@@ -1705,7 +1770,16 @@ components:
         - info
         - signature
         - timestamp
+        - requestFromAccountIndex
+        - requestToAccountIndex
+        - requestToHezEthereumAddress
+        - requestToBJJ
+        - requestTokenId
+        - requestAmount
+        - requestFee
+        - requestNonce
         - token
+      additionalProperties: false
     PoolL2Transactions:
       type: object
       properties:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1460,7 +1460,7 @@ components:
           nullable: true
         toHezEthereumAddress:
           type: string
-          description: "Address of an Etherum account linked to the Hermez Network. If this is provided, toAccountIndex and toBjj must be null."
+          description: "Address of an Ethereum account linked to the Hermez Network. If this is provided, toAccountIndex and toBjj must be null."
           pattern: "^hez:0x[a-fA-F0-9]{40}$"
           example: "hez:0xaa942cfcd25ad4d90a62358b0dd84f33b398262a"
           nullable: true
@@ -1609,7 +1609,7 @@ components:
           $ref: '#/components/schemas/AccountIndex'
         fromHezEthereumAddress:
           type: string
-          description: "Address of an Etherum account linked to the Hermez Network."
+          description: "Address of an Ethereum account linked to the Hermez Network."
           pattern: "^hez:0x[a-fA-F0-9]{40}$"
           example: "hez:0xaa942cfcd25ad4d90a62358b0dd84f33b398262a"
           nullable: true
@@ -1628,7 +1628,7 @@ components:
           nullable: true
         toHezEthereumAddress:
           type: string
-          description: "Address of an Etherum account linked to the Hermez Network."
+          description: "Address of an Ethereum account linked to the Hermez Network."
           pattern: "^hez:0x[a-fA-F0-9]{40}$"
           example: null
           nullable: true
@@ -1684,7 +1684,7 @@ components:
           example: null
         requestToHezEthereumAddress:
           type: string
-          description: "Address of an Etherum account linked to the Hermez Network."
+          description: "Address of an Ethereum account linked to the Hermez Network."
           pattern: "^hez:0x[a-fA-F0-9]{40}$"
           nullable: true
           example: null
@@ -1706,7 +1706,7 @@ components:
           example: null
         requestFee:
           type: integer
-          description: Index of the fee type to select, more info [here](https://idocs.hermez.io/#/spec/zkrollup/fee-table?id=transaction-fee-table).
+          description: Index of the fee type to select, more info [here](https://docs.hermez.io/#/developers/protocol/hermez-protocol/circuits/circuits?id=rq-tx-verifier).
           minimum: 0
           maximum: 256
           nullable: true
@@ -1808,12 +1808,12 @@ components:
           $ref: '#/components/schemas/TransactionId'
     EthereumAddress:
       type: string
-      description: "Address of an Etherum account."
+      description: "Address of an Ethereum account."
       pattern: "^0x[a-fA-F0-9]{40}$"
       example: "0xaa942cfcd25ad4d90a62358b0dd84f33b398262a" 
     HezEthereumAddress:
       type: string
-      description: "Address of an Etherum account linked to the Hermez Network."
+      description: "Address of an Ethereum account linked to the Hermez Network."
       pattern: "^hez:0x[a-fA-F0-9]{40}$"
       example: "hez:0xaa942cfcd25ad4d90a62358b0dd84f33b398262a" 
     BJJ:
@@ -1977,7 +1977,7 @@ components:
           nullable: true
         fromHezEthereumAddress:
           type: string
-          description: "Address of an Etherum account linked to the Hermez Network."
+          description: "Address of an Ethereum account linked to the Hermez Network."
           pattern: "^hez:0x[a-fA-F0-9]{40}$"
           example: "hez:0xaa942cfcd25ad4d90a62358b0dd84f33b398262a"
           nullable: true
@@ -1993,7 +1993,7 @@ components:
             - example: "hez:DAI:672"
         toHezEthereumAddress:
           type: string
-          description: "Address of an Etherum account linked to the Hermez Network."
+          description: "Address of an Ethereum account linked to the Hermez Network."
           pattern: "^hez:0x[a-fA-F0-9]{40}$"
           example: "hez:0xaa942cfcd25ad4d90a62358b0dd84f33b398262a"
           nullable: true
@@ -2902,7 +2902,7 @@ components:
           items: 
             allOf:
                 - $ref: '#/components/schemas/Slot'
-                - description: Last synchronized Etherum block.
+                - description: Last synchronized Ethereum block.
         pendingItems:
           $ref: '#/components/schemas/PendingItems'
       additionalProperties: false
@@ -3001,12 +3001,12 @@ components:
         lastEthereumBlock:
           allOf:
             - $ref: '#/components/schemas/EthBlockNum'
-            - description: Current Etherum block. Note that this is the actual last block of Ethereum, not the last synchronized block by the node.
+            - description: Current Ethereum block. Note that this is the actual last block of Ethereum, not the last synchronized block by the node.
             - example: 3457437
         lastSynchedBlock:
           allOf:
             - $ref: '#/components/schemas/EthBlockNum'
-            - description: Last synchronized Etherum block. Compare with lastEthereumBlock to check the synchronization status of the node.
+            - description: Last synchronized Ethereum block. Compare with lastEthereumBlock to check the synchronization status of the node.
             - example: 3457437
         lastBatch:
           $ref: '#/components/schemas/Batch'

--- a/api/txspool.go
+++ b/api/txspool.go
@@ -43,6 +43,7 @@ func (a *API) postPoolTx(c *gin.Context) {
 		return
 	}
 	receivedTx.ClientIP = c.ClientIP()
+	receivedTx.Info = ""
 	// Insert to DB
 	if err := a.l2.AddTxAPI(&receivedTx); err != nil {
 		if strings.Contains(err.Error(), "< minFeeUSD") {

--- a/common/pooll2tx.go
+++ b/common/pooll2tx.go
@@ -519,6 +519,7 @@ func (tx *PoolL2Tx) UnmarshalJSON(data []byte) error {
 		Signature   babyjub.SignatureComp `json:"signature" binding:"required"`
 		State       string                `json:"state"`
 		RqOffset    uint8                 `json:"requestOffset"`
+		Info        *string               `json:"info"`
 	}{}
 	if err := json.Unmarshal(data, &receivedJSON); err != nil {
 		return err
@@ -530,6 +531,10 @@ func (tx *PoolL2Tx) UnmarshalJSON(data []byte) error {
 		if !state.IsValid() {
 			return fmt.Errorf("Invalid state: %s", state)
 		}
+	}
+	var info string
+	if receivedJSON.Info != nil {
+		info = *receivedJSON.Info
 	}
 	// Set values to destination struct
 	*tx = PoolL2Tx{
@@ -548,6 +553,7 @@ func (tx *PoolL2Tx) UnmarshalJSON(data []byte) error {
 		State:       state,
 		TokenSymbol: receivedJSON.FromIdx.TokenSymbol,
 		RqOffset:    receivedJSON.RqOffset,
+		Info:        info,
 	}
 	return nil
 }

--- a/db/l2db/views.go
+++ b/db/l2db/views.go
@@ -24,6 +24,7 @@ type PoolTxAPI struct {
 	Fee                  common.FeeSelector    `meddler:"fee"`
 	Nonce                common.Nonce          `meddler:"nonce"`
 	State                common.PoolL2TxState  `meddler:"state"`
+	MaxNumBatch          uint32                `meddler:"max_num_batch,zeroisnull"`
 	Info                 *string               `meddler:"info"`
 	ErrorCode            *int                  `meddler:"error_code"`
 	ErrorType            *string               `meddler:"error_type"`
@@ -69,6 +70,7 @@ func (tx PoolTxAPI) MarshalJSON() ([]byte, error) {
 		"fee":                         tx.Fee,
 		"nonce":                       tx.Nonce,
 		"state":                       tx.State,
+		"maxNumBatch":                 tx.MaxNumBatch,
 		"info":                        tx.Info,
 		"errorCode":                   tx.ErrorCode,
 		"errorType":                   tx.ErrorType,

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -436,7 +436,7 @@ func (txsel *TxSelector) processL2Txs(
 	failedAG failedAtomicGroup,
 	err error,
 ) {
-	const failedGroupErrMsg = "Failed forging atomic tx from Group %d." +
+	const failedGroupErrMsg = "Failed forging atomic tx from Group %s." +
 		" Restarting selection process without txs from this group"
 	// TODO: differentiate between nonSelectedL2Txs and unforjableL2Txs
 	// (right now all fall into nonSelectedL2Txs, which is safe but non optimal)
@@ -465,7 +465,7 @@ func (txsel *TxSelector) processL2Txs(
 				}
 				return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 					failedGroupErrMsg,
-					l2Txs[i].AtomicGroupID,
+					l2Txs[i].AtomicGroupID.String(),
 				))
 			}
 			// no more available slots for L2Txs, so mark this tx
@@ -495,7 +495,7 @@ func (txsel *TxSelector) processL2Txs(
 				}
 				return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 					failedGroupErrMsg,
-					l2Txs[i].AtomicGroupID,
+					l2Txs[i].AtomicGroupID.String(),
 				))
 			}
 			l2Txs[i].Info = obj.Message
@@ -522,7 +522,7 @@ func (txsel *TxSelector) processL2Txs(
 				}
 				return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 					failedGroupErrMsg,
-					l2Txs[i].AtomicGroupID,
+					l2Txs[i].AtomicGroupID.String(),
 				))
 			}
 			l2Txs[i].Info = obj.Message
@@ -558,7 +558,7 @@ func (txsel *TxSelector) processL2Txs(
 				}
 				return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 					failedGroupErrMsg,
-					l2Txs[i].AtomicGroupID,
+					l2Txs[i].AtomicGroupID.String(),
 				))
 			}
 			// not valid Amount with current Balance. Discard L2Tx,
@@ -587,7 +587,7 @@ func (txsel *TxSelector) processL2Txs(
 				}
 				return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 					failedGroupErrMsg,
-					l2Txs[i].AtomicGroupID,
+					l2Txs[i].AtomicGroupID.String(),
 				))
 			}
 			// not valid Nonce at tx. Discard L2Tx, and update Info
@@ -632,7 +632,7 @@ func (txsel *TxSelector) processL2Txs(
 					}
 					return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 						failedGroupErrMsg,
-						l2Txs[i].AtomicGroupID,
+						l2Txs[i].AtomicGroupID.String(),
 					))
 				}
 				// discard L2Tx, and update Info parameter of
@@ -689,7 +689,7 @@ func (txsel *TxSelector) processL2Txs(
 					}
 					return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 						failedGroupErrMsg,
-						l2Txs[i].AtomicGroupID,
+						l2Txs[i].AtomicGroupID.String(),
 					))
 				}
 				// Discard L2Tx, and update Info parameter of
@@ -741,7 +741,7 @@ func (txsel *TxSelector) processL2Txs(
 					}
 					return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 						failedGroupErrMsg,
-						l2Txs[i].AtomicGroupID,
+						l2Txs[i].AtomicGroupID.String(),
 					))
 				}
 				nonSelectedL2Txs = append(nonSelectedL2Txs, l2Txs[i])
@@ -767,7 +767,7 @@ func (txsel *TxSelector) processL2Txs(
 					}
 					return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 						failedGroupErrMsg,
-						l2Txs[i].AtomicGroupID,
+						l2Txs[i].AtomicGroupID.String(),
 					))
 				}
 				// Discard L2Tx, and update Info parameter of
@@ -817,7 +817,7 @@ func (txsel *TxSelector) processL2Txs(
 				}
 				return nil, nil, nil, nil, nil, failedAG, tracerr.Wrap(fmt.Errorf(
 					failedGroupErrMsg,
-					l2Txs[i].AtomicGroupID,
+					l2Txs[i].AtomicGroupID.String(),
 				))
 			}
 			// Discard L2Tx, and update Info parameter of the tx,


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #1001 
Closes #1002 
Closes #1003

### What does this PR does?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
- Update swagger spec to be more strict when testing `GET /transactions-pool` and `GET /atomic-pool`
- Include `maxNumBatch` as part of `GET /transactions-pool` and `GET /atomic-pool` response
- Marshal/Unmarsal `common.PoolL2Tx.Info`, and set the field as empty string on API to prevent users from sending transactions with info
- Log `AtomicGroupID` as string instead of byte array in `txselector`

### How to test?

<!-- What steps in order should someone run to test -->

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint
- [x] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

