### PR TITLE
Use SuggestGasTipCap to get GasPrice

### DIFF
--- a/eth/ethereum.go
+++ b/eth/ethereum.go
@@ -144,7 +144,7 @@ func (c *EthereumClient) EthSuggestGasPrice(ctx context.Context) (gasPrice *big.
 	}
 	baseFee := head.BaseFee
 	gasPrice = new(big.Int).Add(baseFee, tip)
-	log.Debugw("Suggested Gas Price:", "tip: ", tip, ", baseFee: ", baseFee, ", gasPrice: ", gasPrice)
+	log.Debugw("Suggested Gas Price:", "tip", tip, "baseFee", baseFee, "gasPrice", gasPrice)
 	return
 }
 

--- a/eth/ethereum.go
+++ b/eth/ethereum.go
@@ -9,15 +9,14 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethKeystore "github.com/ethereum/go-ethereum/accounts/keystore"
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/hermeznetwork/hermez-node/common"
 	"github.com/hermeznetwork/hermez-node/eth/contracts/tokenhez"
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/tracerr"
-
-	ethKeystore "github.com/ethereum/go-ethereum/accounts/keystore"
-	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
 // ERC20Consts are the constants defined in a particular ERC20 Token instance

--- a/eth/ethereum.go
+++ b/eth/ethereum.go
@@ -129,7 +129,20 @@ func (c *EthereumClient) EthAddress() (*ethCommon.Address, error) {
 
 // EthSuggestGasPrice retrieves the currently suggested gas price to allow a
 // timely execution of a transaction.
-func (c *EthereumClient) EthSuggestGasPrice(ctx context.Context) (*big.Int, error) {
+func (c *EthereumClient) EthSuggestGasPrice(ctx context.Context) (gasPrice *big.Int, err error) {
+	var head *types.Header
+	head, err =  c.client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		err = fmt.Errorf("[EthSuggestGasPrice]. Error getting head: %s", err.Error())
+		return
+	}
+	var tip *big.Int
+	tip, err = c.client.SuggestGasTipCap(ctx)
+	if err != nil {
+		err = fmt.Errorf("[EthSuggestGasPrice]. Error getting tip: %s\n", err.Error())
+		return
+	}
+	gasPrice = new(big.Int).Add(head.BaseFee, tip)
 	return c.client.SuggestGasTipCap(ctx)
 }
 

--- a/eth/ethereum.go
+++ b/eth/ethereum.go
@@ -9,14 +9,15 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	ethKeystore "github.com/ethereum/go-ethereum/accounts/keystore"
-	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/hermeznetwork/hermez-node/common"
-	tokenhez "github.com/hermeznetwork/hermez-node/eth/contracts/tokenhez"
+	"github.com/hermeznetwork/hermez-node/eth/contracts/tokenhez"
 	"github.com/hermeznetwork/hermez-node/log"
 	"github.com/hermeznetwork/tracerr"
+
+	ethKeystore "github.com/ethereum/go-ethereum/accounts/keystore"
+	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
 // ERC20Consts are the constants defined in a particular ERC20 Token instance
@@ -48,7 +49,7 @@ var (
 	// ErrAccountNil is used when the calls can not be made because the account is nil
 	ErrAccountNil = fmt.Errorf("Authorized calls can't be made when the account is nil")
 	// ErrBlockHashMismatchEvent is used when there's a block hash mismatch
-	// beetween different events of the same block
+	// between different events of the same block
 	ErrBlockHashMismatchEvent = fmt.Errorf("block hash mismatch in event log")
 )
 
@@ -131,7 +132,7 @@ func (c *EthereumClient) EthAddress() (*ethCommon.Address, error) {
 // timely execution of a transaction.
 func (c *EthereumClient) EthSuggestGasPrice(ctx context.Context) (gasPrice *big.Int, err error) {
 	var head *types.Header
-	head, err =  c.client.HeaderByNumber(ctx, nil)
+	head, err = c.client.HeaderByNumber(ctx, nil)
 	if err != nil {
 		err = fmt.Errorf("[EthSuggestGasPrice]. Error getting head: %s", err.Error())
 		return
@@ -139,10 +140,12 @@ func (c *EthereumClient) EthSuggestGasPrice(ctx context.Context) (gasPrice *big.
 	var tip *big.Int
 	tip, err = c.client.SuggestGasTipCap(ctx)
 	if err != nil {
-		err = fmt.Errorf("[EthSuggestGasPrice]. Error getting tip: %s\n", err.Error())
+		err = fmt.Errorf("[EthSuggestGasPrice]. Error getting tip: %s", err.Error())
 		return
 	}
-	gasPrice = new(big.Int).Add(head.BaseFee, tip)
+	baseFee := head.BaseFee
+	gasPrice = new(big.Int).Add(baseFee, tip)
+	log.Debugw("Suggested Gas Price:", "tip: ", tip, ", baseFee: ", baseFee, ", gasPrice: ", gasPrice)
 	return
 }
 

--- a/eth/ethereum.go
+++ b/eth/ethereum.go
@@ -130,7 +130,7 @@ func (c *EthereumClient) EthAddress() (*ethCommon.Address, error) {
 // EthSuggestGasPrice retrieves the currently suggested gas price to allow a
 // timely execution of a transaction.
 func (c *EthereumClient) EthSuggestGasPrice(ctx context.Context) (*big.Int, error) {
-	return c.client.SuggestGasPrice(ctx)
+	return c.client.SuggestGasTipCap(ctx)
 }
 
 // EthKeyStore returns the keystore in the EthereumClient

--- a/eth/ethereum.go
+++ b/eth/ethereum.go
@@ -143,7 +143,7 @@ func (c *EthereumClient) EthSuggestGasPrice(ctx context.Context) (gasPrice *big.
 		return
 	}
 	gasPrice = new(big.Int).Add(head.BaseFee, tip)
-	return c.client.SuggestGasTipCap(ctx)
+	return
 }
 
 // EthKeyStore returns the keystore in the EthereumClient


### PR DESCRIPTION
### What does this PR does?

Uses SuggestGasTipCap to retrieves the currently suggested 1559 priority fee to allow a timely execution of a transaction.

### How to test?

`make test`

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

