### PR TITLE
fix UpdateTxsInfo to handle more than 65535 tx

### DIFF
--- a/coordinator/prover/prover.go
+++ b/coordinator/prover/prover.go
@@ -201,21 +201,20 @@ func (p *ProofServerClient) apiRequest(ctx context.Context, method apiMethod, pa
 		req, err = p.client.New().Get(path).Request()
 	case POST:
 		if path == "input" {
-			fmt.Println("DEBUG ZK-INPUT")
+			fmt.Println("DEBUG ZK-INPUT: collecting zk-inputs")
 			bJson, err := json.MarshalIndent(body, "", "  ")
 			if err != nil {
 				return tracerr.Wrap(err)
 			}
-			fmt.Println("DEBUG ZK-INPUT: JSON OK", bJson)
-
 			n := time.Now()
 			filename := fmt.Sprintf("zk-inputs-debug-%v.%03d.json", n.Unix(), n.Nanosecond()/1_000_000)
 
 			p := pathLib.Join("/tmp/", filename)
-			fmt.Println("DEBUG ZK-INPUT PATH:", p)
+			fmt.Println("DEBUG ZK-INPUT: saving zk-inputs json file", p)
 			if err := ioutil.WriteFile(p, bJson, 0640); err != nil {
 				return tracerr.Wrap(err)
 			}
+			fmt.Println("DEBUG ZK-INPUT: sending request to proof server")
 		}
 
 		req, err = p.client.New().Post(path).BodyJSON(body).Request()

--- a/coordinator/prover/prover.go
+++ b/coordinator/prover/prover.go
@@ -200,7 +200,7 @@ func (p *ProofServerClient) apiRequest(ctx context.Context, method apiMethod, pa
 	case GET:
 		req, err = p.client.New().Get(path).Request()
 	case POST:
-		if path == "/input" {
+		if path == "input" {
 			fmt.Println("DEBUG ZK-INPUT")
 			bJson, err := json.MarshalIndent(body, "", "  ")
 			if err != nil {

--- a/coordinator/prover/prover.go
+++ b/coordinator/prover/prover.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"net/http"
+	pathLib "path"
 	"strings"
 	"time"
 
@@ -198,6 +200,20 @@ func (p *ProofServerClient) apiRequest(ctx context.Context, method apiMethod, pa
 	case GET:
 		req, err = p.client.New().Get(path).Request()
 	case POST:
+
+		if path == "/input" {
+			bJson, err := json.MarshalIndent(body, "", "  ")
+			if err != nil {
+				return tracerr.Wrap(err)
+			}
+
+			n := time.Now()
+			filename := fmt.Sprintf("zk-inputs-debug-%v.%03d.json", n.Unix(), n.Nanosecond()/1_000_000)
+			if err := ioutil.WriteFile(pathLib.Join("/tmp/", filename), bJson, 0640); err != nil {
+				return tracerr.Wrap(err)
+			}
+		}
+
 		req, err = p.client.New().Post(path).BodyJSON(body).Request()
 	default:
 		return tracerr.Wrap(fmt.Errorf("invalid http method: %v", method))

--- a/coordinator/prover/prover.go
+++ b/coordinator/prover/prover.go
@@ -200,16 +200,20 @@ func (p *ProofServerClient) apiRequest(ctx context.Context, method apiMethod, pa
 	case GET:
 		req, err = p.client.New().Get(path).Request()
 	case POST:
-
 		if path == "/input" {
+			fmt.Println("DEBUG ZK-INPUT")
 			bJson, err := json.MarshalIndent(body, "", "  ")
 			if err != nil {
 				return tracerr.Wrap(err)
 			}
+			fmt.Println("DEBUG ZK-INPUT: JSON OK", bJson)
 
 			n := time.Now()
 			filename := fmt.Sprintf("zk-inputs-debug-%v.%03d.json", n.Unix(), n.Nanosecond()/1_000_000)
-			if err := ioutil.WriteFile(pathLib.Join("/tmp/", filename), bJson, 0640); err != nil {
+
+			p := pathLib.Join("/tmp/", filename)
+			fmt.Println("DEBUG ZK-INPUT PATH:", p)
+			if err := ioutil.WriteFile(p, bJson, 0640); err != nil {
 				return tracerr.Wrap(err)
 			}
 		}

--- a/coordinator/prover/prover.go
+++ b/coordinator/prover/prover.go
@@ -202,16 +202,21 @@ func (p *ProofServerClient) apiRequest(ctx context.Context, method apiMethod, pa
 	case POST:
 		if path == "input" {
 			fmt.Println("DEBUG ZK-INPUT: collecting zk-inputs")
-			bJson, err := json.MarshalIndent(body, "", "  ")
+			bJSON, err := json.MarshalIndent(body, "", "  ")
 			if err != nil {
 				return tracerr.Wrap(err)
 			}
 			n := time.Now()
+			// nolint reason: hardcoded 1_000_000 is the number of nanoseconds in a
+			// millisecond
+			//nolint:gomnd
 			filename := fmt.Sprintf("zk-inputs-debug-%v.%03d.json", n.Unix(), n.Nanosecond()/1_000_000)
 
 			p := pathLib.Join("/tmp/", filename)
 			fmt.Println("DEBUG ZK-INPUT: saving zk-inputs json file", p)
-			if err := ioutil.WriteFile(p, bJson, 0640); err != nil {
+			// nolint reason: 0640 allows rw to owner and r to group
+			//nolint:gosec
+			if err = ioutil.WriteFile(p, bJSON, 0640); err != nil {
 				return tracerr.Wrap(err)
 			}
 			fmt.Println("DEBUG ZK-INPUT: sending request to proof server")

--- a/node/node.go
+++ b/node/node.go
@@ -691,6 +691,15 @@ func (n *Node) handleNewBlock(ctx context.Context, stats *synchronizer.Stats,
 		})
 	}
 	n.stateAPIUpdater.SetSCVars(vars)
+
+	/*
+		When the state is out of sync, which means, the last block synchronized by the node is
+		different/smaller from the last block provided by the ethereum, the network info in the state
+		will not be update.	So, in order to get the some information the node state data, we need
+		to wait until the node finish the synchronization with the ethereum network.
+
+		Side effects are information like lastBatch, nextForgers, metrics with zeros, defaults or null values
+	*/
 	if stats.Synced() {
 		if err := n.stateAPIUpdater.UpdateNetworkInfo(
 			stats.Eth.LastBlock, stats.Sync.LastBlock,

--- a/node/node.go
+++ b/node/node.go
@@ -695,7 +695,7 @@ func (n *Node) handleNewBlock(ctx context.Context, stats *synchronizer.Stats,
 	/*
 		When the state is out of sync, which means, the last block synchronized by the node is
 		different/smaller from the last block provided by the ethereum, the network info in the state
-		will not be update.	So, in order to get the some information the node state data, we need
+		will not be updated. So, in order to get some information on the node state, we need
 		to wait until the node finish the synchronization with the ethereum network.
 
 		Side effects are information like lastBatch, nextForgers, metrics with zeros, defaults or null values

--- a/txselector/txselector.go
+++ b/txselector/txselector.go
@@ -699,7 +699,7 @@ func (txsel *TxSelector) processL2Txs(
 				l2Txs[i].Info = obj.Message
 				l2Txs[i].ErrorCode = obj.Code
 				l2Txs[i].ErrorType = obj.Type
-				nonSelectedL2Txs = append(nonSelectedL2Txs, l2Txs[i])
+				unforjableL2Txs = append(unforjableL2Txs, l2Txs[i])
 				continue
 			}
 


### PR DESCRIPTION
Closes #1120.

### What does this PR does?

Allows UpdateTxsInfo to update more than 65535 txs.

### How to test?

Add more than 65535 tx to the pool that will be discarded in the tx selector, causing them to be updated with some information related to the discarding

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Include tests
- [x] Respect code style and lint