### PR TITLE
Improvement/http server configuration

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -10,6 +10,8 @@ UpdateMetricsInterval = HEZNODE_API_UPDATEMETRICSINTERVAL
 UpdateRecommendedFeeInterval = HEZNODE_API_UPDATERECOMMENDEDFEEINTERVAL
 MaxSQLConnections = HEZNODE_API_MAXSQLCONNECTIONS
 SQLConnectionTimeout = HEZNODE_API_SQLCONNECTIONTIMEOUT
+ReadTimeout = HEZNODE_API_READTIMEOUT
+WriteTimeout = HEZNODE_API_WRITETIMEOUT
 
 [Debug]
 APIAddress = HEZNODE_DEBUG_APIADDRESS
@@ -135,6 +137,8 @@ StaticValue = HEZNODE_RECOMMENDEDFEEPOLICY_STATICVALUE
 |API|UpdateRecommendedFeeInterval|HEZNODE_API_UPDATERECOMMENDEDFEEINTERVAL|Optional|"10s"|Interval between updates of the recommended fees
 |API|MaxSQLConnections|HEZNODE_API_MAXSQLCONNECTIONS|Optional|100|Maximum concurrent connections allowed between API and SQL
 |API|SQLConnectionTimeout|HEZNODE_API_SQLCONNECTIONTIMEOUT|Optional|"2s"|Maximum amount of time that an API request can wait to establish a SQL connection
+|API|ReadTimeout|HEZNODE_API_READTIMEOUT|Optional|"30s"|ReadTimeout is the maximum duration for reading the entire request, including the body.
+|API|WriteTimeout|HEZNODE_API_WRITETIMEOUT|Optional|"30s"|WriteTimeout is the maximum duration before timing out writes of the response.
 |Debug|APIAddress|HEZNODE_DEBUG_APIADDRESS|Optional|"0.0.0.0:12345"|If it is set, the debug api will listen in this address and port
 |Debug|MeddlerLogs|HEZNODE_DEBUG_MEDDLERLOGS|Optional|true|Enables meddler debug mode, where unused columns and struct fields will be logged
 |Debug|GinDebugMode|HEZNODE_DEBUG_GINDEBUGMODE|Optional|false|Sets the web framework Gin-Gonic to run in debug mode

--- a/config/config.go
+++ b/config/config.go
@@ -319,44 +319,40 @@ type Node struct {
 		// Rollup is the address of the Hermez.sol smart contract
 		Rollup ethCommon.Address `validate:"required" env:"HEZNODE_SMARTCONTRACTS_ROLLUP"`
 	} `validate:"required"`
-	// API specifies the configuration parameters of the API
-	API struct {
-		// Address where the API will listen if set
-		Address string `env:"HEZNODE_API_ADDRESS"`
-		// Explorer enables the Explorer API endpoints
-		Explorer bool `env:"HEZNODE_API_EXPLORER"`
-		// UpdateMetricsInterval is the interval between updates of the
-		// API metrics
-		UpdateMetricsInterval Duration `validate:"required" env:"HEZNODE_API_UPDATEMETRICSINTERVAL"`
-		// UpdateRecommendedFeeInterval is the interval between updates of the
-		// recommended fees
-		UpdateRecommendedFeeInterval Duration `validate:"required" env:"HEZNODE_API_UPDATERECOMMENDEDFEEINTERVAL"`
-		// Maximum concurrent connections allowed between API and SQL
-		MaxSQLConnections int `validate:"required,gte=1" env:"HEZNODE_API_MAXSQLCONNECTIONS"`
-		// SQLConnectionTimeout is the maximum amount of time that an API request
-		// can wait to establish a SQL connection
-		SQLConnectionTimeout Duration `env:"HEZNODE_API_SQLCONNECTIONTIMEOUT"`
-	} `validate:"required"`
+	API                  APIConfigParameters                  `validate:"required"`
 	RecommendedFeePolicy stateapiupdater.RecommendedFeePolicy `validate:"required"`
 	Debug                NodeDebug                            `validate:"required"`
 	Coordinator          Coordinator                          `validate:"-"`
 }
 
