### PR TITLE
gasPrice must be in wei

### DIFF
--- a/coordinator/txmanager.go
+++ b/coordinator/txmanager.go
@@ -164,9 +164,6 @@ func (t *TxManager) NewAuth(ctx context.Context, batchInfo *BatchInfo) (*bind.Tr
 		eGasPrice = minGasPriceBig
 	}
 
-	// Convert the eGasPrice from gwei , such as 20 to wei
-	eGasPrice = eGasPrice.Mul(eGasPrice, big.NewInt(params.GWei))
-
 	// If the gas price that comes from Etherscan is higher, uses Etherscan's price
 	// It's better pay few more gas than the transaction get stucked at ethereum node pool
 	log.Debugw("TxManager gas prices - ", "Ethereum node gasPrice:", gasPrice, " Etherscan gasPrice:", eGasPrice)


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

During latest release creation this change was incorrectly restored.

### What does this PR does?

Fix the bug that calculates the gasPrice in gwei
