### PR TITLE
atomic: fix error message at invalid group

### DIFF
--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -1249,7 +1249,7 @@ func setInfoForFailedAtomicTx(
 		}
 		return obj
 	}
-	obj := common.TxSelectorError{
+	return common.TxSelectorError{
 		Message: fmt.Sprintf("unselectable atomic group"+" %s, tx %s failed due to: %s",
 			failedAtomicGroupID,
 			failedTxID,
@@ -1258,5 +1258,4 @@ func setInfoForFailedAtomicTx(
 		Code: ErrInvalidAtomicGroupCode,
 		Type: ErrInvalidAtomicGroupType,
 	}
-	return obj
 }

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -1243,15 +1243,20 @@ func setInfoForFailedAtomicTx(
 ) common.TxSelectorError {
 	if isOriginOfFailure {
 		obj := common.TxSelectorError{
-			Message: fmt.Sprintf("unselectable atomic group"+" %s, tx %s failed due to: %s",
-				failedAtomicGroupID,
-				failedTxID,
-				failMessage.Message,
-			),
-			Code: failMessage.Code,
-			Type: failMessage.Type,
+			Message: failMessage.Message,
+			Code:    failMessage.Code,
+			Type:    failMessage.Type,
 		}
 		return obj
 	}
-	return common.TxSelectorError{}
+	obj := common.TxSelectorError{
+		Message: fmt.Sprintf("unselectable atomic group"+" %s, tx %s failed due to: %s",
+			failedAtomicGroupID,
+			failedTxID,
+			failMessage.Message,
+		),
+		Code: ErrInvalidAtomicGroupCode,
+		Type: ErrInvalidAtomicGroupType,
+	}
+	return obj
 }

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -1367,7 +1367,6 @@ func TestFailingAtomicTx(t *testing.T) {
 	log.Debug("block:1 batch:4")
 	_, _, oL1UserTxs, oL1CoordTxs, oL2Txs, discardedL2Txs, err :=
 		txsel.GetL1L2TxSelection(tpc, nil, nil)
-	// log.Debugf("%+v\n", discardedL2Txs)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(oL1UserTxs))
 	assert.Equal(t, 0, len(oL1CoordTxs))

--- a/txselector/txselector_test.go
+++ b/txselector/txselector_test.go
@@ -1375,9 +1375,9 @@ func TestFailingAtomicTx(t *testing.T) {
 
 	for _, tx := range discardedL2Txs {
 		if tx1.TxID == tx.TxID {
-			assert.Equal(t, ErrNoCurrentNonceType, tx.ErrorType) // this should be error to tx1
+			assert.Equal(t, ErrNoCurrentNonceType, tx.ErrorType)
 		} else if tx2.TxID == tx.TxID {
-			assert.Equal(t, ErrInvalidAtomicGroupType, tx.ErrorType) // this should be error to tx1
+			assert.Equal(t, ErrInvalidAtomicGroupType, tx.ErrorType)
 		} else {
 			assert.Fail(t, "unexpected transaction")
 		}


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #1040
### What does this PR does?

Add properly message error to atomic group transactions.

### How to test?

<!-- What steps in order should someone run to test -->

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Include tests
- [X] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)


```
Starting test
    ✓ Init variables (4441ms)
    ✓ Check ETH L1 deposit (38350ms)
    ✓ Check ERC20 L1 deposit (44534ms)
    ✓ Check ETH L1 force exit (44260ms)
    ✓ Check ERC20 L1 force exit (48302ms)
    ✓ Check ETH withdrawal from firsts forceExits (16299ms)
    ✓ Check ERC20 withdrawal from firsts forceExits (12263ms)
    ✓ Check ETH N L1 force exits (38300ms)
    ✓ Check ETH withdrawal from previous N force exits (4107ms)
    ✓ Check single ETH L2 transfer (40267ms)
    ✓ Check single ERC20 L2 transfer (40212ms)
    ✓ Transfer ETH to a non-existent Bjj address (50324ms)
    ✓ Transfer ERC20 to a non-existent Bjj address (40313ms)
    ✓ Transfer ETH to hermez ethereum address (40327ms)
    ✓ Transfer ERC20 to hermez ethereum address (30195ms)
    ✓ Transfer ETH to non-existent ETH address (40334ms)
    ✓ Transfer ETH to hermez ethereum address from internal account (40239ms)
    ✓ Transfer ERC20 to hermez ethereum address from internal account (30208ms)
    ✓ Check multiple L2 ETH transfer in same batch (50779ms)
    ✓ Check multiple L2 ETH transfer in different batches (171580ms)
    ✓ Atomic txs (50478ms)


  21 passing (15m)
```