+// API specifies the configuration parameters of the API
+type APIConfigParameters struct {
+	// Address where the API will listen if set
+	Address string `env:"HEZNODE_API_ADDRESS"`
+	// Explorer enables the Explorer API endpoints
+	Explorer bool `env:"HEZNODE_API_EXPLORER"`
+	// ReadTimeout is the maximum duration for reading the entire
+	// request, including the body.
+	Readtimeout Duration `env:"HEZNODE_API_READTIMEOUT"`
+	// WriteTimeout is the maximum duration before timing out
+	// writes of the response.
+	Writetimeout Duration `env:"HEZNODE_API_WRITETIMEOUT"`
+	// Maximum concurrent connections allowed between API and SQL
+	MaxSQLConnections int `validate:"required,gte=1" env:"HEZNODE_API_MAXSQLCONNECTIONS"`
+	// SQLConnectionTimeout is the maximum amount of time that an API request
+	// can wait to establish a SQL connection
+	SQLConnectionTimeout Duration `env:"HEZNODE_API_SQLCONNECTIONTIMEOUT"`
+	// UpdateMetricsInterval is the interval between updates of the metrics
+	UpdateMetricsInterval Duration `validate:"required" env:"HEZNODE_API_UPDATEMETRICSINTERVAL"`
+	// UpdateRecommendedFeeInterval is the interval between updates of the recommended fees
+	UpdateRecommendedFeeInterval Duration `validate:"required" env:"HEZNODE_API_UPDATERECOMMENDEDFEEINTERVAL"`
+}
+
 // APIServer is the api server configuration parameters
 type APIServer struct {
 	// NodeAPI specifies the configuration parameters of the API
-	API struct {
-		// Address where the API will listen if set
-		Address string `validate:"required" env:"HEZNODE_API_ADDRESS"`
-		// Explorer enables the Explorer API endpoints
-		Explorer bool `env:"HEZNODE_API_EXPLORER"`
-		// Maximum concurrent connections allowed between API and SQL
-		MaxSQLConnections int `validate:"required,gte=1" env:"HEZNODE_API_MAXSQLCONNECTIONS"`
-		// SQLConnectionTimeout is the maximum amount of time that an API request
-		// can wait to establish a SQL connection
-		SQLConnectionTimeout Duration `env:"HEZNODE_API_SQLCONNECTIONTIMEOUT"`
-	} `validate:"required"`
-	PostgreSQL  PostgreSQL `validate:"required"`
+	API         APIConfigParameters `validate:"required"`
+	PostgreSQL  PostgreSQL          `validate:"required"`
 	Coordinator struct {
 		API struct {
 			// Coordinator enables the coordinator API endpoints

--- a/config/config.go
+++ b/config/config.go
@@ -325,7 +325,7 @@ type Node struct {
 	Coordinator          Coordinator                          `validate:"-"`
 }
 
-// API specifies the configuration parameters of the API
+// APIConfigParameters specifies the configuration parameters of the API
 type APIConfigParameters struct {
 	// Address where the API will listen if set
 	Address string `env:"HEZNODE_API_ADDRESS"`

--- a/config/default.go
+++ b/config/default.go
@@ -9,6 +9,8 @@ UpdateMetricsInterval = "10s"
 UpdateRecommendedFeeInterval = "10s"
 MaxSQLConnections = 100
 SQLConnectionTimeout = "2s"
+ReadTimeout = "30s"
+WriteTimeout = "30s"
 
 [StateDB]
 Path = "/var/hermez/statedb"

--- a/node/node.go
+++ b/node/node.go
@@ -452,7 +452,7 @@ func NewNode(mode Mode, cfg *config.Node, version string) (*Node, error) {
 		var err error
 		nodeAPI, err = NewNodeAPI(
 			version,
-			cfg.API.Address,
+			cfg.API,
 			coord, cfg.API.Explorer,
 			server,
 			historyDB,
@@ -556,7 +556,7 @@ func NewAPIServer(mode Mode, cfg *config.APIServer, version string, ethClient *e
 	}
 	nodeAPI, err := NewNodeAPI(
 		version,
-		cfg.API.Address,
+		cfg.API,
 		coord, cfg.API.Explorer,
 		server,
 		historyDB,
@@ -612,8 +612,8 @@ type NodeAPI struct { //nolint:golint
 
 // NewNodeAPI creates a new NodeAPI (which internally calls api.NewAPI)
 func NewNodeAPI(
-	version,
-	addr string,
+	version string,
+	cfgApi config.APIConfigParameters,
 	coordinatorEndpoints, explorerEndpoints bool,
 	server *gin.Engine,
 	hdb *historydb.HistoryDB,

--- a/node/node.go
+++ b/node/node.go
@@ -615,7 +615,7 @@ type NodeAPI struct { //nolint:golint
 // NewNodeAPI creates a new NodeAPI (which internally calls api.NewAPI)
 func NewNodeAPI(
 	version string,
-	cfgApi config.APIConfigParameters,
+	cfgAPI config.APIConfigParameters,
 	coordinatorEndpoints, explorerEndpoints bool,
 	server *gin.Engine,
 	hdb *historydb.HistoryDB,
@@ -640,11 +640,11 @@ func NewNodeAPI(
 		return nil, tracerr.Wrap(err)
 	}
 	return &NodeAPI{
-		addr:         cfgApi.Address,
+		addr:         cfgAPI.Address,
 		api:          _api,
 		engine:       engine,
-		readtimeout:  cfgApi.Readtimeout.Duration,
-		writetimeout: cfgApi.Writetimeout.Duration,
+		readtimeout:  cfgAPI.Readtimeout.Duration,
+		writetimeout: cfgAPI.Writetimeout.Duration,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #1085 

### What does this PR does?

Add ReadTimeout/WriteTimeout API configuration into default configuration files.


### How to test?

<!-- What steps in order should someone run to test -->
Just waiting a bugfix from Q/A team for integration-tests repository.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update swagger file (if needed)
- [ ] Update documentation (*.md) (if needed)

```
Starting test
    ‚úì Init variables (8416ms)
    ‚úì Check ETH L1 deposit (48357ms)
    ‚úì Check ERC20 L1 deposit (48411ms)
    ‚úì Check ETH L1 force exit (48258ms)
    ‚úì Check ERC20 L1 force exit (38296ms)
    ‚úì Check ETH withdrawal from firsts forceExits (16369ms)
    ‚úì Check ERC20 withdrawal from firsts forceExits (12348ms)
    ‚úì Check ETH N L1 force exits (34269ms)
    ‚úì Check ETH withdrawal from previous N force exits (8175ms)
    ‚úì Check single ETH L2 transfer (40338ms)
    ‚úì Check single ERC20 L2 transfer (40350ms)
    ‚úì Transfer ETH to a non-existent Bjj address (40364ms)
    ‚úì Transfer ERC20 to a non-existent Bjj address (30287ms)
    ‚úì Transfer ETH to hermez ethereum address (40227ms)
    ‚úì Transfer ERC20 to hermez ethereum address (40261ms)
    ‚úì Transfer ETH to non-existent ETH address (30294ms)
    ‚úì Transfer ETH to hermez ethereum address from internal account (50281ms)
    ‚úì Transfer ERC20 to hermez ethereum address from internal account (40298ms)
    ‚úì Check multiple L2 ETH transfer in same batch (50792ms)
    ‚úì Check multiple L2 ETH transfer in different batches (171343ms)
    ‚úì Atomic txs (50659ms)
    ‚úì Check L2 ETH exit (40269ms)
    ‚úì Check L2 ERC20 exit (40276ms)
    ‚úì Check ETH withdrawal from L2 exit (8156ms)
    ‚úì Check ERC20 withdrawal from L2 exit (8192ms)
    ‚úì Exit ETH and circuit withdrawal (43232ms)
    ‚úì Assert API endpoints (2220ms)
    ‚úì Update Buckets (12333ms)
    ‚úì Check ETH L1 force exit bucket (48293ms)
    ‚úì Check ERC20 L1 force exit bucket (38290ms)
    ‚úì Check ETH withdrawal buckets (12299ms)
    ‚úì Check ERC20 withdrawal buckets (12362ms)
    ‚úì Check withdrawals buckets (39ms)


  33 passing (20m)
```